### PR TITLE
fix(docker): Codex CLI 挂载路径可覆盖 + 版本号单点维护

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ RUN if [ "$INCLUDE_STOCKSDK" = "1" ]; then \
 FROM node:20-bookworm-slim AS codex-builder
 ARG USE_CN_MIRROR=1
 ARG NPM_REGISTRY=https://registry.npmmirror.com
-ARG CODEX_CLI_VERSION=0.144.3
+# 版本由顶层 ARG CODEX_CLI_VERSION 提供, 这里仅声明以继承, 不再重复默认值。
+ARG CODEX_CLI_VERSION
 RUN if [ "$USE_CN_MIRROR" = "1" ]; then npm config set registry "$NPM_REGISTRY"; fi \
     && npm install --global --prefix /opt/codex "@openai/codex@${CODEX_CLI_VERSION}" \
     && CODEX_NATIVE="$(find /opt/codex -type f -path '*/vendor/*/bin/codex' -print -quit)" \

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ Docker 镜像内置固定版本的 **Codex CLI**，Compose 会将主机 `${HOME}
 CODEX_CLI_VERSION=0.144.3 docker compose up --build
 ```
 
+> **Windows 用户注意**：纯 PowerShell / CMD 下 `HOME` 环境变量通常未设置，会导致挂载路径解析失败、容器读不到 Codex 登录态。请在 `.env` 中显式指定主机 Codex 目录：
+> ```bash
+> # PowerShell 示例(实际路径以本机为准)
+> echo "CODEX_HOME_HOST=C:\Users\你的用户名\.codex" >> .env
+> ```
+
 > Codex CLI 模式允许 TickFlow 容器读取本机 Codex 登录凭据，仅应在受信任的本机环境启用。凭据目录以只读方式挂载，不会写入镜像。
 
 镜像已内置 **stock-sdk** 数据源插件(Node 运行时 + 依赖),开箱即用。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,5 +27,6 @@ services:
       - ./data:/app/data
       - ./tiers.yaml:/app/tiers.yaml:ro
       # 复用主机 Codex 登录态；后端只读后复制到单次请求的临时 CODEX_HOME。
-      - ${HOME}/.codex:/root/.codex:ro
+      # Windows PowerShell/CMD 下 HOME 常未设置, 可通过 .env 里 CODEX_HOME_HOST 覆盖。
+      - ${CODEX_HOME_HOST:-${HOME}/.codex}:/root/.codex:ro
     restart: unless-stopped


### PR DESCRIPTION
PR #116 review 中遗留的两项非阻塞建议的后续修复。

## 改动

**1. Windows 挂载路径可覆盖**(`docker-compose.yml`)
- `${HOME}/.codex` → `${CODEX_HOME_HOST:-${HOME}/.codex}`
- 修复 Windows PowerShell/CMD 下 `HOME` 环境变量未设置时挂载路径解析失败、容器读不到 Codex 登录态的问题
- Windows 用户可在 `.env` 中显式指定 `CODEX_HOME_HOST=C:\Users\xxx\.codex`

**2. 版本号单点维护**(`Dockerfile`)
- `codex-builder` 阶段的 `ARG CODEX_CLI_VERSION=0.144.3` 去掉重复默认值,改为 `ARG CODEX_CLI_VERSION` 从顶层继承
- 版本号 `0.144.3` 现仅出现在 Dockerfile 顶层一处 + docker-compose.yml 一处(此前 codex-builder 阶段是第三处硬编码)
- 与项目中其他参数(如 `INCLUDE_STOCKSDK`)的处理方式一致:顶层设默认值,各 stage 内 ARG 无默认值继承

**3. 文档**(`README.md`)
- 补充 Windows 用户 `CODEX_HOME_HOST` 配置说明

## 验证
- [x] YAML 语法校验通过
- [x] `git diff --check` 无空白错误
- [x] `uv run pytest tests/test_ai_provider.py` 17 passed,无回归

> 注:本机 Docker daemon 未运行,未能跑 `docker compose config` 实测,改动均按 Docker 官方 ARG 继承语义编写。合并前建议在有 Docker 环境的机器上验证一次完整构建。