### PR TITLE
Normalize OpenAI-compatible AI base URLs

### DIFF
--- a/backend/app/services/ai_provider.py
+++ b/backend/app/services/ai_provider.py
@@ -64,6 +64,16 @@ def normalize_codex_command(command: str | None, *, strict: bool = True) -> str:
     return CODEX_DEFAULT_COMMAND
 
 
+def normalize_openai_base_url(url: str) -> str:
+    """Return the OpenAI-compatible base URL expected by the OpenAI SDK."""
+    base = (url or "").strip().rstrip("/")
+    if base.endswith("/chat/completions"):
+        base = base[: -len("/chat/completions")].rstrip("/")
+    if not base.endswith("/v1"):
+        base = f"{base}/v1"
+    return base
+
+
 def codex_cli_available() -> bool:
     try:
         _codex_base_command()
@@ -177,7 +187,7 @@ def _openai_client(api_key: str, timeout: float):
     user_agent = secrets_store.get_ai_config("ai_user_agent", "") or settings.ai_user_agent
     return AsyncOpenAI(
         api_key=api_key,
-        base_url=secrets_store.get_ai_config("ai_base_url", settings.ai_base_url),
+        base_url=normalize_openai_base_url(secrets_store.get_ai_config("ai_base_url", settings.ai_base_url)),
         timeout=timeout,
         max_retries=2,
         default_headers={"User-Agent": user_agent},

--- a/backend/tests/test_ai_provider.py
+++ b/backend/tests/test_ai_provider.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from app.services.ai_provider import normalize_openai_base_url
+
+
+def test_normalize_openai_base_url_adds_v1_for_root_gateway():
+    assert normalize_openai_base_url("http://ai.zedbox.cn:8080") == "http://ai.zedbox.cn:8080/v1"
+
+
+def test_normalize_openai_base_url_preserves_v1_base():
+    assert normalize_openai_base_url("http://ai.zedbox.cn:8080/v1") == "http://ai.zedbox.cn:8080/v1"
+
+
+def test_normalize_openai_base_url_strips_chat_completions_path():
+    assert normalize_openai_base_url("http://ai.zedbox.cn:8080/v1/chat/completions") == "http://ai.zedbox.cn:8080/v1"


### PR DESCRIPTION
## 中文说明

### 背景

当前 AI 配置页允许用户填写 OpenAI 兼容接口地址。如果用户填写的是网关根地址（例如 `http://host:port`），OpenAI SDK 会请求到 `/chat/completions`，而部分 OpenAI-compatible 网关实际只在 `/v1/chat/completions` 提供接口。这会导致 AI 测试或各类 AI 分析拿到 HTML/非标准响应，进而出现无内容、`.model` 属性错误或不易理解的失败提示。

### 改动

- 在统一的 AI provider 适配层中新增 OpenAI-compatible base URL 归一化逻辑。
- 支持以下输入形式自动归一：
  - `http://host:port` → `http://host:port/v1`
  - `http://host:port/v1` → 保持不变
  - `http://host:port/v1/chat/completions` → `http://host:port/v1`
- 归一化逻辑位于统一的 OpenAI SDK client 创建入口，因此会覆盖当前所有 OpenAI-compatible AI 调用路径。
- 增加回归测试覆盖 base URL 归一化。

### 测试

- `cd backend && .\.venv\Scripts\python.exe -m pytest tests\test_ai_provider.py tests\backtest\test_engine_portfolio.py tests\backtest\test_full_simulation_tail.py tests\backtest\test_strategy_backtest_correctness.py -q`
  - `19 passed`
- `cd frontend && pnpm build`
  - 构建成功
  - 仍有既有 Vite chunk/dynamic import 警告，非本次失败项

---

## English Description

### Background

The AI settings page accepts custom OpenAI-compatible endpoint URLs. When users enter a gateway root URL such as `http://host:port`, the OpenAI SDK requests `/chat/completions`, while some OpenAI-compatible gateways expose the actual API under `/v1/chat/completions`. This can make AI tests or AI analysis features receive HTML/non-standard responses, causing empty output, `.model` attribute errors, or unclear failures.

### Changes

- Add OpenAI-compatible base URL normalization in the shared AI provider adapter.
- Normalize common input forms:
  - `http://host:port` → `http://host:port/v1`
  - `http://host:port/v1` → unchanged
  - `http://host:port/v1/chat/completions` → `http://host:port/v1`
- Apply normalization at the shared OpenAI SDK client creation point, so it covers all current OpenAI-compatible AI call paths.
- Add regression tests for base URL normalization.

### Test Plan

- `cd backend && .\.venv\Scripts\python.exe -m pytest tests\test_ai_provider.py tests\backtest\test_engine_portfolio.py tests\backtest\test_full_simulation_tail.py tests\backtest\test_strategy_backtest_correctness.py -q`
  - `19 passed`
- `cd frontend && pnpm build`
  - Build succeeded
  - Existing Vite chunk/dynamic import warnings remain, but they are not build failures