### PR TITLE
fix(docker): 修复国内网络构建失败与前端静态文件 404

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,21 @@
 # 两阶段构建:前端 dist 拷进后端镜像,单容器运行
+# 可选:构建网络无法直连官方源时,传入 --build-arg USE_CN_MIRROR=1 启用国内镜像
+ARG USE_CN_MIRROR=1
+ARG NPM_REGISTRY=https://registry.npmmirror.com
+ARG PYPI_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple
+
 # === Stage 1: 前端构建 ===
 FROM node:20-alpine AS frontend-builder
+ARG USE_CN_MIRROR=1
+ARG NPM_REGISTRY=https://registry.npmmirror.com
 WORKDIR /build
-RUN corepack enable && corepack prepare pnpm@9 --activate
+# 关键:corepack 不读 npm 的 registry 配置,且跨 RUN 不保留环境变量,
+# 因此国内网络下最稳的做法是直接用 npm 安装 pnpm(npm 会读取 .npmrc 镜像源),
+# 彻底绕开 corepack 再次联网下载 pnpm 的问题。
+RUN if [ "$USE_CN_MIRROR" = "1" ]; then npm config set registry "$NPM_REGISTRY"; fi && \
+    npm install -g pnpm@9
+# 让 pnpm 走镜像源安装依赖
+RUN if [ "$USE_CN_MIRROR" = "1" ]; then pnpm config set registry "$NPM_REGISTRY"; fi
 COPY frontend/package.json frontend/pnpm-lock.yaml* ./
 RUN pnpm install --frozen-lockfile || pnpm install
 COPY frontend/ ./
@@ -10,19 +23,32 @@ RUN pnpm build
 
 # === Stage 2: Python 运行时 ===
 FROM python:3.11-slim AS runtime
+ARG USE_CN_MIRROR=1
+ARG PYPI_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple
 WORKDIR /app
 
 # 安装 uv(快)
-RUN pip install --no-cache-dir uv
+RUN if [ "$USE_CN_MIRROR" = "1" ]; then \
+      pip install --no-cache-dir uv -i "$PYPI_INDEX"; \
+    else \
+      pip install --no-cache-dir uv; \
+    fi
 
 # Backend deps
 COPY README.md /README.md
 COPY backend/pyproject.toml backend/uv.lock* ./
-RUN uv sync --frozen --no-dev || uv sync --no-dev
+RUN if [ "$USE_CN_MIRROR" = "1" ]; then export UV_DEFAULT_INDEX="$PYPI_INDEX"; fi; \
+    uv sync --frozen --no-dev || uv sync --no-dev
 
 # Backend code
+# 注意:Docker 里 WORKDIR=/app, 而 config.py 的 _PROJECT_ROOT 是按开发布局
+# (<root>/backend/app/) 推导的, 容器内会错算到 /。这里用环境变量显式指定
+# 三个关键路径, 确保 static / tiers / data 都指向容器内正确位置。
 COPY backend/app ./app
 COPY tiers.yaml /app/tiers.yaml
+ENV STATIC_DIR=/app/static \
+    TIERS_YAML=/app/tiers.yaml \
+    DATA_DIR=/app/data
 
 # Frontend 静态产物
 COPY --from=frontend-builder /build/dist ./static


### PR DESCRIPTION
## 修复内容

本次修复 Docker 打包时的两个独立问题。

### 1. 构建阶段失败(corepack 拉取 pnpm 报错)

**现象**
```
[frontend-builder] RUN ... corepack prepare pnpm@9 --activate
Internal Error: Error when performing the request to https://registry.npmjs.org/pnpm
```

**根因**
- `corepack` 不读 `npm config set registry` 的配置(有自己独立的注册表配置);
- 即便用 `export COREPACK_NPM_REGISTRY` 也只在那一条 `RUN` 内有效,跨 `RUN` 环境变量丢失,corepack 又回去找 npmjs.org;
- 国内网络无法直连 `registry.npmjs.org`。

**修复**
改为直接 `npm install -g pnpm@9`(npm 老实读 `.npmrc` 镜像源),彻底绕开 corepack 的二次联网下载。同时引入 build-arg:
- `USE_CN_MIRROR`(默认 `1`)
- `NPM_REGISTRY`(默认 `registry.npmmirror.com`)
- `PYPI_INDEX`(默认清华源)

海外/有代理环境可用 `--build-arg USE_CN_MIRROR=0` 关闭。

### 2. 打包后访问 http://localhost:3018/ 一直 404

**现象**
```
INFO: "GET / HTTP/1.1" 404 Not Found
```

**根因**
`backend/app/config.py` 的 `_PROJECT_ROOT` 按**开发布局** `<root>/backend/app/`(往上三级 = 项目根)推导。但 Dockerfile 把 `backend/app` 拷到 `/app/app`,导致容器内 `config.py` 在 `/app/app/config.py`,往上三级错算到**系统根目录 `/`**。

| 配置项 | 错误值 | 正确值 |
| :--- | :--- | :--- |
| `static_dir` | `/frontend/dist`(不存在) | `/app/static` |
| `tiers_yaml` | `/tiers.yaml`(不存在) | `/app/tiers.yaml` |
| `data_dir` | `/data` | `/app/data` |

`static_dir` 找不到目录 → `main.py` 里 `if _static.exists()` 为 False → 静态挂载 + SPA fallback 路由被整体跳过 → `GET /` 无路由匹配 → 404。

**修复**
用 `ENV` 显式指定三个关键路径:
```dockerfile
ENV STATIC_DIR=/app/static \
    TIERS_YAML=/app/tiers.yaml \
    DATA_DIR=/app/data
```
Pydantic `BaseSettings` 直接从环境变量读到正确路径,**无需改动任何 Python 代码**,桌面版(PyInstaller frozen)逻辑完全不受影响。

## 验证
- `docker compose up --build` 在国内网络下构建成功(不再卡 corepack);
- 容器内 `GET /` → **200**,返回完整前端 HTML;
- `static_dir=/app/static`、`tiers_yaml=/app/tiers.yaml`、`data_dir=/app/data` 均解析正确。

## 变更范围
仅 `Dockerfile`,1 file changed, 29 insertions(+), 3 deletions(-)。无 Python 代码改动。