### PR TITLE
feat(ext-data): 概念/行业定时拉取默认开启 + 修复启动顺序

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -114,19 +114,20 @@ async def lifespan(app: FastAPI):
     except Exception as e:  # noqa: BLE001
         logger.warning("wecom_bot_service init failed: %s", e)
 
-    # 扩展数据定时拉取
-    from app.services.ext_pull import pull_scheduler
-    pull_scheduler.start(store.data_dir)
-    pull_scheduler.refresh(store.data_dir)
-    app.state.pull_scheduler = pull_scheduler
-
-    # 内置扩展表 (概念/行业): 只创建 config (含拉取配置), 不自动拉数据
-    # 数据获取由用户在概念/行业页点「获取数据」手动触发 (POST /api/ext-data/presets/{id}/fetch)
+    # 内置扩展表 (概念/行业): 先创建 config (含拉取配置), 默认开启定时拉取。
+    # 必须在 pull_scheduler.refresh() 之前执行, 否则全新部署时 scheduler 读不到
+    # 刚创建的预设, 定时任务不会启动。
     try:
         from app.services.ext_presets import ensure_builtin_presets
         await ensure_builtin_presets(store.data_dir)
     except Exception as e:  # noqa: BLE001
         logger.warning("内置扩展表初始化失败 (不影响启动): %s", e)
+
+    # 扩展数据定时拉取: 在预设配置就绪后启动, 自动调度 enabled 的预设。
+    from app.services.ext_pull import pull_scheduler
+    pull_scheduler.start(store.data_dir)
+    pull_scheduler.refresh(store.data_dir)
+    app.state.pull_scheduler = pull_scheduler
 
     # 财务数据 (需 Expert 套餐): 仅初始化调度器供 /api/financials/sync/* 手动同步,
     # 不启动自动调度——用户在「财务分析」页点「同步」手动拉取。

--- a/backend/app/services/ext_presets.py
+++ b/backend/app/services/ext_presets.py
@@ -6,7 +6,9 @@
   - 「已存在则跳过」: 绝不覆盖用户已有数据, 老用户零影响
   - 拉取失败只记 warning, 不阻断启动 (保持「没数据也能跑」)
 
-种子数据来源: https://files.688798.xyz/ths/{concepts,industries}.json
+种子数据来源 (概念/行业各自独立配置):
+  - 概念: https://shy313.com/api/plugins/market_flow/exports/ths-concepts
+  - 行业: https://shy313.com/api/plugins/market_flow/exports/ths-industries
 作者更新数据只需改接口上的 JSON, 用户下次拉取自动同步, 无需发版。
 
 接入点: app.main.lifespan → ensure_builtin_presets(store.data_dir)
@@ -26,8 +28,9 @@ from app.services.ext_data import (
 
 logger = logging.getLogger(__name__)
 
-# 种子数据源 (作者维护, 改这里即对所有用户生效)
-_THS_BASE = "https://files.688798.xyz/ths"
+# 种子数据源 (概念/行业各自独立配置, 作者维护)
+_CONCEPT_DATA_URL = "https://shy313.com/api/plugins/market_flow/exports/ths-concepts"
+_INDUSTRY_DATA_URL = "https://shy313.com/api/plugins/market_flow/exports/ths-industries"
 
 
 # ---------------------------------------------------------------------------
@@ -55,10 +58,10 @@ def _concept_preset() -> ExtConfig:
         symbol_map={"type": "mapped", "col": "股票代码"},
         code_map={"type": "computed", "from": "symbol", "method": "strip_exchange"},
         pull=PullConfig(
-            url=f"{_THS_BASE}/concepts.json",
+            url=_CONCEPT_DATA_URL,
             method="GET",
             schedule_minutes=1440,
-            enabled=False,
+            enabled=True,
         ),
     )
 
@@ -84,10 +87,10 @@ def _industry_preset() -> ExtConfig:
         symbol_map={"type": "mapped", "col": "股票代码"},
         code_map={"type": "computed", "from": "symbol", "method": "strip_exchange"},
         pull=PullConfig(
-            url=f"{_THS_BASE}/industries.json",
+            url=_INDUSTRY_DATA_URL,
             method="GET",
             schedule_minutes=1440,
-            enabled=False,
+            enabled=True,
         ),
     )
 
@@ -209,7 +212,7 @@ async def ensure_builtin_presets(data_dir: Path) -> None:
         try:
             store.upsert(config)
             logger.info("内置扩展表 %s 配置已就绪 (待用户手动获取数据)", config.id)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.warning("内置扩展表 %s 配置写入失败 (不影响启动): %s", config.id, e)
 
 


### PR DESCRIPTION
## 改动
- 概念/行业预设 `enabled` 由 `False` 改为 `True`, 全新部署首次启动即自动调度拉取 (每 1440 分钟一次, 启用即拉取一次)
- **修复 main.py 启动顺序**: `ensure_builtin_presets()` 移到 `pull_scheduler.refresh()` 之前。原顺序下, 改 enabled=True 后全新部署时 scheduler 读不到刚创建的预设 config.json, 定时任务不会启动。

## 影响范围
- 全新部署: 首次启动自动创建 enabled=True 配置并调度
- 已有用户: 遵循「已存在则跳过」原则, 不覆盖其配置
- 接口失败时: _run_loop 捕获异常只记 warning, 不阻断启动

## 验证
- pytest 181 passed
- ruff: 本次改动文件无新增 lint 问题