### PR TITLE
fix: 分时刷新开关不生效 + Pro+默认开启 + 语音涨跌幅漏乘100

### DIFF
--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -428,6 +428,7 @@ def get_preferences() -> dict:
         "webhook_enabled_default": preferences.get_webhook_enabled_default(),
         "webhook_default_channels": preferences.get_webhook_default_channels(),
         "sidebar_index_symbols": preferences.get_sidebar_index_symbols(),
+        "minute_intraday_refresh": preferences.get_minute_intraday_refresh(),
         "nav_order": preferences.get_nav_order(),
         "nav_hidden": preferences.get_nav_hidden(),
         "screener_auto_run": preferences.get_screener_auto_run(),
@@ -752,6 +753,7 @@ class RealtimeMonitorConfigIn(BaseModel):
     strategy_monitor_ids: list[str] | None = None
     sidebar_index_symbols: list[str] | None = None
     screener_auto_run: bool | None = None
+    minute_intraday_refresh: bool | None = None
 
 
 @router.put("/preferences/realtime-monitor")

--- a/backend/app/services/preferences.py
+++ b/backend/app/services/preferences.py
@@ -91,8 +91,20 @@ def get_minute_sync_enabled() -> bool:
 
 
 def get_minute_intraday_refresh() -> bool:
-    """自选列表分时图是否跟随实时行情刷新 (默认关闭, 开启后盘中按 SSE 频率刷新)。"""
-    return load().get("minute_intraday_refresh", False)
+    """自选列表分时图是否跟随实时行情刷新。
+
+    默认值随权限: 有实时行情权限 (Pro+) 的用户默认开启, 否则关闭。
+    用户主动设置过的 (key 存在) 以用户选择为准, 即使是 False 也尊重。
+    """
+    data = load()
+    if "minute_intraday_refresh" in data:
+        return bool(data["minute_intraday_refresh"])
+    # 未设置过: 有权限默认开, 无权限默认关。
+    try:
+        from app.services.quote_service import QuoteService
+        return QuoteService.is_realtime_allowed()
+    except Exception:
+        return False
 
 
 def get_minute_sync_days() -> int:

--- a/frontend/src/lib/voiceBroadcast.ts
+++ b/frontend/src/lib/voiceBroadcast.ts
@@ -95,10 +95,12 @@ export function getCurrentVoiceURI(): string {
 
 const MAX_SPEAK = 3  // 单批最多逐条念 3 只, 超出汇总成数量
 
-/** 涨跌幅用中文习惯念: 5.2% → 涨5.2%, -3.1% → 跌3.1% */
+/** 涨跌幅用中文习惯念: 0.052 → 涨5.2%, -0.031 → 跌3.1%。
+ *  入参是小数制 (后端 change_pct, 0.0366 = 3.66%), 需 ×100 再念, 与 format.ts 的 fmtPct 一致。 */
 function fmtPctText(pct: number): string {
-  if (pct >= 0) return `涨${pct.toFixed(1)}%`
-  return `跌${Math.abs(pct).toFixed(1)}%`
+  const p = pct * 100
+  if (p >= 0) return `涨${p.toFixed(1)}%`
+  return `跌${Math.abs(p).toFixed(1)}%`
 }
 
 /**

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -625,8 +625,8 @@ export function Watchlist() {
   const klineData = dailyKVisible ? (klineBatch.data?.data ?? {}) : {}
 
   // 批量分时数据 (Pro+ 用户, 列可见时才拉)
-  // 刷新策略: 实时行情运行中自动按 15s 轮询 (不接 SSE 高频, 避免每秒拉 TickFlow 触限流);
-  // 用户也可在实时监控设置里单独开启 minute_intraday_refresh 强制刷新 (即使未开实时行情)
+  // 刷新策略: 仅当实时行情运行 且 用户在实时监控设置里开启 minute_intraday_refresh 时
+  // 按 15s 轮询 (不接 SSE 高频, 避免每秒拉 TickFlow 触限流); 与 Screener / 设置卡片描述一致。
   const { data: prefsData } = usePreferences()
   const intradayRefreshEnabled = prefsData?.minute_intraday_refresh ?? false
   const minuteBatch = useQuery({
@@ -634,7 +634,7 @@ export function Watchlist() {
     queryFn: () => api.klineMinuteBatch(symbols),
     enabled: intradayVisible && symbols.length > 0,
     staleTime: 10_000,
-    refetchInterval: (realtimeRunning || intradayRefreshEnabled) ? 15_000 : false,
+    refetchInterval: (intradayRefreshEnabled && realtimeRunning) ? 15_000 : false,
   })
   const minuteData = intradayVisible ? (minuteBatch.data?.data ?? {}) : {}
 


### PR DESCRIPTION
## 包含两个独立修复

### 1. 分时图刷新开关不生效 (3 文件)
后端 API 层漏接线:
- \`RealtimeMonitorConfigIn\` 缺 \`minute_intraday_refresh\` 字段 → PUT 时被 Pydantic 丢弃
- \`GET /preferences\` 没返回该字段 → 前端永远读 false, 开关拨完弹回 OFF

服务层 (preferences.py) 本就有 get/set, 纯 API 层漏接。同时:
- **Pro+ 用户默认开启**: 三态逻辑 (未设置→按权限定默认; 已设置→尊重用户)
- **刷新条件统一**: Watchlist \`||\` → \`&&\`, 与 Screener/设置卡片描述一致

### 2. 语音播报涨跌幅漏乘 100 (1 文件)
\`fmtPctText\` 没乘 100, 后端 \`change_pct\` 是小数制 (0.0366=3.66%):
\`\`\`
0.0366 → 旧「涨0.0%」/ 新「涨3.7%」
0.10   → 旧「涨0.1%」/ 新「涨10.0%」
\`\`\`

## 验证
- 后端 216 测试通过
- 前端 tsc 通过
- 语音三态实测: 涨3.66%→涨3.7%、涨停10%→涨10.0%、跌5.2%→跌5.2%