### PR TITLE
feat(strategy): AI生成/自定义编写 tab 加策略开发指南链接

### DIFF
--- a/frontend/src/components/screener/StrategyBuilderDialog.tsx
+++ b/frontend/src/components/screener/StrategyBuilderDialog.tsx
@@ -352,11 +352,21 @@ export function StrategyBuilderDialog({ open, onClose, onSavedId, mode = 'create
               <div className="flex items-center gap-2 text-[11px]">
                 <Sparkles className="h-3.5 w-3.5 text-amber-400 shrink-0" />
                 <span className="text-amber-400/80">步骤 1 描述策略规则 → 步骤 2 预览代码 → 保存</span>
+                <a href="https://github.com/shy3130/tickflow-stock-panel/blob/main/backend/app/strategy/prompts/strategy-guide.md"
+                   target="_blank" rel="noopener noreferrer"
+                   className="inline-flex items-center gap-1 text-accent/70 hover:text-accent transition-colors">
+                  <FileText className="h-3 w-3" />策略开发指南
+                </a>
               </div>
             ) : (
               <div className="flex items-center gap-2 text-[11px]">
                 <Terminal className="h-3.5 w-3.5 text-accent shrink-0" />
                 <span className="text-muted">适合有 Python 基础的开发者，手动编写策略文件进行深度定制和二次开发</span>
+                <a href="https://github.com/shy3130/tickflow-stock-panel/blob/main/backend/app/strategy/prompts/strategy-guide.md"
+                   target="_blank" rel="noopener noreferrer"
+                   className="inline-flex items-center gap-1 text-accent/70 hover:text-accent transition-colors">
+                  <FileText className="h-3 w-3" />策略开发指南
+                </a>
               </div>
             )}
           </div>


### PR DESCRIPTION
两个 tab 描述行都加了指向 GitHub strategy-guide.md 的链接, 方便参考指标列/信号列/filter_history 写法/参数类型。