### PR TITLE
fix(ai): 兼容 reasoning 模型 temperature 限制 + 透出上游真实错误

### DIFF
--- a/backend/app/services/ai_provider.py
+++ b/backend/app/services/ai_provider.py
@@ -100,7 +100,7 @@ def ai_configured(provider: str | None = None) -> bool:
 async def generate_ai_text(
     messages: Sequence[Message],
     *,
-    temperature: float = 0.3,
+    temperature: float | None = 0.3,
     max_tokens: int = 3000,
     timeout: float = 180.0,
 ) -> str:
@@ -118,7 +118,7 @@ async def generate_ai_text(
 async def stream_ai_text(
     messages: Sequence[Message],
     *,
-    temperature: float = 0.5,
+    temperature: float | None = 0.5,
     max_tokens: int = 4000,
     timeout: float = 180.0,
 ) -> AsyncIterator[str]:
@@ -143,7 +143,7 @@ async def stream_ai_text(
 async def _run_openai_once(
     messages: Sequence[Message],
     *,
-    temperature: float,
+    temperature: float | None,
     max_tokens: int,
     timeout: float,
 ) -> str:
@@ -152,17 +152,28 @@ async def _run_openai_once(
         raise RuntimeError("AI API Key 未配置, 请在设置页配置")
 
     client = _openai_client(ai_key, timeout)
+    model = current_ai_model()
+    req_messages = list(messages)
     try:
         resp = await client.chat.completions.create(
-            model=current_ai_model(),
-            messages=list(messages),
-            temperature=temperature,
-            max_tokens=max_tokens,
+            model=model,
+            messages=req_messages,
+            **_openai_kwargs(temperature=temperature, max_tokens=max_tokens),
         )
     except Exception as exc:
-        if _is_openai_transport_error(exc):
-            raise RuntimeError(_format_openai_error(exc)) from exc
-        raise
+        # Reasoning 类模型 (如 kimi-k2.7-code, deepseek-r1, o 系列) 拒绝非约定
+        # temperature (Moonshot 报 "only 1 is allowed for this model")。不再靠
+        # 模型名猜测, 而是捕获该错误后去掉 temperature 重试一次 —— 对所有此类模型都稳。
+        if temperature is not None and _is_temperature_rejected(exc):
+            resp = await client.chat.completions.create(
+                model=model,
+                messages=req_messages,
+                **_openai_kwargs(temperature=None, max_tokens=max_tokens),
+            )
+        else:
+            if _is_openai_transport_error(exc):
+                raise RuntimeError(_format_openai_error(exc)) from exc
+            raise
     if not resp.choices:
         return ""
     return (resp.choices[0].message.content or "").strip()
@@ -171,7 +182,7 @@ async def _run_openai_once(
 async def _stream_openai(
     messages: Sequence[Message],
     *,
-    temperature: float,
+    temperature: float | None,
     max_tokens: int,
     timeout: float,
 ) -> AsyncIterator[str]:
@@ -180,19 +191,39 @@ async def _stream_openai(
         raise RuntimeError("AI API Key 未配置, 请在设置页配置")
 
     client = _openai_client(ai_key, timeout)
-    try:
-        stream = await client.chat.completions.create(
-            model=current_ai_model(),
-            messages=list(messages),
-            temperature=temperature,
-            max_tokens=max_tokens,
-            stream=True,
-        )
+    model = current_ai_model()
+    req_messages = list(messages)
 
+    async def _iter(stream):
         async for chunk in stream:
             delta = chunk.choices[0].delta if chunk.choices else None
             if delta and delta.content:
                 yield delta.content
+
+    try:
+        stream = await client.chat.completions.create(
+            model=model,
+            messages=req_messages,
+            **_openai_kwargs(temperature=temperature, max_tokens=max_tokens),
+            stream=True,
+        )
+    except Exception as exc:
+        # 流尚未开始 yield, 可安全重建: 去掉 temperature 后重开 stream。
+        if temperature is not None and _is_temperature_rejected(exc):
+            stream = await client.chat.completions.create(
+                model=model,
+                messages=req_messages,
+                **_openai_kwargs(temperature=None, max_tokens=max_tokens),
+                stream=True,
+            )
+        else:
+            if _is_openai_transport_error(exc):
+                raise RuntimeError(_format_openai_error(exc)) from exc
+            raise
+
+    try:
+        async for piece in _iter(stream):
+            yield piece
     except Exception as exc:
         if _is_openai_transport_error(exc):
             raise RuntimeError(_format_openai_error(exc)) from exc
@@ -210,6 +241,29 @@ def _openai_client(api_key: str, timeout: float):
         max_retries=0,
         default_headers={"User-Agent": user_agent},
     )
+
+
+# Reasoning / thinking 类模型 (kimi-k2.7-code, deepseek-r1, OpenAI o 系列等) 不接受
+# 任意 temperature, 上游会以 400 拒绝 (如 Moonshot: "only 1 is allowed for this model")。
+# 这里不靠模型名猜测, 而是在真正命中该错误后自动去掉 temperature 重试 (见
+# _run_openai_once / _stream_openai), 对任意 reasoning 模型都稳健。
+_TEMP_REJECT_HINTS = ("temperature", "only 1 is allowed", "unsupported parameter")
+
+
+def _is_temperature_rejected(exc: Exception) -> bool:
+    """True if the upstream 400 is specifically about the temperature param."""
+    if getattr(exc, "status_code", None) != 400:
+        return False
+    text = _openai_error_detail(exc) or str(exc)
+    return any(h in text.lower() for h in _TEMP_REJECT_HINTS)
+
+
+def _openai_kwargs(*, temperature: float | None, max_tokens: int) -> dict:
+    """Build OpenAI create() kwargs; temperature omitted when None."""
+    kwargs: dict = {"max_tokens": max_tokens}
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+    return kwargs
 
 
 def _is_openai_transport_error(exc: Exception) -> bool:
@@ -254,7 +308,9 @@ def _format_openai_error(exc: Exception) -> str:
         503: "AI 服务暂时不可用, 请稍后重试",
         504: "AI 上游服务超时, 请稍后重试或检查 AI Base URL / 网络",
     }
-    message = status_messages.get(status) or detail or "请稍后重试或检查 AI 服务配置"
+    # 优先透出上游真实错误 (如 Moonshot 的 "model not found"), 仅在没有
+    # 可读 detail 时才回落到按状态码的通用文案, 避免吞掉排障关键信息。
+    message = detail or status_messages.get(status) or "请稍后重试或检查 AI 服务配置"
     if status:
         return f"AI 服务请求失败({status}): {message}"
     return f"AI 服务请求失败: {message}"

--- a/backend/tests/test_ai_provider.py
+++ b/backend/tests/test_ai_provider.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import httpx
 import openai
 
-from app.services.ai_provider import _format_openai_error, normalize_openai_base_url
+from app.services.ai_provider import (
+    _format_openai_error,
+    _is_temperature_rejected,
+    normalize_openai_base_url,
+)
 
 
 def test_normalize_openai_base_url_adds_v1_for_root_gateway():
@@ -53,7 +57,8 @@ def test_format_openai_error_hides_html_gateway_body():
     assert "Gateway Timeout" not in message
 
 
-def test_format_openai_error_uses_status_message_when_available():
+def test_format_openai_error_prefers_upstream_detail_when_available():
+    """有可读的上游 detail 时优先透出, 而不是用 400 通用文案吞掉。"""
     response = httpx.Response(
         400,
         json={"error": {"message": "model context length exceeded"}},
@@ -67,4 +72,71 @@ def test_format_openai_error_uses_status_message_when_available():
 
     message = _format_openai_error(exc)
 
+    assert message == "AI 服务请求失败(400): model context length exceeded"
+
+
+def test_format_openai_error_falls_back_to_status_message_without_detail():
+    """上游无可读 detail (如 HTML 网关页) 时, 才回落到 400 通用文案。"""
+    response = httpx.Response(
+        400,
+        headers={"content-type": "text/html; charset=utf-8"},
+        text="<!DOCTYPE html><html></html>",
+        request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+    )
+    exc = openai.BadRequestError("bad request", response=response, body=None)
+
+    message = _format_openai_error(exc)
+
     assert message == "AI 服务请求失败(400): 请求参数无效, 请检查模型名称和上下文长度"
+
+
+def test_is_temperature_rejected_matches_moonshot_message():
+    """Moonshot 对 reasoning 模型报 'only 1 is allowed for this model'。"""
+    response = httpx.Response(
+        400,
+        json={"error": {"message": "invalid temperature: only 1 is allowed for this model"}},
+        request=httpx.Request("POST", "https://api.moonshot.cn/v1/chat/completions"),
+    )
+    exc = openai.BadRequestError(
+        "bad request",
+        response=response,
+        body={"error": {"message": "invalid temperature: only 1 is allowed for this model"}},
+    )
+    assert _is_temperature_rejected(exc) is True
+
+
+def test_is_temperature_rejected_matches_generic_temperature_hint():
+    response = httpx.Response(
+        400,
+        json={"error": {"message": "unsupported parameter: temperature"}},
+        request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+    )
+    exc = openai.BadRequestError(
+        "bad request", response=response,
+        body={"error": {"message": "unsupported parameter: temperature"}},
+    )
+    assert _is_temperature_rejected(exc) is True
+
+
+def test_is_temperature_rejected_false_for_other_400():
+    """非 temperature 相关的 400 (如 model not found) 不应触发去 temperature 重试。"""
+    response = httpx.Response(
+        400,
+        json={"error": {"message": "model not found"}},
+        request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+    )
+    exc = openai.BadRequestError(
+        "bad request", response=response,
+        body={"error": {"message": "model not found"}},
+    )
+    assert _is_temperature_rejected(exc) is False
+
+
+def test_is_temperature_rejected_false_for_non_400():
+    response = httpx.Response(
+        401,
+        json={"error": {"message": "invalid api key"}},
+        request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+    )
+    exc = openai.AuthenticationError("unauthorized", response=response, body=None)
+    assert _is_temperature_rejected(exc) is False

--- a/frontend/src/pages/settings/AI.tsx
+++ b/frontend/src/pages/settings/AI.tsx
@@ -28,7 +28,7 @@ const PRESETS: { label: string; provider?: string; url: string; model: string; c
   { label: 'DeepSeek', url: 'https://api.deepseek.com', model: 'deepseek-v4-pro', website: 'https://www.deepseek.com/', websiteLabel: 'deepseek.com', description: 'DeepSeek 官方 OpenAI 兼容接口。' },
   { label: '通义千问', url: 'https://dashscope.aliyuncs.com/compatible-mode/v1', model: 'qwen-3.6plus', website: 'https://tongyi.aliyun.com/', websiteLabel: 'tongyi.aliyun.com', description: '阿里云 DashScope 兼容模式接口。' },
   { label: '智谱 GLM', url: 'https://open.bigmodel.cn/api/paas/v4', model: 'glm-5.2', website: 'https://open.bigmodel.cn/', websiteLabel: 'open.bigmodel.cn', description: '智谱 AI 官方 OpenAI 兼容接口。' },
-  { label: 'Kimi', url: 'https://api.moonshot.cn/v1', model: 'kimi-k2.6', website: 'https://platform.moonshot.cn/', websiteLabel: 'platform.moonshot.cn', description: '月之暗面 Moonshot 官方 OpenAI 兼容接口，支持超长上下文。' },
+  { label: 'Kimi', url: 'https://api.moonshot.cn/v1', model: 'kimi-k2.7-code', website: 'https://platform.moonshot.cn/', websiteLabel: 'platform.moonshot.cn', description: '月之暗面 Moonshot 官方 OpenAI 兼容接口，支持超长上下文。' },
   { label: 'Codex CLI', provider: CODEX_PROVIDER, url: '', model: '', codexCommand: CODEX_COMMAND, website: 'https://developers.openai.com/codex/noninteractive', websiteLabel: 'codex exec', description: '调用本机 Codex CLI 的 codex exec, 适合已登录 ChatGPT/Codex 的本地环境。' },
   { label: '炸鸡中转站', url: 'https://api.zhaji.dev/v1', model: 'gpt-5.5', website: 'https://api.zhaji.dev', websiteLabel: 'api.zhaji.dev', description: 'OpenAI 兼容中转服务，适合直接使用国际模型。', partner: true, promo: '通过链接邀请注册赠送免费额度 · 国际模型最低0.02倍率' },
 ]


### PR DESCRIPTION
## 问题
配置 Kimi (`kimi-k2.7-code`) 密钥后测试连通报 400 失败。根因:
1. Reasoning 类模型拒绝非约定 temperature (Moonshot 报 `only 1 is allowed for this model`),而之前无条件下发导致请求被拒。
2. `_format_openai_error` 用状态码通用文案吞掉了上游真实错误(如 `model not found`),排查困难。
3. 前端 Kimi 预设 model `kimi-k2.6` 不存在。

## 改动
- `ai_provider.py`:捕获 temperature 相关 400 后自动去掉 temperature 重试一次(非流式 + 流式都覆盖)。不依赖模型名猜测,对任意 reasoning 模型稳健。
- `ai_provider.py`:`_format_openai_error` 优先透出上游真实 detail,仅无可读 detail 时才回落到状态码通用文案。
- `AI.tsx`:Kimi 预设 model 更正为 `kimi-k2.7-code`。
- `test_ai_provider.py`:新增 `_is_temperature_rejected` / 错误透出 / 回落测试。全量 181 测试通过,ruff 通过。