### PR TITLE
fix(dev): dev.ps1 Start-Job 子进程强制 UTF-8, 修后端中文日志乱码

### DIFF
--- a/dev.ps1
+++ b/dev.ps1
@@ -171,6 +171,11 @@ $frontendPidFile = [System.IO.Path]::GetTempFileName()
 
 $backendJob = Start-Job -Name 'backend' -ScriptBlock {
     param($pidFile, $dir, $port)
+    # Start-Job 开的是全新 powershell.exe 子进程, 不继承主进程的 UTF-8 设置,
+    # 默认用系统 ANSI (中文 Windows = GBK/cp936) 解码后端 UTF-8 输出 → 中文乱码。
+    # 这里强制子进程用 UTF-8, 与 app/__init__.py 的 stdout/stderr 编码对齐。
+    [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false
+    $OutputEncoding           = New-Object System.Text.UTF8Encoding $false
     $PID | Out-File -FilePath $pidFile -Encoding ascii -Force
     $env:PYTHONUNBUFFERED = '1'
     Set-Location $dir
@@ -179,6 +184,9 @@ $backendJob = Start-Job -Name 'backend' -ScriptBlock {
 
 $frontendJob = Start-Job -Name 'frontend' -ScriptBlock {
     param($pidFile, $dir, $port)
+    # 同上: job 子进程默认 GBK, pnpm/前端工具链也是 UTF-8 输出, 需对齐。
+    [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false
+    $OutputEncoding           = New-Object System.Text.UTF8Encoding $false
     $PID | Out-File -FilePath $pidFile -Encoding ascii -Force
     Set-Location $dir
     & pnpm dev --host 0.0.0.0 --port $port 2>&1


### PR DESCRIPTION
## 问题
Windows 上 \`dev.ps1\` 启动时, 后端日志的中文变乱码:
\`\`\`
strategy param 瀹氫箟缂哄皯 id, 宸蹭涪寮? {...}
\`\`\`
（应为 \`strategy param 定义缺少 id, 已丢弃\`）

## 根因
\`dev.ps1:25-28\` 主进程设了 UTF-8（注释还写着 \"so child process logs aren't garbled\"），但 \`Start-Job\` 开的是**全新 powershell.exe 子进程**, 不继承这个设置。job 子进程用系统默认 GBK(cp936) 解码后端的 UTF-8 输出 → 中文乱码。

后端本身 (\`app/__init__.py\`) 输出的是正确 UTF-8, 问题完全在 \`dev.ps1\` 的日志读取层。

## 修复
在 backend / frontend 两个 \`Start-Job\` scriptBlock 开头各加两行强制 UTF-8, 与主进程第 27-28 行一致。

## 验证
- PowerShell 语法校验通过
- Docker / dev.sh (Mac/Linux) 不受影响（本就是 UTF-8 透明）