### PR TITLE
fix(strategy): parsePyValue 兜底非 JSON 值, 修复 AI 修改 date 参数崩溃

### DIFF
--- a/frontend/src/components/screener/StrategyBuilderDialog.tsx
+++ b/frontend/src/components/screener/StrategyBuilderDialog.tsx
@@ -12,7 +12,13 @@ function parsePyValue(v: string): any {
   if (s === 'True') return true
   if (s === 'False') return false
   if (s === 'None') return null
-  return JSON.parse(s)
+  // get() 已对字符串去外层引号, 纯文本值(如 2024-01-01 / anchor_date)
+  // 不是合法 JSON, JSON.parse 会抛错 → 兜底返回原始字符串
+  try {
+    return JSON.parse(s)
+  } catch {
+    return s
+  }
 }
 
 function slugId(prefix: 'ai' | 'custom' = 'ai'): string {


### PR DESCRIPTION
## 问题
点击策略的 AI 修改按钮, StrategyBuilderDialog 白屏:
Unexpected non-whitespace character after JSON at position 4

## 根因
parsePyValue 用 JSON.parse 解析参数值, 但 get() 先去了字符串外层引号。
date 类型的 default "2024-01-01" 去引号后变 2024-01-01, JSON.parse 在
第一个 - 处报错崩溃。

## 修复
parsePyValue 加 try/catch 兜底, JSON.parse 失败时返回原始字符串。
数字/布尔不受影响。

## 验证
- tsc --noEmit 通过
- 实际策略 ai_single_yang_unbroken 三个参数(date/float/int)正确解析