### PR TITLE
Normalize OpenAI-compatible AI base URLs

### DIFF
--- a/backend/app/api/strategy.py
+++ b/backend/app/api/strategy.py
@@ -314,13 +314,9 @@ def get_strategy_source(strategy_id: str, request: Request):
 
 
 def _normalize_openai_base_url(url: str) -> str:
-    """Return the OpenAI-compatible base URL expected by the OpenAI SDK."""
-    base = (url or "").strip().rstrip("/")
-    if base.endswith("/chat/completions"):
-        base = base[: -len("/chat/completions")].rstrip("/")
-    if not base.endswith("/v1"):
-        base = f"{base}/v1"
-    return base
+    from app.services.ai_client import normalize_openai_base_url
+
+    return normalize_openai_base_url(url)
 
 
 def _format_ai_test_response(resp: Any) -> dict:

--- a/backend/app/api/strategy.py
+++ b/backend/app/api/strategy.py
@@ -313,6 +313,52 @@ def get_strategy_source(strategy_id: str, request: Request):
     return {"code": path.read_text(encoding="utf-8"), "source": s.source}
 
 
+def _normalize_openai_base_url(url: str) -> str:
+    """Return the OpenAI-compatible base URL expected by the OpenAI SDK."""
+    base = (url or "").strip().rstrip("/")
+    if base.endswith("/chat/completions"):
+        base = base[: -len("/chat/completions")].rstrip("/")
+    if not base.endswith("/v1"):
+        base = f"{base}/v1"
+    return base
+
+
+def _format_ai_test_response(resp: Any) -> dict:
+    """Format OpenAI-compatible test response without assuming SDK object shape."""
+    if isinstance(resp, str):
+        return {"ok": False, "error": "AI 接口返回非标准响应(字符串),请检查 API 地址是否为 OpenAI 兼容的 /v1 接口"}
+
+    if isinstance(resp, dict):
+        model = resp.get("model")
+        usage_obj = resp.get("usage")
+    else:
+        model = getattr(resp, "model", None)
+        usage_obj = getattr(resp, "usage", None)
+
+    if not model:
+        return {"ok": False, "error": "AI 接口返回非标准响应,缺少 model 字段;请检查 API 地址、模型名和中转站兼容性"}
+
+    usage = None
+    if usage_obj:
+        if isinstance(usage_obj, dict):
+            prompt = usage_obj.get("prompt_tokens")
+            completion = usage_obj.get("completion_tokens")
+        else:
+            prompt = getattr(usage_obj, "prompt_tokens", None)
+            completion = getattr(usage_obj, "completion_tokens", None)
+        if prompt is not None and completion is not None:
+            usage = {"prompt": prompt, "completion": completion}
+
+    return {"ok": True, "model": model, "usage": usage}
+
+
+def _friendly_ai_error(exc: Exception) -> str:
+    msg = str(exc)
+    if "object has no attribute 'model'" in msg or 'object has no attribute "model"' in msg:
+        return "AI 接口返回非标准响应,不是 OpenAI Chat Completions 格式;请检查 API 地址是否包含 /v1、模型名是否正确,以及中转站是否支持 /v1/chat/completions"
+    return msg
+
+
 @router.post("/ai/test")
 async def ai_test(request: Request):
     """测试 AI 连通性 — 发送简单请求验证 Key 和模型"""
@@ -328,18 +374,18 @@ async def ai_test(request: Request):
         # User-Agent: 默认浏览器标识,绕过 Cloudflare 等 CDN/WAF 的 Bot 拦截(Issue #8)。
         client = AsyncOpenAI(
             api_key=ai_key,
-            base_url=settings.ai_base_url,
-            default_headers={"User-Agent": settings.ai_user_agent or "Mozilla/5.0"},
+            base_url=_normalize_openai_base_url(secrets_store.get_ai_config("ai_base_url", settings.ai_base_url)),
+            default_headers={"User-Agent": secrets_store.get_ai_config("ai_user_agent", settings.ai_user_agent) or "Mozilla/5.0"},
         )
         resp = await client.chat.completions.create(
-            model=settings.ai_model,
+            model=secrets_store.get_ai_config("ai_model", settings.ai_model),
             messages=[{"role": "user", "content": "回复 OK"}],
             max_tokens=5,
             timeout=15,
         )
-        return {"ok": True, "model": resp.model, "usage": {"prompt": resp.usage.prompt_tokens, "completion": resp.usage.completion_tokens} if resp.usage else None}
+        return _format_ai_test_response(resp)
     except Exception as e:
-        return {"ok": False, "error": str(e)}
+        return {"ok": False, "error": _friendly_ai_error(e)}
 
 
 @router.post("/build")

--- a/backend/app/services/ai_client.py
+++ b/backend/app/services/ai_client.py
@@ -1,0 +1,12 @@
+"""Shared helpers for OpenAI-compatible AI providers."""
+from __future__ import annotations
+
+
+def normalize_openai_base_url(url: str) -> str:
+    """Return the OpenAI-compatible base URL expected by the OpenAI SDK."""
+    base = (url or "").strip().rstrip("/")
+    if base.endswith("/chat/completions"):
+        base = base[: -len("/chat/completions")].rstrip("/")
+    if not base.endswith("/v1"):
+        base = f"{base}/v1"
+    return base

--- a/backend/app/services/financial_analyzer.py
+++ b/backend/app/services/financial_analyzer.py
@@ -18,6 +18,13 @@ from app.services.financial_sync import get_financial_df
 
 logger = logging.getLogger(__name__)
 
+
+def _normalize_ai_base_url(url: str) -> str:
+    from app.services.ai_client import normalize_openai_base_url
+
+    return normalize_openai_base_url(url)
+
+
 # 最多注入的报告期数(最新 N 期),避免上下文爆炸 / token 浪费
 _MAX_PERIODS = 4
 
@@ -178,7 +185,7 @@ async def analyze_financials_stream(
         user_agent = secrets_store.get_ai_config("ai_user_agent", "") or settings.ai_user_agent
         client = AsyncOpenAI(
             api_key=ai_key,
-            base_url=secrets_store.get_ai_config("ai_base_url", "https://api.alysc.top"),
+            base_url=_normalize_ai_base_url(secrets_store.get_ai_config("ai_base_url", "https://api.alysc.top")),
             timeout=180.0,
             max_retries=2,
             default_headers={"User-Agent": user_agent},

--- a/backend/app/services/market_recap.py
+++ b/backend/app/services/market_recap.py
@@ -24,6 +24,12 @@ from app.services.market_overview_builder import build_market_overview
 logger = logging.getLogger(__name__)
 
 
+def _normalize_ai_base_url(url: str) -> str:
+    from app.services.ai_client import normalize_openai_base_url
+
+    return normalize_openai_base_url(url)
+
+
 # 指数简称映射:摘要里用简称(上/深/创/科),全称太长列表放不下。与前端 INDEX_SHORT 对齐。
 _INDEX_SHORT = {
     "上证指数": "上",
@@ -308,7 +314,7 @@ async def recap_market_stream(
         user_agent = secrets_store.get_ai_config("ai_user_agent", "") or settings.ai_user_agent
         client = AsyncOpenAI(
             api_key=ai_key,
-            base_url=secrets_store.get_ai_config("ai_base_url", "https://api.alysc.top"),
+            base_url=_normalize_ai_base_url(secrets_store.get_ai_config("ai_base_url", "https://api.alysc.top")),
             timeout=180.0,
             max_retries=2,
             default_headers={"User-Agent": user_agent},

--- a/backend/app/services/stock_analyzer.py
+++ b/backend/app/services/stock_analyzer.py
@@ -28,9 +28,9 @@ logger = logging.getLogger(__name__)
 
 
 def _normalize_ai_base_url(url: str) -> str:
-    from app.api.strategy import _normalize_openai_base_url
+    from app.services.ai_client import normalize_openai_base_url
 
-    return _normalize_openai_base_url(url)
+    return normalize_openai_base_url(url)
 
 
 # 注入最近多少根日 K(技术面分析样本)

--- a/backend/app/services/stock_analyzer.py
+++ b/backend/app/services/stock_analyzer.py
@@ -26,6 +26,13 @@ from app.services.financial_sync import get_financial_df
 
 logger = logging.getLogger(__name__)
 
+
+def _normalize_ai_base_url(url: str) -> str:
+    from app.api.strategy import _normalize_openai_base_url
+
+    return _normalize_openai_base_url(url)
+
+
 # 注入最近多少根日 K(技术面分析样本)
 _KLINE_WINDOW = 90
 # 注入财务表的最近期数
@@ -307,7 +314,7 @@ async def analyze_stock_stream(
         user_agent = secrets_store.get_ai_config("ai_user_agent", "") or settings.ai_user_agent
         client = AsyncOpenAI(
             api_key=ai_key,
-            base_url=secrets_store.get_ai_config("ai_base_url", "https://api.alysc.top"),
+            base_url=_normalize_ai_base_url(secrets_store.get_ai_config("ai_base_url", "https://api.alysc.top")),
             timeout=180.0,
             max_retries=2,
             default_headers={"User-Agent": user_agent},

--- a/backend/app/strategy/ai_generator.py
+++ b/backend/app/strategy/ai_generator.py
@@ -88,11 +88,11 @@ class AIStrategyGenerator:
         from app.config import settings
         user_agent = secrets_store.get_ai_config("ai_user_agent", "") or settings.ai_user_agent
 
-        from app.api.strategy import _normalize_openai_base_url
+        from app.services.ai_client import normalize_openai_base_url
 
         client = AsyncOpenAI(
             api_key=ai_key,
-            base_url=_normalize_openai_base_url(secrets_store.get_ai_config("ai_base_url", "https://api.alysc.top")),
+            base_url=normalize_openai_base_url(secrets_store.get_ai_config("ai_base_url", "https://api.alysc.top")),
             timeout=180.0,
             max_retries=2,
             default_headers={"User-Agent": user_agent},

--- a/backend/app/strategy/ai_generator.py
+++ b/backend/app/strategy/ai_generator.py
@@ -88,9 +88,11 @@ class AIStrategyGenerator:
         from app.config import settings
         user_agent = secrets_store.get_ai_config("ai_user_agent", "") or settings.ai_user_agent
 
+        from app.api.strategy import _normalize_openai_base_url
+
         client = AsyncOpenAI(
             api_key=ai_key,
-            base_url=secrets_store.get_ai_config("ai_base_url", "https://api.alysc.top"),
+            base_url=_normalize_openai_base_url(secrets_store.get_ai_config("ai_base_url", "https://api.alysc.top")),
             timeout=180.0,
             max_retries=2,
             default_headers={"User-Agent": user_agent},

--- a/backend/tests/test_strategy_ai_test.py
+++ b/backend/tests/test_strategy_ai_test.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from app.api.strategy import _format_ai_test_response, _normalize_openai_base_url
-from app.services.stock_analyzer import _normalize_ai_base_url
+from app.services.ai_client import normalize_openai_base_url
+from app.services.financial_analyzer import _normalize_ai_base_url as normalize_financial_ai_base_url
+from app.services.market_recap import _normalize_ai_base_url as normalize_market_recap_ai_base_url
+from app.services.stock_analyzer import _normalize_ai_base_url as normalize_stock_ai_base_url
 
 
 def test_normalize_openai_base_url_adds_v1_for_root_gateway():
@@ -18,8 +21,14 @@ def test_normalize_openai_base_url_strips_chat_completions_path():
     assert _normalize_openai_base_url("http://ai.zedbox.cn:8080/v1/chat/completions") == "http://ai.zedbox.cn:8080/v1"
 
 
-def test_stock_analyzer_uses_same_openai_base_url_normalization():
-    assert _normalize_ai_base_url("http://ai.zedbox.cn:8080") == "http://ai.zedbox.cn:8080/v1"
+def test_shared_ai_base_url_normalization_adds_v1_for_root_gateway():
+    assert normalize_openai_base_url("http://ai.zedbox.cn:8080") == "http://ai.zedbox.cn:8080/v1"
+
+
+def test_all_ai_analyzers_use_same_base_url_normalization():
+    assert normalize_stock_ai_base_url("http://ai.zedbox.cn:8080") == "http://ai.zedbox.cn:8080/v1"
+    assert normalize_financial_ai_base_url("http://ai.zedbox.cn:8080") == "http://ai.zedbox.cn:8080/v1"
+    assert normalize_market_recap_ai_base_url("http://ai.zedbox.cn:8080") == "http://ai.zedbox.cn:8080/v1"
 
 
 def test_format_ai_test_response_handles_object_response():

--- a/backend/tests/test_strategy_ai_test.py
+++ b/backend/tests/test_strategy_ai_test.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.api.strategy import _format_ai_test_response, _normalize_openai_base_url
+from app.services.stock_analyzer import _normalize_ai_base_url
+
+
+def test_normalize_openai_base_url_adds_v1_for_root_gateway():
+    assert _normalize_openai_base_url("http://ai.zedbox.cn:8080") == "http://ai.zedbox.cn:8080/v1"
+
+
+def test_normalize_openai_base_url_preserves_v1_base():
+    assert _normalize_openai_base_url("http://ai.zedbox.cn:8080/v1") == "http://ai.zedbox.cn:8080/v1"
+
+
+def test_normalize_openai_base_url_strips_chat_completions_path():
+    assert _normalize_openai_base_url("http://ai.zedbox.cn:8080/v1/chat/completions") == "http://ai.zedbox.cn:8080/v1"
+
+
+def test_stock_analyzer_uses_same_openai_base_url_normalization():
+    assert _normalize_ai_base_url("http://ai.zedbox.cn:8080") == "http://ai.zedbox.cn:8080/v1"
+
+
+def test_format_ai_test_response_handles_object_response():
+    resp = SimpleNamespace(
+        model="gpt-test",
+        usage=SimpleNamespace(prompt_tokens=3, completion_tokens=1),
+    )
+
+    assert _format_ai_test_response(resp) == {
+        "ok": True,
+        "model": "gpt-test",
+        "usage": {"prompt": 3, "completion": 1},
+    }
+
+
+def test_format_ai_test_response_handles_dict_response():
+    resp = {
+        "model": "gpt-dict",
+        "usage": {"prompt_tokens": 5, "completion_tokens": 2},
+    }
+
+    assert _format_ai_test_response(resp) == {
+        "ok": True,
+        "model": "gpt-dict",
+        "usage": {"prompt": 5, "completion": 2},
+    }
+
+
+def test_format_ai_test_response_rejects_string_response_without_attribute_error():
+    result = _format_ai_test_response("upstream returned plain text")
+
+    assert result["ok"] is False
+    assert "非标准响应" in result["error"]
+    assert "object has no attribute" not in result["error"]

--- a/dev.ps1
+++ b/dev.ps1
@@ -146,6 +146,10 @@ $frontendPidFile = [System.IO.Path]::GetTempFileName()
 $backendJob = Start-Job -Name 'backend' -ScriptBlock {
     param($pidFile, $dir, $port)
     $PID | Out-File -FilePath $pidFile -Encoding ascii -Force
+    try {
+        [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false
+        $OutputEncoding           = New-Object System.Text.UTF8Encoding $false
+    } catch {}
     $env:PYTHONUNBUFFERED = '1'
     Set-Location $dir
     & .\.venv\Scripts\python.exe -m uvicorn app.main:app --reload --host 0.0.0.0 --port $port 2>&1
@@ -154,6 +158,10 @@ $backendJob = Start-Job -Name 'backend' -ScriptBlock {
 $frontendJob = Start-Job -Name 'frontend' -ScriptBlock {
     param($pidFile, $dir, $port)
     $PID | Out-File -FilePath $pidFile -Encoding ascii -Force
+    try {
+        [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false
+        $OutputEncoding           = New-Object System.Text.UTF8Encoding $false
+    } catch {}
     Set-Location $dir
     & pnpm dev --host 0.0.0.0 --port $port 2>&1
 } -ArgumentList $frontendPidFile, $FrontendDir, $FrontendPort


### PR DESCRIPTION
## 中文说明

### 背景

当前 AI 配置页允许用户填写 OpenAI 兼容接口地址，但如果用户填写的是网关根地址（例如 `http://host:port`），OpenAI SDK 会请求到 `/chat/completions`，而部分 OpenAI-compatible 网关实际只在 `/v1/chat/completions` 提供接口。这会导致 AI 测试或各类 AI 分析拿到 HTML/非标准响应，进而出现无内容、`.model` 属性错误或不易理解的失败提示。

### 改动

- 新增统一的 OpenAI-compatible base URL 归一化 helper。
- 支持以下输入形式自动归一：
  - `http://host:port` → `http://host:port/v1`
  - `http://host:port/v1` → 保持不变
  - `http://host:port/v1/chat/completions` → `http://host:port/v1`
- 将归一化应用到所有 AI 调用入口：
  - AI 设置连通性测试
  - AI 策略生成
  - AI 个股分析
  - AI 财务分析
  - AI 大盘复盘
- AI 连通性测试对非标准响应返回更清晰的错误信息，避免直接暴露 `'str' object has no attribute 'model'`。
- Windows `dev.ps1` 的后台 Job 内补充 UTF-8 输出设置，减少中文日志乱码。
- 增加回归测试覆盖 AI 响应格式和 base URL 归一化。

### 测试

- `cd backend && .\.venv\Scripts\python.exe -m pytest tests\test_strategy_ai_test.py tests\backtest\test_engine_portfolio.py tests\backtest\test_full_simulation_tail.py tests\backtest\test_strategy_backtest_correctness.py -q`
  - `24 passed`
- `cd frontend && pnpm build`
  - 构建成功
  - 仍有既有 Vite chunk/dynamic import 警告，非本次失败项

---

## English Description

### Background

The AI settings page accepts custom OpenAI-compatible endpoint URLs. When users enter a gateway root URL such as `http://host:port`, the OpenAI SDK requests `/chat/completions`, while some OpenAI-compatible gateways expose the actual API under `/v1/chat/completions`. This can make AI tests or AI analysis features receive HTML/non-standard responses, causing empty output, `.model` attribute errors, or unclear failures.

### Changes

- Add a shared helper to normalize OpenAI-compatible base URLs.
- Normalize common input forms:
  - `http://host:port` → `http://host:port/v1`
  - `http://host:port/v1` → unchanged
  - `http://host:port/v1/chat/completions` → `http://host:port/v1`
- Apply the same normalization to all AI call sites:
  - AI settings connectivity test
  - AI strategy generation
  - AI stock analysis
  - AI financial analysis
  - AI market recap
- Make the AI connectivity test handle non-standard responses with clearer error messages instead of exposing `'str' object has no attribute 'model'`.
- Configure UTF-8 output inside Windows `dev.ps1` background jobs to reduce garbled Chinese logs.
- Add regression tests for AI response formatting and base URL normalization.

### Test Plan

- `cd backend && .\.venv\Scripts\python.exe -m pytest tests\test_strategy_ai_test.py tests\backtest\test_engine_portfolio.py tests\backtest\test_full_simulation_tail.py tests\backtest\test_strategy_backtest_correctness.py -q`
  - `24 passed`
- `cd frontend && pnpm build`
  - Build succeeded
  - Existing Vite chunk/dynamic import warnings remain, but they are not build failures