### PR TITLE
fix(settings): 实时监控设置页左右两列等宽

### DIFF
--- a/frontend/src/pages/settings/Monitoring.tsx
+++ b/frontend/src/pages/settings/Monitoring.tsx
@@ -284,7 +284,7 @@ export function SettingsMonitoringPanel({ highlight }: { highlight?: string } = 
   }
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-[1fr_1fr] gap-6 max-w-5xl">
+    <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] gap-6 max-w-5xl">
       {/* ========== 左列 ========== */}
       <div className="space-y-6">
         {/* 行情状态 — 开关 + 间隔 */}


### PR DESCRIPTION
## 问题
实时行情设置页(`/settings?tab=monitoring`)左右两栏宽度不一致,右侧特别窄。

## 原因
布局为 `lg:grid-cols-[1fr_1fr]`,其中 `1fr` 等价于 `minmax(auto, 1fr)`。左列有多张卡片且文字较长,内容撑出最小宽度,导致右列被挤压变窄。

## 修复
改为 `lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]`,将最小宽度设为 0,两列严格 1:1 等分容器宽度。

> 注:工作区中其他文件的改动(backtest / AI / CustomSignalDialog 等)为既有未提交内容,与本修复无关,未纳入本次提交。