### PR TITLE
fix(overview): 修复看板顶部指数不随实时行情刷新

### DIFF
--- a/backend/app/services/market_overview_builder.py
+++ b/backend/app/services/market_overview_builder.py
@@ -367,9 +367,12 @@ def build_market_overview(
         as_of: 指定日期,None 则取最新有数据日。
     """
     svc = ScreenerService(repo)
+    # 调用方未指定日期时视为"最新"请求: 指数行情走实时缓存 (quote_service),
+    # 其余装配仍以解析出的真实日期为准。显式指定日期(历史复盘)时才回退数据库。
+    explicit_as_of = as_of is not None
     as_of = as_of or svc.latest_date()
     status = _quote_status(quote_service)
-    indices = _index_quotes(repo, quote_service, as_of)
+    indices = _index_quotes(repo, quote_service, None if not explicit_as_of else as_of)
 
     if not as_of:
         return {

--- a/backend/app/services/quote_service.py
+++ b/backend/app/services/quote_service.py
@@ -267,6 +267,13 @@ class QuoteService:
             return list(self._subscribers)
 
     def _broadcast_quote_updated(self) -> None:
+        # 实时行情刷新后清空总览聚合缓存, 使看板 (overview-market) 在 SSE 触发的
+        # 重取中拿到最新指数/聚合值。与 _broadcast 同时进行, 与侧栏 /intraday/indices
+        # (无缓存, 直读实时缓存) 行为对齐, 避免看板落后于侧栏。
+        # 延迟导入规避 services <-> api 层循环依赖。
+        from app.api.overview import invalidate_overview_cache
+
+        invalidate_overview_cache()
         for sub in self._snapshot_subscribers():
             sub.notify_quote()
 


### PR DESCRIPTION
## 问题
开启实时行情后，看板顶部四个指数不刷新，但左侧菜单的四个指数能正常刷新。

## 根因
看板顶部与左侧菜单走的是不同数据源分支，问题出在 `backend/app/services/market_overview_builder.py`：

- **左侧菜单**：直接调用 `quote_service.get_index_quotes()` → 读实时缓存 → 实时刷新 ✓
- **看板顶部**：经 `build_market_overview()` → `_index_quotes()`，但存在逻辑断点：
  ```python
  as_of = as_of or svc.latest_date()   # as_of 从 None 变成真实日期
  indices = _index_quotes(repo, quote_service, as_of)

  # _index_quotes 内：
  if quote_service and as_of is None:  # 永远 False，实时分支进不来
  ```
  `build_market_overview` 把 `as_of` 从 `None` 解析成真实日期后，`_index_quotes` 的 `as_of is None` 判断永远不成立，实时缓存分支走不到，始终回退 `kline_index_daily` 数据库快照。

复现（curl 验证）：刷新后侧栏 `000001.SH = 3952.492 (realtime)`，看板始终返回 `3970.88 (index_daily 快照)`。

## 修复
**`market_overview_builder.py`**：区分调用方是否显式指定日期。仅历史复盘（显式 `as_of`）才让 `_index_quotes` 回退数据库；"最新"请求传 `None` 优先读实时缓存。`_index_quotes` 自身有实时为空回退数据库的兜底，盘后/无实时数据场景不受影响。

**`quote_service.py`**：实时刷新后清空 overview 聚合缓存，使 SSE 触发的重取拿到最新值，与侧栏 `/intraday/indices`（无缓存）行为对齐。

## 验证
| 场景 | 000001.SH | 结果 |
|------|-----------|------|
| 看板（最新）| 3952.492 | 与侧栏实时一致 ✓ |
| 侧栏 | 3952.492 (realtime) | 正常 ✓ |
| 看板（历史 07-08）| 3970.88 | 正确回退数据库 ✓ |

- 后端 132 个测试全部通过
- 另两个复用 `build_market_overview` 的调用方（大盘复盘、概念轮动分析）均安全：复盘显式传日期走数据库；概念轮动传 `None` 走实时，且实时为空时自动回退