### PR TITLE
fix(strategy): 实盘选股 lookback 窗口用自然日裁剪导致偏少

### DIFF
--- a/backend/app/services/screener.py
+++ b/backend/app/services/screener.py
@@ -428,9 +428,15 @@ class ScreenerService:
             if "name" not in df_full.columns:
                 df_full = df_full.join(instruments.select(inst_cols), on="symbol", how="left")
 
-        # 裁剪掉 warmup 部分, 只保留 lookback 范围 (减少 group_by 开销)
-        lookback_start = target_date - timedelta(days=lookback_days)
+        # 裁剪掉 warmup 部分, 只保留 lookback 范围 (减少 group_by 开销)。
+        # 按交易日计数: 从数据里实际存在的交易日序列取最后 lookback_days 个交易日,
+        # 不能用 timedelta(days=N) (自然日), 否则周末/节假日会让窗口偏少, 与回测不一致。
         if "date" in df_full.columns:
+            trading_dates = df_full["date"].unique().sort()
+            if len(trading_dates) > lookback_days:
+                lookback_start = trading_dates[-(lookback_days + 1)]
+            else:
+                lookback_start = trading_dates[0]
             df_full = df_full.filter(pl.col("date") >= lookback_start)
 
         df_full = df_full.sort(["symbol", "date"])

--- a/backend/app/tickflow/repository.py
+++ b/backend/app/tickflow/repository.py
@@ -942,12 +942,19 @@ class KlineRepository:
         cache_max = cache["date"].max()
         cache_min = cache["date"].min()
         from datetime import timedelta
-        # 验证缓存覆盖完整范围 (含 warmup)
+        # 验证缓存覆盖完整范围 (含 warmup)。lookback_days 是交易日语义, 用 ×2 日历日
+        # 放宽确保覆盖 (节假日/周末), 与 warmup 60 一起留足余量。
         warmup_start = target_date - timedelta(days=(lookback_days + 60) * 2)
         if cache_min > warmup_start or cache_max < target_date:
             return None
-        # 只返回 lookback 范围 (日历天数 ≈ 2/3 交易日, 足够覆盖)
-        lookback_start = target_date - timedelta(days=lookback_days)
+        # 按交易日计数裁剪: 从数据里实际存在的交易日序列取最后 lookback_days 个交易日。
+        # 不能用 timedelta(days=N) (自然日), 否则周末/节假日会让窗口只有 ~N×5/7 个交易日,
+        # 导致 filter_history 策略的滚动窗口/行号差(_gap)漏算, 与回测结果不一致。
+        trading_dates = cache["date"].unique().sort()
+        if len(trading_dates) > lookback_days:
+            lookback_start = trading_dates[-(lookback_days + 1)]
+        else:
+            lookback_start = trading_dates[0]
         return cache.filter((pl.col("date") >= lookback_start) & (pl.col("date") <= target_date))
 
     def get_enriched_range(


### PR DESCRIPTION
## Bug
策略 `LOOKBACK_DAYS` 语义是**交易日数**(见 `strategy-guide.md`: "回看交易日数"), 但实盘选股路径用 `timedelta(days=N)` 按**自然日**裁剪历史窗口。

N 个自然日 ≈ N×5/7 个交易日, 周末/节假日让窗口系统性偏少 → `filter_history` 策略的滚动窗口/行号差(`_gap`)漏算 → **实盘与回测结果不一致**。

## 根因
| 位置 | 旧代码 | 问题 |
|------|--------|------|
| `repository.py` `get_enriched_history` | `target_date - timedelta(days=lookback_days)` | 自然日 |
| `screener.py` `_load_enriched_history` | 同上 | 自然日 |

策略内部(`_gap = _idx - _lu_idx`、`rolling_sum(window_size=N)`)是按交易日的行数计算的, 但喂给它的数据窗口是自然日裁剪的。

## 回测不受影响 ✓
回测路径 `strategy.py:427` 把完整 `panel`(无裁剪)传给 `filter_history_fn`, 本就是交易日口径。

## 修复
从数据的**实际交易日序列**取最后 N 个交易日作为窗口左边界:
```python
trading_dates = df["date"].unique().sort()
lookback_start = trading_dates[-(lookback_days + 1)]  # 含 target 当天
```

## 不动的部分
- **warmup 裁剪**(`screener.py:398`): `×2` 日历日放宽, 多读无害, 保持不变
- **run_all cap=30**(`screener.py:456`): 性能保护, 独立问题, 保持不变
- **回测路径**: 本就正确, 不涉及

## 验证
- lookback=10: 旧逻辑返回 **7** 交易日 → 新逻辑返回 **11** 交易日(10回看+target当天)
- 129 后端测试全过, 无回归