### PR TITLE
fix(docker): 修复 .env 相对路径覆盖导致每次重建容器丢数据

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,12 @@ services:
       - "${PORT:-3018}:3018"
     env_file:
       - .env
+    environment:
+      # 强制固定为容器内绝对路径, 防止 .env 里的 DATA_DIR=./data(开发模式用)
+      # 被 env_file 原样传入容器后按错误的相对路径解析, 写到未挂载卷的目录,
+      # 导致每次 up --build 重建容器都丢数据。environment 优先级高于 env_file,
+      # 无论 .env 怎么写这里都以容器路径为准。
+      - DATA_DIR=/app/data
     volumes:
       - ./data:/app/data
       - ./tiers.yaml:/app/tiers.yaml:ro


### PR DESCRIPTION
## Summary

- `.env` 里 `DATA_DIR=./data`(为本地开发模式设计,与项目根解析出的默认值一致)经 `docker-compose.yml` 的 `env_file: .env` 原样传入容器,覆盖了 `Dockerfile` 里显式设置的 `ENV DATA_DIR=/app/data`
- `backend/app/config.py` 的 `_project_root()` 按开发布局 `<repo>/backend/app/config.py` 三层父目录推算项目根;但 Docker 镜像里 `COPY backend/app ./app` 抹掉了 `backend` 这层,文件实际落在 `/app/app/config.py`,三层父目录数到了 `/`(而非 `/app`)
- 两者叠加:相对路径 `./data` 被解析成 `/data`,不在 `docker-compose.yml` 挂载的 `./data:/app/data` 范围内。容器可写层不持久化,每次 `docker compose up --build` 重建容器都会清空该目录 —— 这就是「每次改代码 rebuild 就丢数据」的根因
- 修复:在 `docker-compose.yml` 里显式加 `environment: DATA_DIR=/app/data`。Compose 的 `environment` 优先级高于 `env_file`,无论 `.env` 里怎么写,容器内路径始终固定为 `/app/data`,与 `Dockerfile` 注释里「显式指定三个关键路径,确保 static/tiers/data 都指向容器内正确位置」的原意保持一致

## Test plan

- [x] 用受影响的 `.env`(`DATA_DIR=./data`)本地复现问题:确认修复前容器内 `settings.data_dir` 解析为 `/data`(未挂载,数据写入即丢);已用 `docker cp` 从旧容器抢救回 89M 在用数据到宿主机 `./data`
- [x] `docker compose config` 验证:`environment` 覆盖生效,最终 `DATA_DIR: /app/data`
- [x] `docker compose up --build` 重建后进容器验证:`settings.data_dir == /app/data`,容器内不再存在游离的 `/data` 目录
- [x] 重建后 `/health` 返回 200,日志显示 pipeline/monitor/scheduler 正常加载