### PR TITLE
fix(optimizer): SSE 放弃时清 localStorage + JSON 解析失败告警

### DIFF
--- a/backend/app/api/backtest.py
+++ b/backend/app/api/backtest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import queue
 import threading
 from dataclasses import asdict
@@ -20,6 +21,8 @@ from app.services.backtest import (
     VectorbtUnavailable,
     is_available,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/backtest", tags=["backtest"])
 
@@ -664,10 +667,13 @@ async def optimize_stream(
                 try:
                     base_params = json.loads(params) if params else {}
                 except (json.JSONDecodeError, TypeError):
+                    # 静默降级会让"用户配置丢失"变成无声 bug: 至少 warn 供诊断 (前端应传合法 JSON)。
+                    logger.warning("optimize: params JSON 解析失败, 降级为空 params: %r", params)
                     base_params = {}
                 try:
                     ov = json.loads(overrides) if overrides else None
                 except (json.JSONDecodeError, TypeError):
+                    logger.warning("optimize: overrides JSON 解析失败, 降级为 None: %r", overrides)
                     ov = None
                 ocfg = OptimizeConfig(
                     strategy_id=strategy_id,

--- a/frontend/src/lib/optimizerTask.ts
+++ b/frontend/src/lib/optimizerTask.ts
@@ -174,6 +174,9 @@ function connectSSE(url: string): void {
       if (reconnectAttempts > MAX_RECONNECT) {
         es.close()
         eventSource = null
+        // 清 localStorage: 否则刷新页面 tryReconnect 会重连到这个已放弃的任务。
+        localStorage.removeItem(RECONNECT_KEY)
+        localStorage.removeItem(JOB_KEY_KEY)
         current = { ...current, isPending: false, error: '连接中断, 重连多次失败' }
         emit()
       }
@@ -244,9 +247,16 @@ export function stopOptimize(): void {
     localStorage.removeItem(RECONNECT_KEY)
     localStorage.removeItem(JOB_KEY_KEY)
   } else if (eventSource) {
-    // 保持连接等 job 事件; 兜底: 5s 后仍没 key 就强关
+    // 保持连接等 job 事件; 兜底: 5s 后仍没 key 就强关并清 localStorage,
+    // 避免刷新重连到未取消任务。(若期间 job 到达, handler 已清并置 null, 下面条件不成立跳过)
     const es = eventSource
-    setTimeout(() => { if (es === eventSource) { es.close(); eventSource = null } }, 5000)
+    setTimeout(() => {
+      if (es === eventSource) {
+        es.close(); eventSource = null
+        localStorage.removeItem(RECONNECT_KEY)
+        localStorage.removeItem(JOB_KEY_KEY)
+      }
+    }, 5000)
   }
   if (current?.isPending) {
     current = { ...current, isPending: false, error: '已取消' }


### PR DESCRIPTION
## 背景
对抗式审查 walk-forward 任务管理时，发现两处健壮性问题**同样存在于已合并的优化器**（`optimizerTask.ts` / `optimize_stream`）。为避免只在 walk-forward 侧修造成两组件分歧，此 PR 修优化器侧（walk-forward 侧同款修复随其 PR 走）。

## 问题与修复

**1. SSE 放弃时漏清 localStorage → 刷新重连到僵尸任务**
`stopOptimize` 的延迟取消分支（job_key 未到手时的 5s 兜底）与 `MAX_RECONNECT` 超限退出，都只关了 `EventSource`，没清 `RECONNECT_KEY`/`JOB_KEY_KEY`。用户放弃任务后刷新页面，`tryReconnectOptimize` 会重连到一个已放弃/未取消的后端任务。
→ 两处补 `localStorage.removeItem`。延迟分支的清理放在 setTimeout 内 `es === eventSource` 判断下，若期间 job 事件到达（handler 已 postCancel + 清 storage + 置 null），条件不成立自动跳过，不误清。

**2. params/overrides JSON 解析失败静默降级 → 用户配置丢失变无声 bug**
`optimize_stream` 解析前端传来的 `params`/`overrides` 时，`except → {}/None` 无任何日志。若字符串损坏（截断/编码），优化会静默用空配置跑出与用户策略不一致的结果，无从诊断。
→ 升级为 `logger.warning`（仍降级不崩流，但可诊断）。

## 影响面
纯健壮性修复，正常路径行为不变（合法 JSON 照常解析、任务正常结束照常清理）。后端 optimizer API 测试通过。

## 说明
`import logging` + `logger` 为本 PR 新增（api/backtest.py 原无 logger）。