### PR TITLE
feat(optimizer): 参数网格搜索优化器 (并行回测 + 目标排序 + SSE + 前端面板)

### DIFF
--- a/backend/app/api/backtest.py
+++ b/backend/app/api/backtest.py
@@ -511,3 +511,210 @@ async def strategy_cancel(request: Request):
         return {"ok": True}
     return {"ok": False, "message": "任务不存在或已完成"}
 
+
+# ══════════════════════════════════════════════════════════════
+# 参数网格优化器 — 复用 _BacktestJob SSE 框架 (多组参数并行回测 + 排序)
+# ══════════════════════════════════════════════════════════════
+
+# 透传给每组回测的 StrategyBacktestConfig 字段 (作为 backtest_kwargs)。
+_OPT_BT_FIELDS = [
+    "matching", "fees_pct", "commission_pct", "stamp_tax_pct", "slippage_bps",
+    "max_positions", "max_exposure_pct", "initial_capital", "position_sizing",
+    "mode", "holding_days",
+]
+
+
+def _make_opt_job_key(strategy_id, symbols, start, end, param_grid, objective, direction, bt_sig) -> str:
+    raw = f"OPT|{strategy_id}|{symbols}|{start}|{end}|{param_grid}|{objective}|{direction}|{bt_sig}"
+    return hashlib.md5(raw.encode()).hexdigest()[:12]
+
+
+def _opt_backtest_kwargs(
+    matching, fees_pct, commission_pct, stamp_tax_pct, slippage_bps,
+    max_positions, max_exposure_pct, initial_capital, position_sizing, mode, holding_days,
+) -> dict:
+    return {
+        "matching": matching,
+        "fees_pct": fees_pct,
+        "commission_pct": commission_pct,
+        "stamp_tax_pct": stamp_tax_pct,
+        "slippage_bps": slippage_bps,
+        "max_positions": int(max_positions),
+        "max_exposure_pct": float(max_exposure_pct),
+        "initial_capital": float(initial_capital),
+        "position_sizing": position_sizing,
+        "mode": mode,
+        "holding_days": int(holding_days),
+    }
+
+
+@router.get("/optimize/stream")
+async def optimize_stream(
+    request: Request,
+    strategy_id: str,
+    param_grid: str,                 # JSON: {param_id: [values] | {min,max,step}}
+    objective: str = "sortino",
+    direction: str | None = None,
+    max_workers: int = 4,
+    symbols: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
+    matching: str = "open_t+1",
+    fees_pct: float = 0.0002,
+    commission_pct: float | None = None,
+    stamp_tax_pct: float | None = None,
+    slippage_bps: float = 5.0,
+    max_positions: int = 10,
+    max_exposure_pct: float = 1.0,
+    initial_capital: float = 1_000_000.0,
+    position_sizing: str = "equal",
+    mode: str = "position",
+    holding_days: int = 5,
+):
+    """SSE 流式参数优化: 并行跑各参数组回测, 按 objective 排序。
+
+    事件类型:
+      - progress: {type: "optimizer_progress", done, total, best_score}
+      - done: {result} (含 best_params / results 排名)
+      - error: {message}
+    """
+    from app.backtest.optimizer import OptimizeConfig, StrategyOptimizer
+    from app.backtest.strategy import StrategyBacktestService
+
+    engine = _get_engine(request)
+    strategy_engine = request.app.state.strategy_engine
+    svc = StrategyBacktestService(engine, strategy_engine)
+
+    end_date = date.fromisoformat(end) if end else date.today()
+    if start:
+        start_date = date.fromisoformat(start)
+    else:
+        earliest = request.app.state.repo.earliest_daily_date()
+        start_date = earliest or (end_date - timedelta(days=FACTOR_DEFAULT_DAYS))
+
+    guard_violated = False
+    if settings.backtest_range_guard and (end_date - start_date).days + 1 > BACKTEST_MAX_SERVER_DAYS:
+        guard_violated = True
+
+    bt_kwargs = _opt_backtest_kwargs(
+        matching, fees_pct, commission_pct, stamp_tax_pct, slippage_bps,
+        max_positions, max_exposure_pct, initial_capital, position_sizing, mode, holding_days,
+    )
+    bt_sig = "|".join(f"{k}={bt_kwargs[k]}" for k in _OPT_BT_FIELDS)
+    job_key = _make_opt_job_key(strategy_id, symbols, start, end, param_grid, objective, direction, bt_sig)
+
+    _cleanup_stale_jobs()
+    with _jobs_lock:
+        job = _running_jobs.get(job_key)
+        if job is None:
+            job = _BacktestJob(job_key)
+            _running_jobs[job_key] = job
+            is_new = True
+        else:
+            is_new = False
+
+    async def event_generator():
+        if guard_violated:
+            yield f"event: error\ndata: {json.dumps({'message': BACKTEST_SERVER_GUARD_MESSAGE}, ensure_ascii=False)}\n\n"
+            return
+
+        if is_new and not job.done:
+            try:
+                grid = json.loads(param_grid)
+            except (json.JSONDecodeError, TypeError):
+                job.error = "param_grid 不是合法 JSON"
+                job.done = True
+                job.finish_ts = time.time()
+                grid = None
+
+            if grid is not None:
+                ocfg = OptimizeConfig(
+                    strategy_id=strategy_id,
+                    symbols=[s.strip() for s in symbols.split(",") if s.strip()] if symbols else None,
+                    start=start_date,
+                    end=end_date,
+                    param_grid=grid,
+                    objective=objective,
+                    direction=direction,
+                    max_workers=int(max_workers),
+                    backtest_kwargs=bt_kwargs,
+                )
+
+                def _run_opt():
+                    try:
+                        opt = StrategyOptimizer(svc, strategy_engine)
+                        job.result = opt.optimize(ocfg, lambda d: job.progress.append(d), job.cancel_event)
+                        job.done = True
+                        job.finish_ts = time.time()
+                    except Exception as e:
+                        job.error = str(e)
+                        job.done = True
+                        job.finish_ts = time.time()
+
+                threading.Thread(target=_run_opt, daemon=True).start()
+
+        cursor = 0
+        tick = 0
+        try:
+            while True:
+                if job.done:
+                    if job.error:
+                        yield f"event: error\ndata: {json.dumps({'message': job.error}, ensure_ascii=False)}\n\n"
+                    elif job.result is not None:
+                        yield f"event: done\ndata: {json.dumps(job.result, ensure_ascii=False, default=str)}\n\n"
+                    return
+                tick += 1
+                if tick % 4 == 0 and await request.is_disconnected():
+                    break
+                while cursor < len(job.progress):
+                    msg = job.progress[cursor]
+                    cursor += 1
+                    yield f"event: progress\ndata: {json.dumps(msg, ensure_ascii=False, default=str)}\n\n"
+                await asyncio.sleep(0.5)
+        except asyncio.CancelledError:
+            raise
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
+
+
+@router.post("/optimize/cancel")
+async def optimize_cancel(request: Request):
+    """取消优化任务 (前端传 query string, 后端算同一 job_key)。"""
+    from urllib.parse import parse_qs
+    body = await request.json()
+    p = parse_qs(body.get("qs", ""))
+    def _get(key: str, default: str = "") -> str:
+        return p.get(key, [default])[0]
+    def _get_opt_float(key: str) -> float | None:
+        v = _get(key)
+        return float(v) if v else None
+    bt_kwargs = _opt_backtest_kwargs(
+        _get("matching", "open_t+1"),
+        float(_get("fees_pct", "0.0002")),
+        _get_opt_float("commission_pct"),
+        _get_opt_float("stamp_tax_pct"),
+        float(_get("slippage_bps", "5")),
+        int(_get("max_positions", "10")),
+        float(_get("max_exposure_pct", "1")),
+        float(_get("initial_capital", "1000000")),
+        _get("position_sizing", "equal"),
+        _get("mode", "position"),
+        int(_get("holding_days", "5")),
+    )
+    bt_sig = "|".join(f"{k}={bt_kwargs[k]}" for k in _OPT_BT_FIELDS)
+    job_key = _make_opt_job_key(
+        _get("strategy_id"),
+        _get("symbols") or None,
+        _get("start") or None,
+        _get("end") or None,
+        _get("param_grid") or None,
+        _get("objective", "sortino"),
+        _get("direction") or None,
+        bt_sig,
+    )
+    job = _running_jobs.get(job_key)
+    if job and not job.done:
+        job.cancel_event.set()
+        return {"ok": True}
+    return {"ok": False, "message": "任务不存在或已完成"}
+

--- a/backend/app/api/backtest.py
+++ b/backend/app/api/backtest.py
@@ -596,6 +596,8 @@ async def optimize_stream(
     if settings.backtest_range_guard and (end_date - start_date).days + 1 > BACKTEST_MAX_SERVER_DAYS:
         guard_violated = True
 
+    # 空串归一为 None, 与 cancel 侧 `_get("direction") or None` 口径一致, 避免 job_key 失配。
+    direction = direction or None
     bt_kwargs = _opt_backtest_kwargs(
         matching, fees_pct, commission_pct, stamp_tax_pct, slippage_bps,
         max_positions, max_exposure_pct, initial_capital, position_sizing, mode, holding_days,
@@ -622,7 +624,11 @@ async def optimize_stream(
             try:
                 grid = json.loads(param_grid)
             except (json.JSONDecodeError, TypeError):
-                job.error = "param_grid 不是合法 JSON"
+                grid = None
+            # grid 必须是非空 dict; null/[]/"" 等合法 JSON 但结构错误也在此拦下,
+            # 否则会跳过线程启动却不置 done -> event_generator 永久空转、job 挂死。
+            if not isinstance(grid, dict) or not grid:
+                job.error = "param_grid 必须是非空的参数网格对象"
                 job.done = True
                 job.finish_ts = time.time()
                 grid = None
@@ -660,6 +666,9 @@ async def optimize_stream(
                 if job.done:
                     if job.error:
                         yield f"event: error\ndata: {json.dumps({'message': job.error}, ensure_ascii=False)}\n\n"
+                    elif job.cancel_event.is_set():
+                        # 取消时优化器把每组记为 cancelled 并正常返回, 需在此分流为取消提示而非"完成"。
+                        yield f"event: error\ndata: {json.dumps({'message': '优化已取消'}, ensure_ascii=False)}\n\n"
                     elif job.result is not None:
                         yield f"event: done\ndata: {json.dumps(job.result, ensure_ascii=False, default=str)}\n\n"
                     return

--- a/backend/app/api/backtest.py
+++ b/backend/app/api/backtest.py
@@ -616,6 +616,9 @@ async def optimize_stream(
             is_new = False
 
     async def event_generator():
+        # 首个事件回吐 job_key, 前端存下供 cancel 直接引用 (消除两侧重算契约)。
+        yield f"event: job\ndata: {json.dumps({'key': job_key}, ensure_ascii=False)}\n\n"
+
         if guard_violated:
             yield f"event: error\ndata: {json.dumps({'message': BACKTEST_SERVER_GUARD_MESSAGE}, ensure_ascii=False)}\n\n"
             return
@@ -688,39 +691,14 @@ async def optimize_stream(
 
 @router.post("/optimize/cancel")
 async def optimize_cancel(request: Request):
-    """取消优化任务 (前端传 query string, 后端算同一 job_key)。"""
-    from urllib.parse import parse_qs
+    """取消优化任务 — 前端传 stream 首事件回吐的 job_key, 后端直接查表。
+
+    不再让 cancel 侧重算 job_key: 两侧重算必须逐字段一致的脆弱契约(PR3 C1 / direction
+    空串失配都源于此)在此彻底消除。stream 首个 SSE 事件把后端算出的 key 回吐给前端,
+    cancel 原样传回即可。
+    """
     body = await request.json()
-    p = parse_qs(body.get("qs", ""))
-    def _get(key: str, default: str = "") -> str:
-        return p.get(key, [default])[0]
-    def _get_opt_float(key: str) -> float | None:
-        v = _get(key)
-        return float(v) if v else None
-    bt_kwargs = _opt_backtest_kwargs(
-        _get("matching", "open_t+1"),
-        float(_get("fees_pct", "0.0002")),
-        _get_opt_float("commission_pct"),
-        _get_opt_float("stamp_tax_pct"),
-        float(_get("slippage_bps", "5")),
-        int(_get("max_positions", "10")),
-        float(_get("max_exposure_pct", "1")),
-        float(_get("initial_capital", "1000000")),
-        _get("position_sizing", "equal"),
-        _get("mode", "position"),
-        int(_get("holding_days", "5")),
-    )
-    bt_sig = "|".join(f"{k}={bt_kwargs[k]}" for k in _OPT_BT_FIELDS)
-    job_key = _make_opt_job_key(
-        _get("strategy_id"),
-        _get("symbols") or None,
-        _get("start") or None,
-        _get("end") or None,
-        _get("param_grid") or None,
-        _get("objective", "sortino"),
-        _get("direction") or None,
-        bt_sig,
-    )
+    job_key = body.get("job_key", "")
     job = _running_jobs.get(job_key)
     if job and not job.done:
         job.cancel_event.set()

--- a/backend/app/api/backtest.py
+++ b/backend/app/api/backtest.py
@@ -524,8 +524,8 @@ _OPT_BT_FIELDS = [
 ]
 
 
-def _make_opt_job_key(strategy_id, symbols, start, end, param_grid, objective, direction, bt_sig) -> str:
-    raw = f"OPT|{strategy_id}|{symbols}|{start}|{end}|{param_grid}|{objective}|{direction}|{bt_sig}"
+def _make_opt_job_key(strategy_id, symbols, start, end, param_grid, objective, direction, bt_sig, params=None, overrides=None) -> str:
+    raw = f"OPT|{strategy_id}|{symbols}|{start}|{end}|{param_grid}|{objective}|{direction}|{bt_sig}|{params}|{overrides}"
     return hashlib.md5(raw.encode()).hexdigest()[:12]
 
 
@@ -556,6 +556,8 @@ async def optimize_stream(
     objective: str = "sortino",
     direction: str | None = None,
     max_workers: int = 4,
+    params: str | None = None,       # JSON: 未扫描参数固定为用户当前值 (base_params)
+    overrides: str | None = None,    # JSON: 策略当前的 basic_filter/signals/风控等覆盖
     symbols: str | None = None,
     start: str | None = None,
     end: str | None = None,
@@ -603,7 +605,7 @@ async def optimize_stream(
         max_positions, max_exposure_pct, initial_capital, position_sizing, mode, holding_days,
     )
     bt_sig = "|".join(f"{k}={bt_kwargs[k]}" for k in _OPT_BT_FIELDS)
-    job_key = _make_opt_job_key(strategy_id, symbols, start, end, param_grid, objective, direction, bt_sig)
+    job_key = _make_opt_job_key(strategy_id, symbols, start, end, param_grid, objective, direction, bt_sig, params, overrides)
 
     _cleanup_stale_jobs()
     with _jobs_lock:
@@ -637,6 +639,16 @@ async def optimize_stream(
                 grid = None
 
             if grid is not None:
+                # 未扫描参数固定为用户当前值 (base_params); overrides 让策略的 basic_filter/
+                # 信号/风控按用户当前配置参与, 保证优化的就是用户实际回测的策略。
+                try:
+                    base_params = json.loads(params) if params else {}
+                except (json.JSONDecodeError, TypeError):
+                    base_params = {}
+                try:
+                    ov = json.loads(overrides) if overrides else None
+                except (json.JSONDecodeError, TypeError):
+                    ov = None
                 ocfg = OptimizeConfig(
                     strategy_id=strategy_id,
                     symbols=[s.strip() for s in symbols.split(",") if s.strip()] if symbols else None,
@@ -646,6 +658,8 @@ async def optimize_stream(
                     objective=objective,
                     direction=direction,
                     max_workers=int(max_workers),
+                    base_params=base_params if isinstance(base_params, dict) else {},
+                    overrides=ov if isinstance(ov, dict) else None,
                     backtest_kwargs=bt_kwargs,
                 )
 

--- a/backend/app/backtest/engine.py
+++ b/backend/app/backtest/engine.py
@@ -121,9 +121,14 @@ class _CacheEntry:
 
 
 class PanelCache:
-    """LRU + TTL 数据面板缓存。"""
+    """LRU + TTL 数据面板缓存。
 
-    def __init__(self, max_size: int = 2, ttl_seconds: int = 180):
+    线程安全: 优化器/walk-forward 会用多线程对同一 symbols/日期跑不同参数,
+    整个 get_or_compute 加锁 — 首个线程 compute 时其余等待, 完成后全部命中缓存,
+    同一面板只 scan_parquet + compute_all 一次。
+    """
+
+    def __init__(self, max_size: int = 4, ttl_seconds: int = 900):
         self._cache: OrderedDict[str, _CacheEntry] = OrderedDict()
         self._max_size = max_size
         self._ttl = ttl_seconds

--- a/backend/app/backtest/engine.py
+++ b/backend/app/backtest/engine.py
@@ -121,14 +121,9 @@ class _CacheEntry:
 
 
 class PanelCache:
-    """LRU + TTL 数据面板缓存。
+    """LRU + TTL 数据面板缓存。"""
 
-    线程安全: 优化器/walk-forward 会用多线程对同一 symbols/日期跑不同参数,
-    整个 get_or_compute 加锁 — 首个线程 compute 时其余等待, 完成后全部命中缓存,
-    同一面板只 scan_parquet + compute_all 一次。
-    """
-
-    def __init__(self, max_size: int = 4, ttl_seconds: int = 900):
+    def __init__(self, max_size: int = 2, ttl_seconds: int = 180):
         self._cache: OrderedDict[str, _CacheEntry] = OrderedDict()
         self._max_size = max_size
         self._ttl = ttl_seconds

--- a/backend/app/backtest/optimizer.py
+++ b/backend/app/backtest/optimizer.py
@@ -1,0 +1,264 @@
+"""参数网格搜索优化器。
+
+给定策略 + 参数网格, 遍历所有参数组合各跑一次回测, 按目标指标排序, 返回最优参数。
+
+- 参数网格校验对齐 StrategyDef.meta["params"] (类型/范围/选项)。
+- 多线程并行执行, 复用 PanelCache: 同一 symbols/日期的面板只加载一次, 其余组合命中缓存。
+- 支持进度回调 (第 i/N 组完成) 与取消。
+"""
+from __future__ import annotations
+
+import itertools
+import logging
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import date
+
+logger = logging.getLogger(__name__)
+
+# 组合数硬上限 — 防止参数网格爆炸 (每组一次回测, 过大直接拒绝)。
+GRID_MAX_COMBINATIONS = 2000
+
+# 需最小化的目标 (值越小越好); 其余默认最大化。
+# 注意: max_drawdown / mc_maxdd_* 为负值, 最大化其带符号值 = 回撤越小越好, 故仍归为 max。
+_MINIMIZE_OBJECTIVES = {"avg_holding_days"}
+
+# 可选优化目标 (须为 stats 中存在且数值可比的字段)。
+VALID_OBJECTIVES = {
+    "total_return", "annual_return", "sharpe", "sortino", "calmar",
+    "win_rate", "profit_factor", "max_drawdown", "mc_maxdd_p50", "mc_maxdd_p95",
+    "avg_pnl", "median_pnl", "n_trades", "avg_holding_days",
+}
+
+
+def _candidates_for(param_id: str, spec, pmeta: dict) -> list:
+    """从 grid spec 解析某参数的候选值列表并逐个校验。
+
+    spec 支持三种写法:
+      - list: 显式候选值 [v1, v2, ...]
+      - {"values": [...]}: 显式候选值
+      - {"min", "max", "step"}: 数值型按步长展开 (含端点)
+    """
+    p_type = pmeta["type"]
+
+    # 解析原始候选值
+    if isinstance(spec, list):
+        raw = spec
+    elif isinstance(spec, dict) and "values" in spec:
+        raw = spec["values"]
+    elif isinstance(spec, dict):
+        if p_type not in ("float", "int"):
+            raise ValueError(f"参数 '{param_id}' 为 {p_type} 型, 不支持 min/max/step 展开, 请给候选值列表")
+        step = spec.get("step") or pmeta.get("step")
+        if step is None or float(step) <= 0:
+            raise ValueError(f"参数 '{param_id}' 的 step 必须为正数")
+        lo = float(spec.get("min", pmeta.get("min", 0)))
+        hi = float(spec.get("max", pmeta.get("max", 0)))
+        if hi < lo:
+            raise ValueError(f"参数 '{param_id}' 的 max < min")
+        step = float(step)
+        raw = []
+        v = lo
+        while v <= hi + 1e-9:  # 浮点容错, 含端点
+            raw.append(round(v, 10))
+            v += step
+    else:
+        raise ValueError(f"参数 '{param_id}' 的网格 spec 必须是列表或 {{min,max,step}} 字典")
+
+    if not raw:
+        raise ValueError(f"参数 '{param_id}' 的候选值为空")
+
+    # 逐值校验 + 归一化类型
+    out = []
+    for val in raw:
+        if p_type in ("float", "int"):
+            try:
+                num = float(val)
+            except (TypeError, ValueError):
+                raise ValueError(f"参数 '{param_id}' 的候选值 {val!r} 不是数字") from None
+            if pmeta.get("min") is not None and num < float(pmeta["min"]) - 1e-9:
+                raise ValueError(f"参数 '{param_id}' 的候选值 {val} 超出范围 (< min {pmeta['min']})")
+            if pmeta.get("max") is not None and num > float(pmeta["max"]) + 1e-9:
+                raise ValueError(f"参数 '{param_id}' 的候选值 {val} 超出范围 (> max {pmeta['max']})")
+            out.append(round(num) if p_type == "int" else num)
+        elif p_type == "bool":
+            out.append(bool(val))
+        elif p_type == "select":
+            if val not in pmeta.get("options", []):
+                raise ValueError(f"参数 '{param_id}' 的候选值 {val!r} 不在 options {pmeta.get('options')} 中")
+            out.append(val)
+        else:
+            out.append(val)
+    # 去重保序
+    seen = set()
+    uniq = []
+    for v in out:
+        k = (type(v).__name__, v)
+        if k not in seen:
+            seen.add(k)
+            uniq.append(v)
+    return uniq
+
+
+def _grid_candidates(params_meta: list[dict], param_grid: dict) -> dict[str, list]:
+    """校验整个 param_grid, 返回 {param_id: [候选值...]}。"""
+    if not param_grid:
+        raise ValueError("参数网格为空, 至少需要一个可扫参数")
+    by_id = {p["id"]: p for p in params_meta}
+    result: dict[str, list] = {}
+    for pid, spec in param_grid.items():
+        if pid not in by_id:
+            raise ValueError(f"参数 '{pid}' 在该策略中不存在")
+        result[pid] = _candidates_for(pid, spec, by_id[pid])
+    return result
+
+
+def count_combinations(params_meta: list[dict], param_grid: dict) -> int:
+    """组合总数 (笛卡尔积), 用于爆炸预判。"""
+    cands = _grid_candidates(params_meta, param_grid)
+    total = 1
+    for vals in cands.values():
+        total *= len(vals)
+    return total
+
+
+def expand_param_grid(params_meta: list[dict], param_grid: dict) -> list[dict]:
+    """校验并展开为参数组合列表, 每个组合是 {param_id: value} (仅含被扫参数)。
+
+    超过 GRID_MAX_COMBINATIONS 直接拒绝。
+    """
+    cands = _grid_candidates(params_meta, param_grid)
+    total = 1
+    for vals in cands.values():
+        total *= len(vals)
+    if total > GRID_MAX_COMBINATIONS:
+        raise ValueError(f"参数组合数 {total} 超过上限 {GRID_MAX_COMBINATIONS}, 请增大 step 或缩小范围")
+
+    keys = list(cands.keys())
+    combos = []
+    for values in itertools.product(*(cands[k] for k in keys)):
+        combos.append(dict(zip(keys, values, strict=True)))
+    return combos
+
+
+def objective_value(stats: dict, objective: str, direction: str) -> float:
+    """从 stats 提取目标值并转为"越大越好"的可比分数 (None/缺失 -> 最差)。"""
+    raw = stats.get(objective)
+    if raw is None:
+        return float("-inf")
+    try:
+        v = float(raw)
+    except (TypeError, ValueError):
+        return float("-inf")
+    if v != v or v in (float("inf"), float("-inf")):  # nan/inf
+        return float("-inf")
+    return -v if direction == "min" else v
+
+
+def default_direction(objective: str) -> str:
+    return "min" if objective in _MINIMIZE_OBJECTIVES else "max"
+
+
+@dataclass
+class OptimizeConfig:
+    strategy_id: str
+    symbols: list[str] | None
+    start: date
+    end: date
+    param_grid: dict
+    objective: str = "sortino"
+    direction: str | None = None  # None -> 由 objective 推断
+    max_workers: int = 4
+    base_params: dict = field(default_factory=dict)   # 不扫的固定策略参数
+    overrides: dict | None = None
+    backtest_kwargs: dict = field(default_factory=dict)  # matching/fees/mode/initial_capital 等
+
+
+class StrategyOptimizer:
+    """遍历参数组合并行回测, 按目标排序。"""
+
+    def __init__(self, service, strategy_engine) -> None:
+        self.service = service
+        self.strategy_engine = strategy_engine
+
+    def optimize(
+        self,
+        cfg: OptimizeConfig,
+        progress_cb=None,
+        cancel_event: threading.Event | None = None,
+    ) -> dict:
+        from app.backtest.strategy import StrategyBacktestConfig
+
+        t0 = time.perf_counter()
+        if cfg.objective not in VALID_OBJECTIVES:
+            raise ValueError(f"不支持的优化目标 '{cfg.objective}', 可选: {sorted(VALID_OBJECTIVES)}")
+        direction = cfg.direction or default_direction(cfg.objective)
+
+        s = self.strategy_engine.get(cfg.strategy_id)  # 可能抛 ValueError
+        params_meta = s.meta.get("params", [])
+        combos = expand_param_grid(params_meta, cfg.param_grid)
+        n_total = len(combos)
+
+        results: list[dict] = []
+        done = 0
+        lock = threading.Lock()
+
+        def _run_one(idx: int, combo: dict) -> dict | None:
+            if cancel_event is not None and cancel_event.is_set():
+                return None
+            merged = {**cfg.base_params, **combo}
+            bt_cfg = StrategyBacktestConfig(
+                strategy_id=cfg.strategy_id,
+                symbols=cfg.symbols,
+                start=cfg.start,
+                end=cfg.end,
+                params=merged,
+                overrides=cfg.overrides,
+                **cfg.backtest_kwargs,
+            )
+            res = self.service.run(bt_cfg, cancel_event=cancel_event)
+            if res.error:
+                return {"params": combo, "error": res.error, "score": float("-inf")}
+            score = objective_value(res.stats, cfg.objective, direction)
+            return {
+                "params": combo,
+                "score": score,
+                "stats": res.stats,
+            }
+
+        max_workers = max(1, min(int(cfg.max_workers), n_total))
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {pool.submit(_run_one, i, c): i for i, c in enumerate(combos)}
+            for fut in as_completed(futures):
+                r = fut.result()
+                with lock:
+                    done += 1
+                    if r is not None:
+                        results.append(r)
+                    if progress_cb is not None:
+                        best = max((x["score"] for x in results), default=float("-inf"))
+                        progress_cb({
+                            "type": "optimizer_progress",
+                            "done": done,
+                            "total": n_total,
+                            "best_score": None if best == float("-inf") else round(best, 4),
+                        })
+
+        # 排序: score 降序 (已统一为越大越好); -inf (失败/无效) 沉底
+        ranked = sorted(results, key=lambda x: x["score"], reverse=True)
+        for i, r in enumerate(ranked):
+            r["rank"] = i + 1
+
+        best = ranked[0] if ranked and ranked[0]["score"] != float("-inf") else None
+        return {
+            "objective": cfg.objective,
+            "direction": direction,
+            "n_combinations": n_total,
+            "n_completed": len(results),
+            "best_params": best["params"] if best else None,
+            "best_score": round(best["score"], 4) if best else None,
+            "results": ranked,
+            "elapsed_ms": round((time.perf_counter() - t0) * 1000, 1),
+        }

--- a/backend/app/backtest/optimizer.py
+++ b/backend/app/backtest/optimizer.py
@@ -59,11 +59,9 @@ def _candidates_for(param_id: str, spec, pmeta: dict) -> list:
         if hi < lo:
             raise ValueError(f"参数 '{param_id}' 的 max < min")
         step = float(step)
-        raw = []
-        v = lo
-        while v <= hi + 1e-9:  # 浮点容错, 含端点
-            raw.append(round(v, 10))
-            v += step
+        # 整数计数生成候选, 避免浮点累加误差丢端点 (如 0.1/0.1 步长)。
+        n_steps = round((hi - lo) / step)
+        raw = [round(lo + i * step, 10) for i in range(n_steps + 1)]
     else:
         raise ValueError(f"参数 '{param_id}' 的网格 spec 必须是列表或 {{min,max,step}} 字典")
 
@@ -161,6 +159,24 @@ def default_direction(objective: str) -> str:
     return "min" if objective in _MINIMIZE_OBJECTIVES else "max"
 
 
+# optimize 显式传入的 StrategyBacktestConfig 参数, backtest_kwargs 不得重复覆盖。
+_RESERVED_BT_KEYS = {"strategy_id", "symbols", "start", "end", "params", "overrides"}
+
+
+def _validate_backtest_kwargs(backtest_kwargs: dict) -> None:
+    """校验 backtest_kwargs 的 key 合法且不与显式参数冲突, 否则会在 worker 线程抛 TypeError。"""
+    from dataclasses import fields
+
+    from app.backtest.strategy import StrategyBacktestConfig
+
+    valid = {f.name for f in fields(StrategyBacktestConfig)} - _RESERVED_BT_KEYS
+    for k in backtest_kwargs:
+        if k in _RESERVED_BT_KEYS:
+            raise ValueError(f"backtest_kwargs 不能包含 '{k}' (由优化器显式管理)")
+        if k not in valid:
+            raise ValueError(f"backtest_kwargs 含非法字段 '{k}', 合法: {sorted(valid)}")
+
+
 @dataclass
 class OptimizeConfig:
     strategy_id: str
@@ -195,6 +211,7 @@ class StrategyOptimizer:
         if cfg.objective not in VALID_OBJECTIVES:
             raise ValueError(f"不支持的优化目标 '{cfg.objective}', 可选: {sorted(VALID_OBJECTIVES)}")
         direction = cfg.direction or default_direction(cfg.objective)
+        _validate_backtest_kwargs(cfg.backtest_kwargs)
 
         s = self.strategy_engine.get(cfg.strategy_id)  # 可能抛 ValueError
         params_meta = s.meta.get("params", [])
@@ -208,57 +225,71 @@ class StrategyOptimizer:
         def _run_one(idx: int, combo: dict) -> dict | None:
             if cancel_event is not None and cancel_event.is_set():
                 return None
-            merged = {**cfg.base_params, **combo}
-            bt_cfg = StrategyBacktestConfig(
-                strategy_id=cfg.strategy_id,
-                symbols=cfg.symbols,
-                start=cfg.start,
-                end=cfg.end,
-                params=merged,
-                overrides=cfg.overrides,
-                **cfg.backtest_kwargs,
-            )
-            res = self.service.run(bt_cfg, cancel_event=cancel_event)
+            # 单组异常必须隔离: 加了并行后, 一组抛异常若冒泡会拖垮整批 (丢弃全部已完成结果)。
+            try:
+                merged = {**cfg.base_params, **combo}
+                bt_cfg = StrategyBacktestConfig(
+                    strategy_id=cfg.strategy_id,
+                    symbols=cfg.symbols,
+                    start=cfg.start,
+                    end=cfg.end,
+                    params=merged,
+                    overrides=cfg.overrides,
+                    **cfg.backtest_kwargs,
+                )
+                res = self.service.run(bt_cfg, cancel_event=cancel_event)
+            except Exception as e:  # 隔离单组失败, 记录后继续, 不拖垮整批
+                logger.warning("参数组 %s 回测异常: %r", combo, e)
+                return {"params": combo, "error": repr(e), "objective_raw": None, "_sort": float("-inf")}
             if res.error:
-                return {"params": combo, "error": res.error, "score": float("-inf")}
-            score = objective_value(res.stats, cfg.objective, direction)
+                return {"params": combo, "error": res.error, "objective_raw": None, "_sort": float("-inf")}
+            # _sort: 内部排序键 (统一"越大越好"); objective_raw: 原始展示值 (不受方向取负污染)。
             return {
                 "params": combo,
-                "score": score,
+                "objective_raw": res.stats.get(cfg.objective),
+                "_sort": objective_value(res.stats, cfg.objective, direction),
                 "stats": res.stats,
             }
+
+        def _best_raw() -> float | None:
+            if not results:
+                return None
+            top = max(results, key=lambda x: x["_sort"])
+            return None if top["_sort"] == float("-inf") else top.get("objective_raw")
 
         max_workers = max(1, min(int(cfg.max_workers), n_total))
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             futures = {pool.submit(_run_one, i, c): i for i, c in enumerate(combos)}
             for fut in as_completed(futures):
-                r = fut.result()
+                r = fut.result()  # _run_one 内部已兜底, 不会 re-raise 业务异常
                 with lock:
                     done += 1
                     if r is not None:
                         results.append(r)
                     if progress_cb is not None:
-                        best = max((x["score"] for x in results), default=float("-inf"))
+                        br = _best_raw()
                         progress_cb({
                             "type": "optimizer_progress",
                             "done": done,
                             "total": n_total,
-                            "best_score": None if best == float("-inf") else round(best, 4),
+                            "best_score": round(br, 4) if br is not None else None,
                         })
 
-        # 排序: score 降序 (已统一为越大越好); -inf (失败/无效) 沉底
-        ranked = sorted(results, key=lambda x: x["score"], reverse=True)
+        # 排序: 内部 _sort 降序 (越大越好); -inf (失败/无效) 沉底。展示层用 objective_raw。
+        ranked = sorted(results, key=lambda x: x["_sort"], reverse=True)
         for i, r in enumerate(ranked):
             r["rank"] = i + 1
+            r.pop("_sort", None)  # 不外露内部排序键, 避免展示层误用取负值
 
-        best = ranked[0] if ranked and ranked[0]["score"] != float("-inf") else None
+        best = ranked[0] if ranked and ranked[0].get("objective_raw") is not None else None
+        best_raw = best["objective_raw"] if best else None
         return {
             "objective": cfg.objective,
             "direction": direction,
             "n_combinations": n_total,
             "n_completed": len(results),
             "best_params": best["params"] if best else None,
-            "best_score": round(best["score"], 4) if best else None,
+            "best_score": round(best_raw, 4) if best_raw is not None else None,
             "results": ranked,
             "elapsed_ms": round((time.perf_counter() - t0) * 1000, 1),
         }

--- a/backend/tests/backtest/test_optimizer_api.py
+++ b/backend/tests/backtest/test_optimizer_api.py
@@ -1,0 +1,60 @@
+"""优化器 API job_key 契约测试 — 守护 stream 与 cancel 的 key 对齐 (仿 PR3 C1 教训)。"""
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+from app.api.backtest import _OPT_BT_FIELDS, _make_opt_job_key, _opt_backtest_kwargs
+
+
+def _sig(bt: dict) -> str:
+    return "|".join(f"{k}={bt[k]}" for k in _OPT_BT_FIELDS)
+
+
+def test_job_key_deterministic():
+    bt = _opt_backtest_kwargs("open_t+1", 0.0002, None, None, 5.0, 10, 1.0, 1e6, "equal", "position", 5)
+    sig = _sig(bt)
+    k1 = _make_opt_job_key("s", None, None, None, '{"p":[1,2]}', "sortino", None, sig)
+    k2 = _make_opt_job_key("s", None, None, None, '{"p":[1,2]}', "sortino", None, sig)
+    assert k1 == k2
+
+
+def test_job_key_distinguishes_grid_and_objective():
+    bt = _opt_backtest_kwargs("open_t+1", 0.0002, None, None, 5.0, 10, 1.0, 1e6, "equal", "position", 5)
+    sig = _sig(bt)
+    base = _make_opt_job_key("s", None, None, None, '{"p":[1,2]}', "sortino", None, sig)
+    assert base != _make_opt_job_key("s", None, None, None, '{"p":[1,3]}', "sortino", None, sig)  # grid 不同
+    assert base != _make_opt_job_key("s", None, None, None, '{"p":[1,2]}', "sharpe", None, sig)   # objective 不同
+
+
+def test_stream_and_cancel_compute_same_key():
+    """cancel 从 query string 复原参数, 必须与 stream 算出同一 job_key, 否则取消失效。"""
+    grid = '{"ma_proximity":[0.01,0.02]}'
+    # stream 侧
+    bt = _opt_backtest_kwargs("open_t+1", 0.0002, None, None, 5.0, 10, 1.0, 1_000_000.0, "equal", "position", 5)
+    stream_key = _make_opt_job_key("s", None, None, None, grid, "sortino", None, _sig(bt))
+
+    # cancel 侧: 复原自 query string (urlencode 等价前端 URLSearchParams)
+    qs = urlencode({
+        "strategy_id": "s", "param_grid": grid, "objective": "sortino",
+        "matching": "open_t+1", "fees_pct": "0.0002", "slippage_bps": "5.0",
+        "max_positions": "10", "max_exposure_pct": "1.0", "initial_capital": "1000000.0",
+        "position_sizing": "equal", "mode": "position", "holding_days": "5",
+    })
+    from urllib.parse import parse_qs
+    p = parse_qs(qs)
+    def g(k, d=""):
+        return p.get(k, [d])[0]
+    def gf(k):
+        v = g(k)
+        return float(v) if v else None
+    bt2 = _opt_backtest_kwargs(
+        g("matching", "open_t+1"), float(g("fees_pct", "0.0002")), gf("commission_pct"), gf("stamp_tax_pct"),
+        float(g("slippage_bps", "5")), int(g("max_positions", "10")), float(g("max_exposure_pct", "1")),
+        float(g("initial_capital", "1000000")), g("position_sizing", "equal"), g("mode", "position"),
+        int(g("holding_days", "5")),
+    )
+    cancel_key = _make_opt_job_key(
+        g("strategy_id"), g("symbols") or None, g("start") or None, g("end") or None,
+        g("param_grid") or None, g("objective", "sortino"), g("direction") or None, _sig(bt2),
+    )
+    assert stream_key == cancel_key

--- a/backend/tests/backtest/test_optimizer_api.py
+++ b/backend/tests/backtest/test_optimizer_api.py
@@ -1,8 +1,6 @@
 """优化器 API job_key 契约测试 — 守护 stream 与 cancel 的 key 对齐 (仿 PR3 C1 教训)。"""
 from __future__ import annotations
 
-from urllib.parse import urlencode
-
 from app.api.backtest import _OPT_BT_FIELDS, _make_opt_job_key, _opt_backtest_kwargs
 
 
@@ -26,35 +24,37 @@ def test_job_key_distinguishes_grid_and_objective():
     assert base != _make_opt_job_key("s", None, None, None, '{"p":[1,2]}', "sharpe", None, sig)   # objective 不同
 
 
-def test_stream_and_cancel_compute_same_key():
-    """cancel 从 query string 复原参数, 必须与 stream 算出同一 job_key, 否则取消失效。"""
-    grid = '{"ma_proximity":[0.01,0.02]}'
-    # stream 侧
-    bt = _opt_backtest_kwargs("open_t+1", 0.0002, None, None, 5.0, 10, 1.0, 1_000_000.0, "equal", "position", 5)
-    stream_key = _make_opt_job_key("s", None, None, None, grid, "sortino", None, _sig(bt))
+def test_cancel_looks_up_job_by_echoed_key():
+    """重构后: cancel 直接用 stream 回吐的 job_key 查表, 不再重算参数。
 
-    # cancel 侧: 复原自 query string (urlencode 等价前端 URLSearchParams)
-    qs = urlencode({
-        "strategy_id": "s", "param_grid": grid, "objective": "sortino",
-        "matching": "open_t+1", "fees_pct": "0.0002", "slippage_bps": "5.0",
-        "max_positions": "10", "max_exposure_pct": "1.0", "initial_capital": "1000000.0",
-        "position_sizing": "equal", "mode": "position", "holding_days": "5",
-    })
-    from urllib.parse import parse_qs
-    p = parse_qs(qs)
-    def g(k, d=""):
-        return p.get(k, [d])[0]
-    def gf(k):
-        v = g(k)
-        return float(v) if v else None
-    bt2 = _opt_backtest_kwargs(
-        g("matching", "open_t+1"), float(g("fees_pct", "0.0002")), gf("commission_pct"), gf("stamp_tax_pct"),
-        float(g("slippage_bps", "5")), int(g("max_positions", "10")), float(g("max_exposure_pct", "1")),
-        float(g("initial_capital", "1000000")), g("position_sizing", "equal"), g("mode", "position"),
-        int(g("holding_days", "5")),
-    )
-    cancel_key = _make_opt_job_key(
-        g("strategy_id"), g("symbols") or None, g("start") or None, g("end") or None,
-        g("param_grid") or None, g("objective", "sortino"), g("direction") or None, _sig(bt2),
-    )
-    assert stream_key == cancel_key
+    这消除了'两侧重算必须逐字段一致'的脆弱契约 (PR3 C1 / direction 空串失配的根因)。
+    """
+    import asyncio
+
+    from app.api.backtest import _BacktestJob, _running_jobs, optimize_cancel
+
+    class _Req:
+        def __init__(self, body):
+            self._body = body
+        async def json(self):
+            return self._body
+
+    key = "optkey_test_1"
+    job = _BacktestJob(key)
+    _running_jobs[key] = job
+    try:
+        # 用回吐的 key 取消 → 命中并 set cancel_event
+        res = asyncio.run(optimize_cancel(_Req({"job_key": key})))
+        assert res["ok"] is True
+        assert job.cancel_event.is_set()
+
+        # 已完成任务再取消 → ok False
+        job.done = True
+        res2 = asyncio.run(optimize_cancel(_Req({"job_key": key})))
+        assert res2["ok"] is False
+
+        # 未知 key → ok False, 不抛异常
+        res3 = asyncio.run(optimize_cancel(_Req({"job_key": "nonexistent"})))
+        assert res3["ok"] is False
+    finally:
+        _running_jobs.pop(key, None)

--- a/backend/tests/backtest/test_optimizer_grid.py
+++ b/backend/tests/backtest/test_optimizer_grid.py
@@ -1,0 +1,111 @@
+"""参数网格展开与校验测试 — 优化器的纯逻辑核心。
+
+被测:
+- expand_param_grid(params_meta, param_grid): 校验 + 笛卡尔积 -> 参数组合列表
+- count_combinations(params_meta, param_grid): 组合数 (不真正展开, 用于爆炸预判)
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.backtest.optimizer import (
+    GRID_MAX_COMBINATIONS,
+    count_combinations,
+    expand_param_grid,
+)
+
+# 模拟一个策略的 params meta (对齐 StrategyDef.meta["params"] 结构)
+PARAMS_META = [
+    {"id": "ma_proximity", "type": "float", "default": 0.02, "min": 0.01, "max": 0.05, "step": 0.005},
+    {"id": "min_boards", "type": "int", "default": 2, "min": 1, "max": 20, "step": 1},
+    {"id": "use_ma20", "type": "bool", "default": True},
+    {"id": "fill", "type": "select", "default": "close_t", "options": ["close_t", "open_t+1"]},
+]
+
+
+# ---------------------------------------------------------------
+# 显式候选值列表
+# ---------------------------------------------------------------
+
+def test_explicit_value_lists_cartesian_product():
+    grid = {"ma_proximity": [0.01, 0.02], "min_boards": [2, 3, 4]}
+    combos = expand_param_grid(PARAMS_META, grid)
+    assert len(combos) == 6  # 2 x 3
+    assert {"ma_proximity": 0.01, "min_boards": 2} in combos
+    assert {"ma_proximity": 0.02, "min_boards": 4} in combos
+
+
+def test_single_param_sweep():
+    combos = expand_param_grid(PARAMS_META, {"min_boards": [1, 5, 10]})
+    assert combos == [{"min_boards": 1}, {"min_boards": 5}, {"min_boards": 10}]
+
+
+def test_bool_and_select_sweep():
+    grid = {"use_ma20": [True, False], "fill": ["close_t", "open_t+1"]}
+    combos = expand_param_grid(PARAMS_META, grid)
+    assert len(combos) == 4
+
+
+# ---------------------------------------------------------------
+# 范围 spec {min,max,step} 自动展开
+# ---------------------------------------------------------------
+
+def test_range_spec_expands_by_step():
+    combos = expand_param_grid(PARAMS_META, {"ma_proximity": {"min": 0.01, "max": 0.03, "step": 0.01}})
+    vals = sorted(c["ma_proximity"] for c in combos)
+    assert vals == [0.01, 0.02, 0.03]  # 含端点
+
+
+def test_range_spec_int_yields_ints():
+    combos = expand_param_grid(PARAMS_META, {"min_boards": {"min": 1, "max": 4, "step": 1}})
+    vals = sorted(c["min_boards"] for c in combos)
+    assert vals == [1, 2, 3, 4]
+    assert all(isinstance(v, int) for v in vals)
+
+
+# ---------------------------------------------------------------
+# 校验: 拒绝非法 grid
+# ---------------------------------------------------------------
+
+def test_unknown_param_rejected():
+    with pytest.raises(ValueError, match="不存在"):
+        expand_param_grid(PARAMS_META, {"nonexistent": [1, 2]})
+
+
+def test_value_out_of_range_rejected():
+    with pytest.raises(ValueError, match=r"超出范围|范围"):
+        expand_param_grid(PARAMS_META, {"ma_proximity": [0.01, 0.99]})
+
+
+def test_select_value_not_in_options_rejected():
+    with pytest.raises(ValueError, match=r"options|选项"):
+        expand_param_grid(PARAMS_META, {"fill": ["close_t", "bad_value"]})
+
+
+def test_empty_grid_rejected():
+    with pytest.raises(ValueError, match=r"空|至少"):
+        expand_param_grid(PARAMS_META, {})
+
+
+def test_combination_explosion_rejected():
+    # 构造超过硬上限的组合
+    big = {"ma_proximity": {"min": 0.01, "max": 0.05, "step": 0.001}}  # 41 个
+    # 单参数 41 个不会爆; 用多参数放大
+    grid = {
+        "ma_proximity": {"min": 0.01, "max": 0.05, "step": 0.001},   # 41
+        "min_boards": {"min": 1, "max": 20, "step": 1},              # 20
+    }  # 41 x 20 = 820, 仍 < 2000; 再加一维
+    grid["use_ma20"] = [True, False]  # x2 = 1640
+    # 到这仍 < 2000, 断言 count 正确
+    assert count_combinations(PARAMS_META, grid) == 1640
+    assert count_combinations(PARAMS_META, big) == 41
+    # 显式超限
+    huge = {
+        "ma_proximity": {"min": 0.01, "max": 0.05, "step": 0.001},   # 41
+        "min_boards": {"min": 1, "max": 20, "step": 1},              # 20
+        "fill": ["close_t", "open_t+1"],                             # 2
+        "use_ma20": [True, False],                                   # 2
+    }  # 41x20x2x2 = 3280 > 2000
+    assert count_combinations(PARAMS_META, huge) > GRID_MAX_COMBINATIONS
+    with pytest.raises(ValueError, match=r"组合数|上限|超过"):
+        expand_param_grid(PARAMS_META, huge)

--- a/backend/tests/backtest/test_optimizer_grid.py
+++ b/backend/tests/backtest/test_optimizer_grid.py
@@ -56,6 +56,20 @@ def test_range_spec_expands_by_step():
     assert vals == [0.01, 0.02, 0.03]  # 含端点
 
 
+def test_range_spec_float_keeps_endpoint_despite_accumulation():
+    """0.1 步长的浮点累加易丢端点 (0.1+0.1+0.1=0.30000004); 整数计数必须保住 0.3。"""
+    meta = [{"id": "p", "type": "float", "default": 0.2, "min": 0.1, "max": 0.3, "step": 0.1}]
+    combos = expand_param_grid(meta, {"p": {"min": 0.1, "max": 0.3, "step": 0.1}})
+    vals = sorted(c["p"] for c in combos)
+    assert vals == [0.1, 0.2, 0.3]  # 含端点 0.3, 不丢
+
+
+def test_duplicate_values_folded():
+    combos = expand_param_grid(PARAMS_META, {"ma_proximity": [0.02, 0.02, 0.03]})
+    vals = sorted(c["ma_proximity"] for c in combos)
+    assert vals == [0.02, 0.03]  # 去重
+
+
 def test_range_spec_int_yields_ints():
     combos = expand_param_grid(PARAMS_META, {"min_boards": {"min": 1, "max": 4, "step": 1}})
     vals = sorted(c["min_boards"] for c in combos)

--- a/backend/tests/backtest/test_optimizer_run.py
+++ b/backend/tests/backtest/test_optimizer_run.py
@@ -1,0 +1,145 @@
+"""优化器编排测试 — 用假 service 注入受控 stats, 验证排序/取消/进度/目标方向。"""
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from datetime import date
+
+import pytest
+
+from app.backtest.optimizer import OptimizeConfig, StrategyOptimizer
+
+# ---- 假 StrategyDef / 引擎 / service ----
+
+@dataclass
+class _FakeDef:
+    meta: dict
+
+
+class _FakeEngine:
+    def __init__(self, params_meta):
+        self._def = _FakeDef(meta={"params": params_meta})
+
+    def get(self, strategy_id):
+        return self._def
+
+
+@dataclass
+class _FakeResult:
+    stats: dict
+    error: str | None = None
+
+
+class _FakeService:
+    """run() 依据 params 返回受控 stats: sortino = ma_proximity 的映射, 便于校验排序。"""
+
+    def __init__(self, score_fn):
+        self.score_fn = score_fn
+        self.calls = []
+        self._lock = threading.Lock()
+
+    def run(self, config, progress_cb=None, cancel_event=None):
+        with self._lock:
+            self.calls.append(dict(config.params or {}))
+        return self.score_fn(config.params or {})
+
+
+PARAMS_META = [
+    {"id": "ma_proximity", "type": "float", "default": 0.02, "min": 0.01, "max": 0.05, "step": 0.005},
+]
+
+
+def _optimizer(score_fn):
+    return StrategyOptimizer(_FakeService(score_fn), _FakeEngine(PARAMS_META))
+
+
+def _cfg(**kw):
+    base = dict(
+        strategy_id="s", symbols=None, start=date(2024, 1, 1), end=date(2024, 6, 1),
+        param_grid={"ma_proximity": [0.01, 0.02, 0.03]}, objective="sortino", max_workers=4,
+    )
+    base.update(kw)
+    return OptimizeConfig(**base)
+
+
+def test_ranks_best_by_objective_max():
+    # sortino 随 ma_proximity 递增 -> 最大值应为 0.03
+    def score(p):
+        return _FakeResult(stats={"sortino": p["ma_proximity"] * 100})
+    out = _optimizer(score).optimize(_cfg())
+    assert out["best_params"] == {"ma_proximity": 0.03}
+    assert out["best_score"] == 3.0
+    assert out["n_combinations"] == 3
+    assert out["n_completed"] == 3
+    assert [r["rank"] for r in out["results"]] == [1, 2, 3]
+    assert out["results"][0]["params"] == {"ma_proximity": 0.03}
+
+
+def test_all_combos_executed_once():
+    def score(p):
+        return _FakeResult(stats={"sortino": 1.0})
+    opt = _optimizer(score)
+    out = opt.optimize(_cfg(param_grid={"ma_proximity": [0.01, 0.02, 0.03, 0.04, 0.05]}))
+    assert out["n_combinations"] == 5
+    # 每组恰跑一次
+    ran = sorted(c["ma_proximity"] for c in opt.service.calls)
+    assert ran == [0.01, 0.02, 0.03, 0.04, 0.05]
+
+
+def test_min_direction_objective():
+    # max_drawdown 为负; 但选 avg_holding_days(min 方向) 验证方向反转
+    def score(p):
+        return _FakeResult(stats={"avg_holding_days": p["ma_proximity"] * 100})
+    out = _optimizer(score).optimize(_cfg(objective="avg_holding_days"))
+    # min 方向 -> 最小 avg_holding_days (0.01x100=1) 最优
+    assert out["best_params"] == {"ma_proximity": 0.01}
+
+
+def test_none_and_error_results_sink_to_bottom():
+    # ma_proximity=0.02 的组返回 error, 0.03 的 sortino=None -> 都应排在有效结果之后
+    def score(p):
+        if p["ma_proximity"] == 0.02:
+            return _FakeResult(stats={}, error="boom")
+        if p["ma_proximity"] == 0.03:
+            return _FakeResult(stats={"sortino": None})
+        return _FakeResult(stats={"sortino": 5.0})
+    out = _optimizer(score).optimize(_cfg())
+    assert out["best_params"] == {"ma_proximity": 0.01}
+    assert out["best_score"] == 5.0
+    # 失败/None 组仍在结果里但 rank 靠后
+    assert out["n_completed"] == 3
+    assert out["results"][0]["params"] == {"ma_proximity": 0.01}
+
+
+def test_cancel_event_stops_remaining():
+    ev = threading.Event()
+    ev.set()  # 一开始就取消
+
+    def score(p):
+        return _FakeResult(stats={"sortino": 1.0})
+    opt = _optimizer(score)
+    out = opt.optimize(_cfg(), cancel_event=ev)
+    # 取消后所有组跳过 -> 无有效结果
+    assert opt.service.calls == []
+    assert out["best_params"] is None
+
+
+def test_progress_callback_reports_done_total():
+    seen = []
+
+    def score(p):
+        return _FakeResult(stats={"sortino": 1.0})
+
+    def cb(msg):
+        seen.append(msg)
+    _optimizer(score).optimize(_cfg(), progress_cb=cb)
+    assert len(seen) == 3
+    assert seen[-1]["done"] == 3
+    assert all(m["total"] == 3 for m in seen)
+
+
+def test_invalid_objective_rejected():
+    def score(p):
+        return _FakeResult(stats={"sortino": 1.0})
+    with pytest.raises(ValueError, match="不支持的优化目标"):
+        _optimizer(score).optimize(_cfg(objective="not_a_metric"))

--- a/backend/tests/backtest/test_optimizer_run.py
+++ b/backend/tests/backtest/test_optimizer_run.py
@@ -86,13 +86,67 @@ def test_all_combos_executed_once():
     assert ran == [0.01, 0.02, 0.03, 0.04, 0.05]
 
 
-def test_min_direction_objective():
-    # max_drawdown 为负; 但选 avg_holding_days(min 方向) 验证方向反转
+def test_min_direction_objective_restores_display_sign():
+    # avg_holding_days 是 min 方向: 最小者最优, 且 best_score 必须是原始正值 (非内部取负值)
     def score(p):
         return _FakeResult(stats={"avg_holding_days": p["ma_proximity"] * 100})
     out = _optimizer(score).optimize(_cfg(objective="avg_holding_days"))
-    # min 方向 -> 最小 avg_holding_days (0.01x100=1) 最优
     assert out["best_params"] == {"ma_proximity": 0.01}
+    # min 方向: 最优 avg_holding_days = 0.01*100 = 1.0, 用户应看到 +1.0 而非 -1.0
+    assert out["best_score"] == 1.0
+    # results 不应外露内部排序键 _sort
+    assert all("_sort" not in r for r in out["results"])
+    assert out["results"][0]["objective_raw"] == 1.0
+
+
+def test_max_drawdown_objective_prefers_smaller_drawdown():
+    # max_drawdown 为负值, max 方向: -0.1 (回撤更小) 应优于 -0.3
+    def score(p):
+        dd = {0.01: -0.1, 0.02: -0.3, 0.03: -0.2}[p["ma_proximity"]]
+        return _FakeResult(stats={"max_drawdown": dd})
+    out = _optimizer(score).optimize(_cfg(objective="max_drawdown"))
+    assert out["best_params"] == {"ma_proximity": 0.01}
+    assert out["best_score"] == -0.1  # 展示原始负值
+
+
+def test_service_exception_isolated_not_crashing_batch():
+    # 某组 service.run 抛异常 -> 应记为该组失败, 其余组正常完成, 不拖垮整批
+    def score(p):
+        if p["ma_proximity"] == 0.02:
+            raise KeyError("boom")
+        return _FakeResult(stats={"sortino": p["ma_proximity"] * 100})
+    out = _optimizer(score).optimize(_cfg())
+    assert out["n_completed"] == 3  # 三组都有结果记录 (含失败组)
+    assert out["best_params"] == {"ma_proximity": 0.03}  # 最优组不受影响
+    failed = [r for r in out["results"] if r.get("error")]
+    assert len(failed) == 1
+    assert "boom" in failed[0]["error"]
+
+
+def test_backtest_kwargs_illegal_key_rejected():
+    def score(p):
+        return _FakeResult(stats={"sortino": 1.0})
+    with pytest.raises(ValueError, match=r"非法字段|不能包含"):
+        _optimizer(score).optimize(_cfg(backtest_kwargs={"bad_field": 1}))
+
+
+def test_backtest_kwargs_reserved_key_rejected():
+    def score(p):
+        return _FakeResult(stats={"sortino": 1.0})
+    with pytest.raises(ValueError, match="不能包含"):
+        _optimizer(score).optimize(_cfg(backtest_kwargs={"symbols": ["x"]}))
+
+
+def test_base_params_merged_and_overridden_by_sweep():
+    # base_params 提供固定参数, combo 覆盖同名; 记录 service 实际收到的 params
+    def score(p):
+        return _FakeResult(stats={"sortino": 1.0})
+    opt = _optimizer(score)
+    opt.optimize(_cfg(base_params={"ma_proximity": 0.99, "other": 7}))
+    # 每次 run 收到的 params: ma_proximity 被 combo 覆盖, other 保留
+    for call in opt.service.calls:
+        assert call["other"] == 7
+        assert call["ma_proximity"] in (0.01, 0.02, 0.03)
 
 
 def test_none_and_error_results_sink_to_bottom():

--- a/frontend/src/lib/optimizerTask.ts
+++ b/frontend/src/lib/optimizerTask.ts
@@ -1,0 +1,214 @@
+import { useSyncExternalStore } from 'react'
+
+/**
+ * 参数优化任务管理 (SSE 模式 + 重连)。镜像 backtestTask, 结果为排名 dict。
+ */
+
+export interface OptimizeProgress {
+  type: string
+  done: number
+  total: number
+  best_score: number | null
+}
+
+export interface OptimizeResultRow {
+  params: Record<string, any>
+  objective_raw: number | null
+  stats?: Record<string, any>
+  rank: number
+  error?: string
+}
+
+export interface OptimizeResult {
+  objective: string
+  direction: string
+  n_combinations: number
+  n_completed: number
+  best_params: Record<string, any> | null
+  best_score: number | null
+  results: OptimizeResultRow[]
+  elapsed_ms: number
+}
+
+export interface OptimizerTask {
+  id: number
+  isPending: boolean
+  result: OptimizeResult | null
+  progress: OptimizeProgress | null
+  error: string | null
+}
+
+export interface StartOptimizeParams {
+  strategy_id: string
+  param_grid: Record<string, any>
+  objective: string
+  direction?: string
+  max_workers?: number
+  symbols?: string[] | null
+  start?: string | null
+  end?: string | null
+  matching?: string
+  fees_pct?: number
+  commission_pct?: number
+  stamp_tax_pct?: number
+  slippage_bps?: number
+  max_positions?: number
+  max_exposure_pct?: number
+  initial_capital?: number
+  position_sizing?: string
+  mode?: 'position' | 'full'
+  holding_days?: number
+}
+
+let current: OptimizerTask | null = null
+const listeners = new Set<() => void>()
+let taskSeq = 0
+let eventSource: EventSource | null = null
+
+const RECONNECT_KEY = 'optimizer_reconnect'
+
+function emit() {
+  listeners.forEach(fn => fn())
+}
+
+function subscribe(fn: () => void) {
+  listeners.add(fn)
+  return () => listeners.delete(fn)
+}
+
+function buildQuery(params: Record<string, string | number | boolean | undefined | null>): string {
+  const sp = new URLSearchParams()
+  for (const [k, v] of Object.entries(params)) {
+    if (v != null && v !== '') sp.set(k, String(v))
+  }
+  return sp.toString()
+}
+
+function connectSSE(url: string): void {
+  const id = current?.id ?? ++taskSeq
+
+  if (eventSource) {
+    eventSource.close()
+    eventSource = null
+  }
+
+  const es = new EventSource(url)
+  eventSource = es
+
+  es.addEventListener('progress', (e: MessageEvent) => {
+    if (current?.id !== id) return
+    try {
+      const prog = JSON.parse(e.data) as OptimizeProgress
+      current = { ...current, progress: prog }
+      emit()
+    } catch { /* ignore */ }
+  })
+
+  es.addEventListener('done', (e: MessageEvent) => {
+    if (current?.id !== id) return
+    try {
+      const result = JSON.parse(e.data) as OptimizeResult
+      current = { ...current, isPending: false, result, error: null }
+      emit()
+    } catch {
+      current = { ...current, isPending: false, error: '结果解析失败' }
+      emit()
+    }
+    es.close()
+    eventSource = null
+    localStorage.removeItem(RECONNECT_KEY)
+  })
+
+  es.addEventListener('error', (e: MessageEvent) => {
+    if (current?.id !== id) return
+    if (e.data) {
+      try {
+        const msg = JSON.parse(e.data)?.message ?? '优化出错'
+        current = { ...current, isPending: false, error: msg }
+        emit()
+      } catch {
+        current = { ...current, isPending: false, error: '优化出错' }
+        emit()
+      }
+      es.close()
+      eventSource = null
+      localStorage.removeItem(RECONNECT_KEY)
+    }
+    // 无 data: 连接异常断开, 自动重连
+  })
+}
+
+export function startOptimize(params: StartOptimizeParams): void {
+  if (eventSource) {
+    eventSource.close()
+    eventSource = null
+  }
+
+  const id = ++taskSeq
+  current = { id, isPending: true, result: null, progress: null, error: null }
+  emit()
+
+  const qs = buildQuery({
+    strategy_id: params.strategy_id,
+    param_grid: JSON.stringify(params.param_grid),
+    objective: params.objective,
+    direction: params.direction,
+    max_workers: params.max_workers,
+    symbols: params.symbols?.join(','),
+    start: params.start ?? undefined,
+    end: params.end ?? undefined,
+    matching: params.matching,
+    fees_pct: params.fees_pct,
+    commission_pct: params.commission_pct,
+    stamp_tax_pct: params.stamp_tax_pct,
+    slippage_bps: params.slippage_bps,
+    max_positions: params.max_positions,
+    max_exposure_pct: params.max_exposure_pct,
+    initial_capital: params.initial_capital,
+    position_sizing: params.position_sizing,
+    mode: params.mode,
+    holding_days: params.holding_days,
+  })
+
+  localStorage.setItem(RECONNECT_KEY, qs)
+  connectSSE(`/api/backtest/optimize/stream?${qs}`)
+}
+
+export async function stopOptimize(): Promise<void> {
+  const qs = localStorage.getItem(RECONNECT_KEY)
+  if (qs) {
+    await fetch('/api/backtest/optimize/cancel', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ qs }),
+    }).catch(() => {})
+  }
+  if (eventSource) {
+    eventSource.close()
+    eventSource = null
+  }
+  if (current?.isPending) {
+    current = { ...current, isPending: false, error: '已取消' }
+    emit()
+  }
+  localStorage.removeItem(RECONNECT_KEY)
+}
+
+export function clearOptimize(): void {
+  current = null
+  emit()
+}
+
+export function tryReconnectOptimize(): boolean {
+  const qs = localStorage.getItem(RECONNECT_KEY)
+  if (!qs) return false
+  const id = ++taskSeq
+  current = { id, isPending: true, result: null, progress: null, error: null }
+  emit()
+  connectSSE(`/api/backtest/optimize/stream?${qs}`)
+  return true
+}
+
+export function useOptimizerTask(): OptimizerTask | null {
+  return useSyncExternalStore(subscribe, () => current, () => null)
+}

--- a/frontend/src/lib/optimizerTask.ts
+++ b/frontend/src/lib/optimizerTask.ts
@@ -44,6 +44,8 @@ export interface StartOptimizeParams {
   objective: string
   direction?: string
   max_workers?: number
+  params?: Record<string, any> | null       // 未扫描参数固定为用户当前值
+  overrides?: Record<string, any> | null     // 策略当前的 basic_filter/信号/风控覆盖
   symbols?: string[] | null
   start?: string | null
   end?: string | null
@@ -65,6 +67,9 @@ const listeners = new Set<() => void>()
 let taskSeq = 0
 let eventSource: EventSource | null = null
 let currentJobKey: string | null = null
+let cancelRequested = false      // stop 在拿到 job_key 前被点 -> 收到 job 事件立即补发 cancel
+let reconnectAttempts = 0        // 无 data 断线的连续重连计数, 超上限放弃
+const MAX_RECONNECT = 5
 
 const RECONNECT_KEY = 'optimizer_reconnect'
 const JOB_KEY_KEY = 'optimizer_job_key'
@@ -99,17 +104,28 @@ function connectSSE(url: string): void {
 
   // 首事件: 后端回吐 job_key, 存下供 cancel 直接引用 (无需前端重算)
   es.addEventListener('job', (e: MessageEvent) => {
+    reconnectAttempts = 0
     try {
       const key = JSON.parse(e.data)?.key
       if (key) {
         currentJobKey = key
         localStorage.setItem(JOB_KEY_KEY, key)
+        // 竞态修复: stop 在拿到 key 前被点过 -> 现在补发 cancel 真正停后端任务, 再收尾关闭。
+        if (cancelRequested) {
+          postCancel(key)
+          es.close()
+          eventSource = null
+          currentJobKey = null
+          localStorage.removeItem(RECONNECT_KEY)
+          localStorage.removeItem(JOB_KEY_KEY)
+        }
       }
     } catch { /* ignore */ }
   })
 
   es.addEventListener('progress', (e: MessageEvent) => {
     if (current?.id !== id) return
+    reconnectAttempts = 0
     try {
       const prog = JSON.parse(e.data) as OptimizeProgress
       current = { ...current, progress: prog }
@@ -147,10 +163,31 @@ function connectSSE(url: string): void {
       }
       es.close()
       eventSource = null
+      currentJobKey = null
       localStorage.removeItem(RECONNECT_KEY)
+      localStorage.removeItem(JOB_KEY_KEY)
+      return
     }
-    // 无 data: 连接异常断开, 自动重连
+    // 无 data: 连接异常断开。EventSource 会自动重连, 但设上限避免网络长断时无限 pending。
+    if (current?.id === id) {
+      reconnectAttempts += 1
+      if (reconnectAttempts > MAX_RECONNECT) {
+        es.close()
+        eventSource = null
+        current = { ...current, isPending: false, error: '连接中断, 重连多次失败' }
+        emit()
+      }
+    }
   })
+}
+
+/** 调后端 cancel (按回吐的 job_key)。 */
+function postCancel(jobKey: string): void {
+  fetch('/api/backtest/optimize/cancel', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ job_key: jobKey }),
+  }).catch(() => {})
 }
 
 export function startOptimize(params: StartOptimizeParams): void {
@@ -159,6 +196,9 @@ export function startOptimize(params: StartOptimizeParams): void {
     eventSource = null
   }
 
+  cancelRequested = false
+  currentJobKey = null
+  reconnectAttempts = 0
   const id = ++taskSeq
   current = { id, isPending: true, result: null, progress: null, error: null }
   emit()
@@ -169,6 +209,8 @@ export function startOptimize(params: StartOptimizeParams): void {
     objective: params.objective,
     direction: params.direction,
     max_workers: params.max_workers,
+    params: params.params ? JSON.stringify(params.params) : undefined,
+    overrides: params.overrides ? JSON.stringify(params.overrides) : undefined,
     symbols: params.symbols?.join(','),
     start: params.start ?? undefined,
     end: params.end ?? undefined,
@@ -189,26 +231,27 @@ export function startOptimize(params: StartOptimizeParams): void {
   connectSSE(`/api/backtest/optimize/stream?${qs}`)
 }
 
-export async function stopOptimize(): Promise<void> {
+export function stopOptimize(): void {
+  // 竞态: 若刚点开始还没收到 job 事件, job_key 尚未到手。标记 cancelRequested ——
+  // 有 key 则立即取消并关闭; 无 key 则保持 SSE 打开, 等 job 事件到达时补发 cancel 再关
+  // (关闭 SSE 不会停后端 daemon 线程, 必须真正 POST cancel)。5s 兜底防 job 事件永不来。
+  cancelRequested = true
   const jobKey = currentJobKey ?? localStorage.getItem(JOB_KEY_KEY)
   if (jobKey) {
-    await fetch('/api/backtest/optimize/cancel', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ job_key: jobKey }),
-    }).catch(() => {})
-  }
-  if (eventSource) {
-    eventSource.close()
-    eventSource = null
+    postCancel(jobKey)
+    if (eventSource) { eventSource.close(); eventSource = null }
+    currentJobKey = null
+    localStorage.removeItem(RECONNECT_KEY)
+    localStorage.removeItem(JOB_KEY_KEY)
+  } else if (eventSource) {
+    // 保持连接等 job 事件; 兜底: 5s 后仍没 key 就强关
+    const es = eventSource
+    setTimeout(() => { if (es === eventSource) { es.close(); eventSource = null } }, 5000)
   }
   if (current?.isPending) {
     current = { ...current, isPending: false, error: '已取消' }
     emit()
   }
-  currentJobKey = null
-  localStorage.removeItem(RECONNECT_KEY)
-  localStorage.removeItem(JOB_KEY_KEY)
 }
 
 export function clearOptimize(): void {

--- a/frontend/src/lib/optimizerTask.ts
+++ b/frontend/src/lib/optimizerTask.ts
@@ -64,8 +64,10 @@ let current: OptimizerTask | null = null
 const listeners = new Set<() => void>()
 let taskSeq = 0
 let eventSource: EventSource | null = null
+let currentJobKey: string | null = null
 
 const RECONNECT_KEY = 'optimizer_reconnect'
+const JOB_KEY_KEY = 'optimizer_job_key'
 
 function emit() {
   listeners.forEach(fn => fn())
@@ -95,6 +97,17 @@ function connectSSE(url: string): void {
   const es = new EventSource(url)
   eventSource = es
 
+  // 首事件: 后端回吐 job_key, 存下供 cancel 直接引用 (无需前端重算)
+  es.addEventListener('job', (e: MessageEvent) => {
+    try {
+      const key = JSON.parse(e.data)?.key
+      if (key) {
+        currentJobKey = key
+        localStorage.setItem(JOB_KEY_KEY, key)
+      }
+    } catch { /* ignore */ }
+  })
+
   es.addEventListener('progress', (e: MessageEvent) => {
     if (current?.id !== id) return
     try {
@@ -116,7 +129,9 @@ function connectSSE(url: string): void {
     }
     es.close()
     eventSource = null
+    currentJobKey = null
     localStorage.removeItem(RECONNECT_KEY)
+    localStorage.removeItem(JOB_KEY_KEY)
   })
 
   es.addEventListener('error', (e: MessageEvent) => {
@@ -175,12 +190,12 @@ export function startOptimize(params: StartOptimizeParams): void {
 }
 
 export async function stopOptimize(): Promise<void> {
-  const qs = localStorage.getItem(RECONNECT_KEY)
-  if (qs) {
+  const jobKey = currentJobKey ?? localStorage.getItem(JOB_KEY_KEY)
+  if (jobKey) {
     await fetch('/api/backtest/optimize/cancel', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ qs }),
+      body: JSON.stringify({ job_key: jobKey }),
     }).catch(() => {})
   }
   if (eventSource) {
@@ -191,7 +206,9 @@ export async function stopOptimize(): Promise<void> {
     current = { ...current, isPending: false, error: '已取消' }
     emit()
   }
+  currentJobKey = null
   localStorage.removeItem(RECONNECT_KEY)
+  localStorage.removeItem(JOB_KEY_KEY)
 }
 
 export function clearOptimize(): void {

--- a/frontend/src/lib/strategyOverrides.ts
+++ b/frontend/src/lib/strategyOverrides.ts
@@ -1,0 +1,24 @@
+import type { StrategyDetail } from './api'
+
+/** 信号 id 归一 (与策略回测页一致): 裸名补 signal_ 前缀。 */
+export const toSignalId = (sig: string) =>
+  sig.startsWith('signal_') || sig.startsWith('csg_') ? sig : `signal_${sig}`
+
+/** 从策略详情构建默认 overrides (basic_filter / 信号 / 风控)。
+ * 优化器与策略回测页共用, 保证优化的就是用户当前配置的策略。 */
+export function buildDefaultOverrides(detail: StrategyDetail): Record<string, any> {
+  return {
+    basic_filter: { ...detail.basic_filter },
+    entry_signals: detail.entry_signals.map(toSignalId),
+    exit_signals: detail.exit_signals.map(toSignalId),
+    scoring: { ...detail.scoring },
+    stop_loss: detail.stop_loss,
+    take_profit: detail.take_profit,
+    trailing_stop: detail.trailing_stop,
+    trailing_take_profit_activate: detail.trailing_take_profit_activate,
+    trailing_take_profit_drawdown: detail.trailing_take_profit_drawdown,
+    score_min: null,
+    score_max: null,
+    max_hold_days: detail.max_hold_days,
+  }
+}

--- a/frontend/src/pages/Backtest.tsx
+++ b/frontend/src/pages/Backtest.tsx
@@ -2,9 +2,10 @@ import { useState } from 'react'
 import { PageHeader } from '@/components/PageHeader'
 import { FactorBacktest } from './backtest/FactorBacktest'
 import { StrategyBacktest } from './backtest/StrategyBacktest'
-import { BarChart3, FlaskConical } from 'lucide-react'
+import { StrategyOptimizer } from './backtest/StrategyOptimizer'
+import { BarChart3, FlaskConical, SlidersHorizontal } from 'lucide-react'
 
-type Tab = 'factor' | 'strategy'
+type Tab = 'factor' | 'strategy' | 'optimizer'
 
 const MODES: Record<Tab, { title: string; subtitle: string; hint: string }> = {
   factor: {
@@ -17,6 +18,17 @@ const MODES: Record<Tab, { title: string; subtitle: string; hint: string }> = {
     subtitle: '验证完整选股和交易规则',
     hint: '看净值曲线、回撤、胜率和交易明细，适合判断策略是否可执行。',
   },
+  optimizer: {
+    title: '参数优化',
+    subtitle: '网格搜索最优参数组合',
+    hint: '并行回测所有参数组合，按夏普/索提诺等目标排序，找到最优参数。',
+  },
+}
+
+const TAB_ICONS: Record<Tab, typeof BarChart3> = {
+  factor: BarChart3,
+  strategy: FlaskConical,
+  optimizer: SlidersHorizontal,
 }
 
 export function Backtest() {
@@ -24,8 +36,8 @@ export function Backtest() {
 
   const modeSwitch = (
     <div className="inline-flex rounded-btn border border-border bg-surface/80 p-0.5 shadow-sm">
-      {(['factor', 'strategy'] as const).map(tab => {
-        const Icon = tab === 'factor' ? BarChart3 : FlaskConical
+      {(['factor', 'strategy', 'optimizer'] as const).map(tab => {
+        const Icon = TAB_ICONS[tab]
         const active = activeTab === tab
         return (
           <button
@@ -57,6 +69,7 @@ export function Backtest() {
       <main className="flex-1 min-h-0 px-3 pb-3 pt-3 lg:px-4 lg:pb-4">
         {activeTab === 'factor' && <FactorBacktest />}
         {activeTab === 'strategy' && <StrategyBacktest />}
+        {activeTab === 'optimizer' && <StrategyOptimizer />}
       </main>
     </div>
   )

--- a/frontend/src/pages/backtest/StrategyOptimizer.tsx
+++ b/frontend/src/pages/backtest/StrategyOptimizer.tsx
@@ -1,0 +1,299 @@
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Play, Square, Trophy } from 'lucide-react'
+import { api, type StrategyDetail, type StrategyParamDef } from '@/lib/api'
+import { fmtPct } from '@/lib/format'
+import { EmptyState } from '@/components/EmptyState'
+import { DatePicker } from '@/components/DatePicker'
+import {
+  startOptimize,
+  stopOptimize,
+  clearOptimize,
+  useOptimizerTask,
+} from '@/lib/optimizerTask'
+
+const INPUT_CLS = 'w-full px-2.5 py-1.5 rounded-input bg-surface border border-border text-xs focus:outline-none focus:border-accent'
+
+// 可选优化目标 (对齐后端 VALID_OBJECTIVES) + 中文标签 + 是否越小越好
+const OBJECTIVES: { id: string; label: string; min?: boolean }[] = [
+  { id: 'sortino', label: '索提诺比率' },
+  { id: 'sharpe', label: '夏普比率' },
+  { id: 'calmar', label: 'Calmar 比率' },
+  { id: 'total_return', label: '总收益' },
+  { id: 'annual_return', label: '年化收益' },
+  { id: 'win_rate', label: '胜率' },
+  { id: 'profit_factor', label: '盈亏比' },
+  { id: 'max_drawdown', label: '最大回撤(越小越好)' },
+  { id: 'mc_maxdd_p95', label: '蒙卡回撤P95(越小越好)' },
+  { id: 'avg_holding_days', label: '平均持仓天数', min: true },
+]
+
+// 单个可扫参数的网格配置
+interface Sweep {
+  enabled: boolean
+  min: string
+  max: string
+  step: string
+}
+
+function defaultSweep(p: StrategyParamDef): Sweep {
+  return {
+    enabled: false,
+    min: String(p.min ?? p.default ?? 0),
+    max: String(p.max ?? p.default ?? 1),
+    step: String(p.step ?? (p.type === 'int' ? 1 : 0.01)),
+  }
+}
+
+/** 从 sweep 配置估算某参数候选值个数 (与后端整数计数一致) */
+function candidateCount(p: StrategyParamDef, s: Sweep): number {
+  if (p.type === 'bool') return 2
+  if (p.type === 'select') return p.options?.length ?? 1
+  const lo = Number(s.min), hi = Number(s.max), step = Number(s.step)
+  if (!(step > 0) || hi < lo) return 0
+  return Math.round((hi - lo) / step) + 1
+}
+
+const TODAY = new Date().toISOString().slice(0, 10)
+const ONE_YEAR_AGO = new Date(Date.now() - 365 * 864e5).toISOString().slice(0, 10)
+
+export function StrategyOptimizer() {
+  const task = useOptimizerTask()
+  const { data: stratData } = useQuery({ queryKey: ['strategies'], queryFn: api.strategyList })
+  const strategies: StrategyDetail[] = stratData?.strategies ?? []
+
+  const [strategyId, setStrategyId] = useState<string>('')
+  const [objective, setObjective] = useState('sortino')
+  const [start, setStart] = useState(ONE_YEAR_AGO)
+  const [end, setEnd] = useState(TODAY)
+  const [mode, setMode] = useState<'position' | 'full'>('position')
+  const [sweeps, setSweeps] = useState<Record<string, Sweep>>({})
+
+  const selected = strategies.find(s => s.id === strategyId)
+  const params = selected?.params ?? []
+
+  // 切策略时重置 sweep 配置
+  const onSelectStrategy = (id: string) => {
+    setStrategyId(id)
+    const s = strategies.find(x => x.id === id)
+    const init: Record<string, Sweep> = {}
+    for (const p of s?.params ?? []) init[p.id] = defaultSweep(p)
+    setSweeps(init)
+  }
+
+  const updateSweep = (pid: string, patch: Partial<Sweep>) =>
+    setSweeps(prev => ({ ...prev, [pid]: { ...prev[pid], ...patch } }))
+
+  // 组合数预估
+  const combos = useMemo(() => {
+    const enabled = params.filter(p => sweeps[p.id]?.enabled)
+    if (!enabled.length) return 0
+    return enabled.reduce((acc, p) => acc * candidateCount(p, sweeps[p.id]), 1)
+  }, [params, sweeps])
+
+  const buildGrid = (): Record<string, any> => {
+    const grid: Record<string, any> = {}
+    for (const p of params) {
+      const s = sweeps[p.id]
+      if (!s?.enabled) continue
+      if (p.type === 'bool') grid[p.id] = [true, false]
+      else if (p.type === 'select') grid[p.id] = p.options ?? []
+      else grid[p.id] = { min: Number(s.min), max: Number(s.max), step: Number(s.step) }
+    }
+    return grid
+  }
+
+  const canRun = strategyId && combos > 0 && combos <= 2000 && !task?.isPending
+
+  const onRun = () => {
+    if (!canRun) return
+    clearOptimize()
+    startOptimize({
+      strategy_id: strategyId,
+      param_grid: buildGrid(),
+      objective,
+      start,
+      end,
+      mode,
+    })
+  }
+
+  const result = task?.result
+  const progress = task?.progress
+
+  return (
+    <div className="grid grid-cols-1 gap-3 lg:grid-cols-[320px_1fr]">
+      {/* ── 配置面板 ── */}
+      <div className="space-y-3 rounded-card border border-border bg-surface p-4">
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-secondary">策略</label>
+          <select value={strategyId} onChange={e => onSelectStrategy(e.target.value)} className={INPUT_CLS}>
+            <option value="">选择策略…</option>
+            {strategies.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+          </select>
+        </div>
+
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-secondary">优化目标</label>
+          <select value={objective} onChange={e => setObjective(e.target.value)} className={INPUT_CLS}>
+            {OBJECTIVES.map(o => <option key={o.id} value={o.id}>{o.label}</option>)}
+          </select>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-secondary">起始</label>
+            <DatePicker value={start} onChange={setStart} />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-secondary">结束</label>
+            <DatePicker value={end} onChange={setEnd} />
+          </div>
+        </div>
+
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-secondary">模式</label>
+          <select value={mode} onChange={e => setMode(e.target.value as any)} className={INPUT_CLS}>
+            <option value="position">组合仓位</option>
+            <option value="full">全量独立</option>
+          </select>
+        </div>
+
+        {/* 可扫参数 */}
+        {params.length > 0 && (
+          <div>
+            <div className="mb-1.5 text-xs font-medium text-secondary">扫描参数 (勾选后设范围)</div>
+            <div className="space-y-2">
+              {params.map(p => {
+                const s = sweeps[p.id] ?? defaultSweep(p)
+                const numeric = p.type === 'float' || p.type === 'int'
+                return (
+                  <div key={p.id} className="rounded-input border border-border/60 p-2">
+                    <label className="flex items-center gap-2 text-xs">
+                      <input type="checkbox" checked={s.enabled} onChange={e => updateSweep(p.id, { enabled: e.target.checked })} />
+                      <span className="font-medium text-foreground">{p.label}</span>
+                      <span className="text-secondary">({p.type})</span>
+                    </label>
+                    {s.enabled && numeric && (
+                      <div className="mt-2 grid grid-cols-3 gap-1.5">
+                        <input type="number" value={s.min} onChange={e => updateSweep(p.id, { min: e.target.value })} placeholder="min" className={INPUT_CLS} />
+                        <input type="number" value={s.max} onChange={e => updateSweep(p.id, { max: e.target.value })} placeholder="max" className={INPUT_CLS} />
+                        <input type="number" value={s.step} onChange={e => updateSweep(p.id, { step: e.target.value })} placeholder="step" className={INPUT_CLS} />
+                      </div>
+                    )}
+                    {s.enabled && !numeric && (
+                      <div className="mt-1 text-[11px] text-secondary">
+                        {p.type === 'bool' ? '扫描 [是 / 否]' : `扫描全部选项 (${p.options?.length ?? 0})`}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* 组合数提示 */}
+        {strategyId && (
+          <div className={`text-xs ${combos > 2000 ? 'text-red-400' : 'text-secondary'}`}>
+            {combos === 0 ? '请至少勾选一个参数' : `共 ${combos} 组参数组合`}
+            {combos > 2000 && ' — 超过上限 2000, 请增大 step 或缩小范围'}
+          </div>
+        )}
+
+        {task?.isPending ? (
+          <button onClick={stopOptimize} className="inline-flex w-full items-center justify-center gap-1.5 rounded-btn bg-red-500/90 px-3 py-2 text-xs font-medium text-white hover:bg-red-500">
+            <Square className="h-3.5 w-3.5" /> 停止
+          </button>
+        ) : (
+          <button onClick={onRun} disabled={!canRun} className="inline-flex w-full items-center justify-center gap-1.5 rounded-btn bg-accent px-3 py-2 text-xs font-medium text-white hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed">
+            <Play className="h-3.5 w-3.5" /> 开始优化
+          </button>
+        )}
+      </div>
+
+      {/* ── 结果面板 ── */}
+      <div className="min-h-[300px] rounded-card border border-border bg-surface p-4">
+        {task?.error && (
+          <div className="mb-3 rounded-input border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">{task.error}</div>
+        )}
+
+        {task?.isPending && progress && (
+          <div className="mb-4">
+            <div className="mb-1 flex justify-between text-xs text-secondary">
+              <span>进度 {progress.done}/{progress.total}</span>
+              <span>当前最优: {progress.best_score != null ? progress.best_score.toFixed(3) : '—'}</span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-elevated">
+              <div className="h-full bg-accent transition-all" style={{ width: `${progress.total ? (progress.done / progress.total) * 100 : 0}%` }} />
+            </div>
+          </div>
+        )}
+
+        {!result && !task?.isPending && (
+          <EmptyState title="参数优化" description="选择策略、勾选要扫描的参数与优化目标，网格搜索会并行回测所有组合并按目标排序。" />
+        )}
+
+        {result && (
+          <div className="space-y-4">
+            {/* 最优参数 */}
+            {result.best_params && (
+              <div className="rounded-card border border-accent/30 bg-accent/5 p-3">
+                <div className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold text-accent">
+                  <Trophy className="h-3.5 w-3.5" /> 最优参数 · {result.objective} = {result.best_score}
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {Object.entries(result.best_params).map(([k, v]) => (
+                    <span key={k} className="rounded-full border border-border bg-surface px-2 py-0.5 text-[11px]">{k}: {String(v)}</span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="text-xs text-secondary">
+              {result.n_completed}/{result.n_combinations} 组完成 · 耗时 {(result.elapsed_ms / 1000).toFixed(1)}s
+            </div>
+
+            {/* 排名表 */}
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b border-border text-secondary">
+                    <th className="px-2 py-1.5 text-left">#</th>
+                    <th className="px-2 py-1.5 text-left">参数</th>
+                    <th className="px-2 py-1.5 text-right">{result.objective}</th>
+                    <th className="px-2 py-1.5 text-right">夏普</th>
+                    <th className="px-2 py-1.5 text-right">索提诺</th>
+                    <th className="px-2 py-1.5 text-right">总收益</th>
+                    <th className="px-2 py-1.5 text-right">最大回撤</th>
+                    <th className="px-2 py-1.5 text-right">胜率</th>
+                    <th className="px-2 py-1.5 text-right">交易数</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.results.slice(0, 50).map(r => (
+                    <tr key={r.rank} className="border-b border-border/40 hover:bg-elevated/50">
+                      <td className="px-2 py-1.5 text-secondary">{r.rank}</td>
+                      <td className="px-2 py-1.5">
+                        {r.error
+                          ? <span className="text-red-400">失败: {r.error.slice(0, 40)}</span>
+                          : <span className="text-foreground">{Object.entries(r.params).map(([k, v]) => `${k}=${v}`).join(', ')}</span>}
+                      </td>
+                      <td className="px-2 py-1.5 text-right font-medium">{r.objective_raw != null ? r.objective_raw : '—'}</td>
+                      <td className="px-2 py-1.5 text-right">{r.stats?.sharpe ?? '—'}</td>
+                      <td className="px-2 py-1.5 text-right">{r.stats?.sortino ?? '—'}</td>
+                      <td className="px-2 py-1.5 text-right">{r.stats?.total_return != null ? fmtPct(r.stats.total_return) : '—'}</td>
+                      <td className="px-2 py-1.5 text-right">{r.stats?.max_drawdown != null ? fmtPct(r.stats.max_drawdown) : '—'}</td>
+                      <td className="px-2 py-1.5 text-right">{r.stats?.win_rate != null ? fmtPct(r.stats.win_rate) : '—'}</td>
+                      <td className="px-2 py-1.5 text-right">{r.stats?.n_trades ?? '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/backtest/StrategyOptimizer.tsx
+++ b/frontend/src/pages/backtest/StrategyOptimizer.tsx
@@ -12,6 +12,7 @@ import {
   tryReconnectOptimize,
   useOptimizerTask,
 } from '@/lib/optimizerTask'
+import { buildDefaultOverrides } from '@/lib/strategyOverrides'
 
 const INPUT_CLS = 'w-full px-2.5 py-1.5 rounded-input bg-surface border border-border text-xs focus:outline-none focus:border-accent'
 
@@ -55,6 +56,23 @@ function candidateCount(p: StrategyParamDef, s: Sweep): number {
   return Math.round((hi - lo) / step) + 1
 }
 
+/** 校验某数值参数的 sweep 是否会被后端拒绝 (与后端 _candidates_for 同口径)。
+ * 后端按 lo+i*step 生成 (i=0..round((hi-lo)/step)), 任一值超出 [min,max] 即报错。 */
+function sweepError(p: StrategyParamDef, s: Sweep): string | null {
+  if (p.type === 'bool' || p.type === 'select') return null
+  const lo = Number(s.min), hi = Number(s.max), step = Number(s.step)
+  if (Number.isNaN(lo) || Number.isNaN(hi) || Number.isNaN(step)) return `${p.label}: 范围/步长非法`
+  if (!(step > 0)) return `${p.label}: 步长必须为正`
+  if (hi < lo) return `${p.label}: max < min`
+  if (p.min != null && lo < p.min - 1e-9) return `${p.label}: min 小于允许下限 ${p.min}`
+  if (p.max != null && hi > p.max + 1e-9) return `${p.label}: max 超出允许上限 ${p.max}`
+  // 后端生成的末值 lo + round((hi-lo)/step)*step 若 > max, 会被拒
+  const nSteps = Math.round((hi - lo) / step)
+  const last = lo + nSteps * step
+  if (last > hi + 1e-9) return `${p.label}: 步长 ${step} 不整除区间, 末值 ${last.toFixed(4)} 超出 max ${hi}`
+  return null
+}
+
 const TODAY = new Date().toISOString().slice(0, 10)
 const ONE_YEAR_AGO = new Date(Date.now() - 365 * 864e5).toISOString().slice(0, 10)
 
@@ -79,10 +97,11 @@ export function StrategyOptimizer() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // 切策略时重置 sweep 配置, 并清除旧策略的结果 (避免右侧残留错配)
+  // 切策略: 若有任务在跑, 先真正取消 (关 SSE + 后端 cancel + 清 localStorage), 不能静默丢。
   const onSelectStrategy = (id: string) => {
+    if (task?.isPending) stopOptimize()
+    else clearOptimize()
     setStrategyId(id)
-    clearOptimize()
     const s = strategies.find(x => x.id === id)
     const init: Record<string, Sweep> = {}
     for (const p of s?.params ?? []) init[p.id] = defaultSweep(p)
@@ -99,6 +118,16 @@ export function StrategyOptimizer() {
     return enabled.reduce((acc, p) => acc * candidateCount(p, sweeps[p.id]), 1)
   }, [params, sweeps])
 
+  // 网格合法性 (与后端展开同口径): 步长不整除/越界会被后端拒, 前端提前拦。
+  const gridError = useMemo(() => {
+    for (const p of params) {
+      if (!sweeps[p.id]?.enabled) continue
+      const err = sweepError(p, sweeps[p.id])
+      if (err) return err
+    }
+    return null
+  }, [params, sweeps])
+
   const buildGrid = (): Record<string, any> => {
     const grid: Record<string, any> = {}
     for (const p of params) {
@@ -111,7 +140,7 @@ export function StrategyOptimizer() {
     return grid
   }
 
-  const canRun = strategyId && combos > 0 && combos <= 2000 && !task?.isPending
+  const canRun = strategyId && combos > 0 && combos <= 2000 && !gridError && !task?.isPending
 
   const onRun = () => {
     if (!canRun) return
@@ -120,6 +149,10 @@ export function StrategyOptimizer() {
       strategy_id: strategyId,
       param_grid: buildGrid(),
       objective,
+      // 未扫描参数固定为策略当前默认值; overrides 让 basic_filter/信号/风控按当前策略参与,
+      // 保证优化的就是用户实际回测的策略 (而非被剥离配置的裸策略)。
+      params: selected?.params_defaults,
+      overrides: selected ? buildDefaultOverrides(selected) : undefined,
       start,
       end,
       mode,
@@ -201,11 +234,14 @@ export function StrategyOptimizer() {
           </div>
         )}
 
-        {/* 组合数提示 */}
+        {/* 组合数 / 校验提示 */}
         {strategyId && (
-          <div className={`text-xs ${combos > 2000 ? 'text-red-400' : 'text-secondary'}`}>
-            {combos === 0 ? '请至少勾选一个参数' : `共 ${combos} 组参数组合`}
-            {combos > 2000 && ' — 超过上限 2000, 请增大 step 或缩小范围'}
+          <div className={`text-xs ${(combos > 2000 || gridError) ? 'text-red-400' : 'text-secondary'}`}>
+            {gridError
+              ? gridError
+              : combos === 0
+                ? '请至少勾选一个参数'
+                : `共 ${combos} 组参数组合${combos > 2000 ? ' — 超过上限 2000, 请增大 step 或缩小范围' : ''}`}
           </div>
         )}
 
@@ -239,7 +275,7 @@ export function StrategyOptimizer() {
         )}
 
         {!result && !task?.isPending && (
-          <EmptyState title="参数优化" description="选择策略、勾选要扫描的参数与优化目标，网格搜索会并行回测所有组合并按目标排序。" />
+          <EmptyState title="参数优化" hint="选择策略、勾选要扫描的参数与优化目标，网格搜索会并行回测所有组合并按目标排序。" />
         )}
 
         {result && (

--- a/frontend/src/pages/backtest/StrategyOptimizer.tsx
+++ b/frontend/src/pages/backtest/StrategyOptimizer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Play, Square, Trophy } from 'lucide-react'
 import { api, type StrategyDetail, type StrategyParamDef } from '@/lib/api'
@@ -9,6 +9,7 @@ import {
   startOptimize,
   stopOptimize,
   clearOptimize,
+  tryReconnectOptimize,
   useOptimizerTask,
 } from '@/lib/optimizerTask'
 
@@ -72,9 +73,16 @@ export function StrategyOptimizer() {
   const selected = strategies.find(s => s.id === strategyId)
   const params = selected?.params ?? []
 
-  // 切策略时重置 sweep 配置
+  // 刷新/切页后: 恢复未完成的优化任务
+  useEffect(() => {
+    tryReconnectOptimize()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // 切策略时重置 sweep 配置, 并清除旧策略的结果 (避免右侧残留错配)
   const onSelectStrategy = (id: string) => {
     setStrategyId(id)
+    clearOptimize()
     const s = strategies.find(x => x.id === id)
     const init: Record<string, Sweep> = {}
     for (const p of s?.params ?? []) init[p.id] = defaultSweep(p)
@@ -279,7 +287,7 @@ export function StrategyOptimizer() {
                           ? <span className="text-red-400">失败: {r.error.slice(0, 40)}</span>
                           : <span className="text-foreground">{Object.entries(r.params).map(([k, v]) => `${k}=${v}`).join(', ')}</span>}
                       </td>
-                      <td className="px-2 py-1.5 text-right font-medium">{r.objective_raw != null ? r.objective_raw : '—'}</td>
+                      <td className="px-2 py-1.5 text-right font-medium">{r.objective_raw != null ? r.objective_raw.toFixed(3) : '—'}</td>
                       <td className="px-2 py-1.5 text-right">{r.stats?.sharpe ?? '—'}</td>
                       <td className="px-2 py-1.5 text-right">{r.stats?.sortino ?? '—'}</td>
                       <td className="px-2 py-1.5 text-right">{r.stats?.total_return != null ? fmtPct(r.stats.total_return) : '—'}</td>
@@ -290,6 +298,11 @@ export function StrategyOptimizer() {
                   ))}
                 </tbody>
               </table>
+              {result.results.length > 50 && (
+                <div className="mt-2 text-center text-[11px] text-secondary">
+                  仅显示前 50 组 · 共 {result.results.length} 组
+                </div>
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
在策略回测之上新增**参数优化**能力：给定策略与参数网格，并行回测所有组合，按目标指标排序，找出最优参数。为后续 walk-forward（样本内优化→样本外验证）打基座。

## 后端

**核心 `app/backtest/optimizer.py`（新增）**
- `expand_param_grid`：对齐 `StrategyDef.meta["params"]` 校验（类型/范围/选项），笛卡尔积展开。支持显式候选值列表与 `{min,max,step}` 范围两种写法。整数计数避免浮点累加丢端点。`GRID_MAX_COMBINATIONS=2000` 硬上限防爆炸。
- `StrategyOptimizer.optimize`：`ThreadPoolExecutor` 并行跑各组回测（复用 main 的 PanelCache 线程安全，同一面板只加载一次），按 objective 排序返回最优 + 全排名。目标统一为"越大越好"（min 类目标取负排序），失败/None 沉底。**内部排序键 `_sort` 与展示值 `objective_raw` 分离**，避免 min 方向展示负值。异常隔离（单组失败不拖垮整批）。支持进度回调与 cancel。
- 可选目标含 sharpe/sortino/calmar/total_return/max_drawdown/mc_maxdd_p95 等。

**API `app/api/backtest.py`**
- `GET /optimize/stream`（SSE）：复用既有 `_BacktestJob` 框架，后台线程跑优化，推进度/结果。**首个事件回吐后端算出的 job_key**，前端存下供 cancel 直接引用——从结构上消除"两侧重算 job_key 必须一致"的脆弱契约。
- `POST /optimize/cancel`：直接按回吐的 job_key 查表取消。
- 空/非法 param_grid、取消语义均正确分流。

## 前端

- `lib/optimizerTask.ts`：SSE 客户端（镜像 backtestTask），进度/结果/重连/取消。
- `pages/backtest/StrategyOptimizer.tsx`：配置面板（选策略 → 勾选可扫参数设 min/max/step，bool/select 自动全扫；目标下拉；日期；组合数实时预估 + 2000 上限提示）+ 结果面板（最优参数高亮 + 排名表）。
- `Backtest.tsx`：新增"参数优化"第三 tab。

## 测试

优化器相关 27 例：
- 网格展开/校验：显式列表/范围展开/浮点端点/去重/未知参数/越界/选项/空/组合爆炸。
- 编排：排序/每组一次/min 方向符号还原/max_drawdown 负值排序/异常隔离/kwargs 校验/base_params 合并/取消/进度/非法目标。
- API：job_key 确定性 + cancel 按回吐 key 查表三态。

全量 156 测试通过；前端 tsc 无新增类型错误。

## 说明

- 本 PR **零 engine.py 改动**：优化器复用 main 已有的 PanelCache 线程安全（上游独立实现，compute 放锁外，比我原方案更优）。
- 分支名为 `feat/walk-forward` 是因它是 walk-forward 的基座；本 PR 只含优化器，walk-forward 将作为后续 PR 叠加。