### PR TITLE
fix(ai): 随机 UA 按钮可重复点击

### DIFF
--- a/frontend/src/pages/settings/AI.tsx
+++ b/frontend/src/pages/settings/AI.tsx
@@ -224,10 +224,9 @@ export function SettingsAIPanel() {
                 <input type="text" value={userAgent} onChange={e => setUserAgent(e.target.value)}
                   placeholder="留空点击「随机生成」或直接粘贴浏览器 UA"
                   className="flex-1 h-8 px-2.5 rounded-lg bg-base border-0 ring-1 ring-border/30 text-xs font-mono text-foreground placeholder:text-muted/30 focus:outline-none focus:ring-2 focus:ring-accent/30 transition-shadow" />
-                <button type="button" onClick={() => { if (!userAgent) genRandomUa() }}
-                  title={userAgent ? '已存在内容，清空后可重新生成' : '随机生成浏览器 UA'}
-                  className="h-8 px-2.5 rounded-lg border border-border/50 text-xs text-secondary hover:text-accent hover:border-accent/30 transition-all flex items-center gap-1.5 shrink-0 disabled:opacity-40"
-                  disabled={!!userAgent}>
+                <button type="button" onClick={genRandomUa}
+                  title="随机生成一条浏览器 UA"
+                  className="h-8 px-2.5 rounded-lg border border-border/50 text-xs text-secondary hover:text-accent hover:border-accent/30 transition-all flex items-center gap-1.5 shrink-0">
                   <Shuffle className="h-3 w-3" /> 随机
                 </button>
               </div>


### PR DESCRIPTION
## 问题

承接 #10。随机生成 UA 的按钮在文本框已有内容时被 `disabled` + `onClick` 双重拦截,导致只能生成一次,之后按钮再也点不动。

## 修复

移除 `disabled={!!userAgent}` 和 `if (!userAgent)` 保护判断,`onClick={genRandomUa}` 每次点击都覆盖生成新的 UA。

符合随机按钮的正常语义:想换就点,想保留就不点。

改动:单文件,4 行。