### PR TITLE
fix(wecom): 操作指引机器人类型改为「消息推送」

### DIFF
--- a/frontend/src/pages/settings/Monitoring.tsx
+++ b/frontend/src/pages/settings/Monitoring.tsx
@@ -584,7 +584,7 @@ export function SettingsMonitoringPanel({ highlight }: { highlight?: string } = 
                     <summary className="cursor-pointer hover:text-secondary">如何获取企业微信 Webhook 地址?</summary>
                     <ol className="mt-1.5 space-y-1 pl-4 list-decimal leading-relaxed">
                       <li>打开企业微信,进入目标群聊 → 右上角「...」→ <b>群推送 Webhook</b></li>
-                      <li>点击「添加」→ 选择「<b>自定义机器人</b>」→ 填写名字</li>
+                      <li>点击「添加」→ 选择「<b>消息推送</b>」→ 填写名字</li>
                       <li>复制生成的 <b>Webhook 地址</b>(含 key 参数),粘贴到上方输入框</li>
                       <li>也可只复制 key 参数部分(= 后面的内容)填入</li>
                       <li>企业微信群的消息可同步到绑定的个人微信,实现"微信推送"</li>


### PR DESCRIPTION
## 问题
企业微信「如何获取 Webhook 地址」操作指引里, 写的是「选择「自定义机器人」」, 但企业微信 App 添加群机器人时, 对应 webhook 推送的选项实际名为「消息推送」, 用户对不上菜单找不到入口。

## 改动
`Monitoring.tsx` 企业微信操作指引第 2 步:
- 「自定义机器人」→「消息推送」

仅 1 处文案, 飞书指引(实际菜单就是「自定义机器人」)不动。