### PR TITLE
fix(pipeline): free/none 档降级时误调实时行情接口

### DIFF
--- a/backend/app/jobs/daily_pipeline.py
+++ b/backend/app/jobs/daily_pipeline.py
@@ -102,8 +102,8 @@ def run_now(
     emit("resolve_universe", 10, f"标的池规模:{len(universe)} 只")
 
     # Step 1: 日 K 同步
-    #   今天有数据 → 实时行情接口拉一次覆写（1请求全市场）
-    #   今天没数据 → batch K-line API 补齐
+    #   付费档 + 今天有数据 → 实时行情接口拉一次覆写（1请求全市场）
+    #   有历史数据 → batch K-line API 补齐缺口
     #   无任何数据 → batch K-line API 拉首次 1 年
     from datetime import date as _date, timedelta as _td, datetime as _dt
     latest_daily = repo.latest_daily_date()
@@ -111,18 +111,23 @@ def run_now(
     today_exists = latest_daily and latest_daily >= today
     new_daily_days = 0
 
-    if today_exists:
-        # 今天有数据（QuoteService 已落盘）→ 实时行情覆写，确保最新
+    if today_exists and capset.has(Cap.QUOTE_POOL):
+        # 付费档:今天有数据(QuoteService 已落盘)→ 实时行情覆写,确保最新。
+        # free/none 档无 quote.pool 能力,即便今天已有数据(如从 expert 降级),
+        # 也降级到下方 batch 路径刷新,避免调用无权限的实时行情接口。
         emit("sync_daily", 12, f"获取日K [{today} ~ {today}] 实时行情…")
         written_daily = kline_sync.sync_daily_by_quotes(repo)
         new_daily_days = 1
         emit("sync_daily", 45, f"日K 完成,{written_daily} 只标的")
         logger.info("sync_daily: [%s ~ %s] live quotes, %d symbols", today, today, written_daily)
     elif latest_daily:
-        # 有历史但今天没数据 → batch 补齐缺口
+        # 有历史 → batch 补齐缺口。
+        # 也覆盖"今天已有数据但无实时行情权限(free/none)"的降级场景:
+        #   此时 start_date = latest_daily = today,batch 刷新当天日K。
         start_date = latest_daily
         emit("sync_daily", 12, f"获取日K [{start_date} ~ {today}]…")
-        logger.info("sync_daily: [%s ~ %s] gap fill", start_date, today)
+        logger.info("sync_daily: [%s ~ %s] %s", start_date, today,
+                    "refresh today" if today_exists else "gap fill")
 
         def _daily_chunk_progress(cur: int, tot: int) -> None:
             emit("sync_daily", 12 + int(33 * cur / tot),


### PR DESCRIPTION
## 问题

从 expert 切换到 free 档后,本地 `kline_daily` 仍保留今天(expert 时期)实时落盘的数据。在「数据」页点「同步数据」时:

1. `run_now()` 中 `latest_daily = today` → `today_exists = True`
2. 误入分支①,调用 `sync_daily_by_quotes()` → `quotes.get_by_universes()`(实时行情接口)
3. 但 free/none 档走 free-api 服务器,**无实时行情端点** → 报错 / 返回空 → 当天日K数据可能异常

## 根因

`daily_pipeline.py:114` 的分支①只判断「今天有没有数据」,**未判断当前档位有无实时行情能力**。`sync_daily_by_quotes` 内部也无 capability 守卫。

## 修复

分支①条件增加 `capset.has(Cap.QUOTE_POOL)`(对应 `quotes.get_by_universes`,starter+ 才有):

```python
if today_exists and capset.has(Cap.QUOTE_POOL):
    # 付费档:实时行情覆写
elif latest_daily:
    # batch 补齐 / 刷新(含 free/none 降级场景)
```

free/none 档降级到 `elif latest_daily` 分支(`start_date = today`),用 `klines.batch(period='1d')` 历史日K接口刷新当天 —— 这是 free 档唯一可用且正确的数据源。

## 验证矩阵

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| expert 档,今天有数据 | ✅ 实时行情覆写 | ✅ 不变 |
| free 档,今天有数据(从 expert 降级) | ❌ 调实时接口报错 | ✅ batch 刷新当天 |
| free 档,今天没数据 | ✅ batch 补齐 | ✅ 不变 |
| none 档,今天没数据 | ✅ batch 补齐 | ✅ 不变 |

最小修复:单文件、两分支调整,未改动数据写入逻辑或其它服务。