### PR TITLE
feat: add monthly/yearly K-line sync and data page cards

### DIFF
--- a/backend/app/api/data.py
+++ b/backend/app/api/data.py
@@ -42,6 +42,8 @@ _table_cache: dict[str, dict | None] = {
     "etf_enriched": None,
     "etf_instruments": None,
     "minute": None,
+    "monthly": None,
+    "yearly": None,
     "adj_factor": None,
     "instruments": None,
     "financials": None,
@@ -405,6 +407,35 @@ def _safe_aggregate_minute(repo) -> dict | None:
     }
 
 
+def _safe_aggregate_period_dir(repo, subdir: str) -> dict | None:
+    """月/年 K 分区目录轻量统计。"""
+    period_dir = repo.store.data_dir / subdir
+    if not period_dir.exists():
+        return None
+    dates: list[str] = []
+    for d in period_dir.iterdir():
+        if d.is_dir() and d.name.startswith("date="):
+            dates.append(d.name[5:])
+    if not dates:
+        return None
+    dates.sort()
+    return {
+        "rows": 0,
+        "earliest_date": dates[0],
+        "latest_date": dates[-1],
+        "symbols_covered": 0,
+        "trading_days": len(dates),
+    }
+
+
+def _safe_aggregate_monthly(repo) -> dict | None:
+    return _safe_aggregate_period_dir(repo, "kline_monthly")
+
+
+def _safe_aggregate_yearly(repo) -> dict | None:
+    return _safe_aggregate_period_dir(repo, "kline_yearly")
+
+
 def _safe_aggregate_financials(repo) -> dict | None:
     """财务数据统计 — 检查各表文件是否存在及行数。"""
     data_dir = repo.store.data_dir
@@ -492,6 +523,8 @@ def _compute_storage(data_dir: Path) -> dict:
         "etf_instruments": data_dir / "instruments_etf",
         "etf_adj_factor": data_dir / "adj_factor_etf",
         "minute": data_dir / "kline_minute",
+        "monthly": data_dir / "kline_monthly",
+        "yearly": data_dir / "kline_yearly",
         "adj_factor": data_dir / "adj_factor",
         "instruments": data_dir / "instruments",
         "ext_data": data_dir / "ext_data",
@@ -600,6 +633,8 @@ def status(request: Request) -> dict:
     "etf_enriched":      _get_table_stats("etf_enriched",      lambda: _safe_aggregate_etf_enriched(repo)),
     "etf_instruments":   _get_table_stats("etf_instruments",   lambda: _safe_aggregate_etf_instruments(repo)),
     "minute":      _get_table_stats("minute",      lambda: _safe_aggregate_minute(repo)),
+    "monthly":     _get_table_stats("monthly",     lambda: _safe_aggregate_monthly(repo)),
+    "yearly":      _get_table_stats("yearly",      lambda: _safe_aggregate_yearly(repo)),
         "adj_factor":  _get_table_stats("adj_factor",  lambda: _safe_aggregate_adj_factor(repo)),
         "instruments": _get_table_stats("instruments", lambda: _safe_aggregate_instruments(repo)),
         "financials":  _get_table_stats("financials",  lambda: _safe_aggregate_financials(repo)),
@@ -630,6 +665,7 @@ def clear_data(request: Request):
     for sub in (
         "kline_daily", "kline_daily_enriched", "kline_index_daily", "kline_index_enriched",
         "kline_etf_daily", "kline_etf_enriched", "kline_etf_minute", "kline_minute",
+        "kline_monthly", "kline_yearly",
         "adj_factor", "adj_factor_etf", "instruments", "instruments_index", "instruments_etf", "pools", "financials",
         "backtest_results", "screener_results", "ai_cache",
     ):
@@ -734,6 +770,26 @@ _TABLE_FIELD_DESC: dict[str, dict[str, str]] = {
         "volume": "成交量",
         "amount": "成交额",
     },
+    "kline_monthly": {
+        "symbol": "股票代码",
+        "date": "月结束日期",
+        "open": "开盘价",
+        "high": "最高价",
+        "low": "最低价",
+        "close": "收盘价",
+        "volume": "成交量",
+        "amount": "成交额",
+    },
+    "kline_yearly": {
+        "symbol": "股票代码",
+        "date": "年结束日期",
+        "open": "开盘价",
+        "high": "最高价",
+        "low": "最低价",
+        "close": "收盘价",
+        "volume": "成交量",
+        "amount": "成交额",
+    },
     "adj_factor": {
         "symbol": "股票代码",
         "timestamp": "除权除息时间戳(ms)",
@@ -781,6 +837,8 @@ _SCHEMA_VIEWS: dict[str, str] = {
     "etf_enriched": "kline_etf_enriched",
     "etf_instruments": "instruments_etf",
     "minute": "kline_minute",
+    "monthly": "kline_monthly",
+    "yearly": "kline_yearly",
     "adj_factor": "adj_factor",
     "instruments": "instruments",
 }

--- a/backend/app/api/kline.py
+++ b/backend/app/api/kline.py
@@ -29,6 +29,32 @@ def _minute_allowed(capset) -> bool:
     return custom_sources.provider_has_dataset(provider, "minute")
 
 
+def _monthly_allowed(capset) -> bool:  # noqa: ARG001
+    from app.services.period_kline_access import period_provider_active
+    return period_provider_active("monthly")
+
+
+def _yearly_allowed(capset) -> bool:  # noqa: ARG001
+    from app.services.period_kline_access import period_provider_active
+    return period_provider_active("yearly")
+
+
+def _resolve_period_universe(repo) -> list[str]:
+    """月/年 K 同步标的池 — 与分钟 K 全市场同步一致。"""
+    from app.tickflow.pools import get_pool
+
+    universe = sorted(set(get_pool("watchlist")) | set(get_pool("CN_Equity_A")))
+    inst_path = repo.store.data_dir / "instruments" / "instruments.parquet"
+    if inst_path.exists():
+        try:
+            import polars as pl
+            inst = pl.read_parquet(inst_path, columns=["symbol"])
+            universe = sorted(set(universe) | set(inst["symbol"].to_list()))
+        except Exception:  # noqa: BLE001
+            pass
+    return universe
+
+
 @router.get("/instruments/search")
 def search_instruments(
     request: Request,
@@ -772,6 +798,352 @@ async def clear_minute(request: Request):
 
     logger.info("minute K cleared: %d rows removed", removed)
     return {"status": "ok", "removed": removed}
+
+
+@router.post("/sync_monthly")
+async def sync_monthly(request: Request):
+    """手动触发月 K 同步 (stock-sdk → kline_monthly)。"""
+    import asyncio
+
+    from app.api.data import invalidate_data_cache
+    from app.services.monthly_sync import refresh_monthly_view, sync_and_persist_monthly
+    from app.services.pipeline_jobs import job_store, release_run_slot, try_acquire_run_slot
+    from app.services.preferences import get_monthly_sync_months
+
+    repo = request.app.state.repo
+    capset = request.app.state.capabilities
+    if not _monthly_allowed(capset):
+        raise HTTPException(status_code=403, detail="未配置月 K 数据源 (如 stock-sdk)")
+
+    job_id, is_new = job_store.create()
+    if not is_new:
+        return {"status": "reused", "job_id": job_id}
+
+    async def task() -> None:
+        if not try_acquire_run_slot():
+            job_store.fail(job_id, "已有数据任务在运行,请稍后再试")
+            return
+        loop = asyncio.get_event_loop()
+
+        def progress(stage: str, pct: int, msg: str,
+                     stage_pct: int | None = None, skip_log: bool = False) -> None:
+            job_store.progress(job_id, stage, pct, msg,
+                               stage_pct=stage_pct, skip_log=skip_log)
+
+        try:
+            job_store.start(job_id)
+            progress("sync_monthly", 5, "解析标的池…")
+            universe = _resolve_period_universe(repo)
+            progress("sync_monthly", 10, f"标的池 {len(universe)} 只")
+            months = get_monthly_sync_months()
+
+            def _chunk(cur: int, tot: int) -> None:
+                progress("sync_monthly", 10 + int(85 * cur / tot),
+                         f"月K 批次 {cur}/{tot}", stage_pct=int(100 * cur / tot), skip_log=True)
+
+            written = await loop.run_in_executor(
+                _long_task_executor,
+                lambda: sync_and_persist_monthly(
+                    universe, repo, months=months, on_chunk_done=_chunk
+                ),
+            )
+            refresh_monthly_view(repo)
+            progress("done", 100, f"月K 同步完成,{written} 行")
+            job_store.succeed(job_id, {
+                "monthly_rows": written,
+                "universe_size": len(universe),
+            })
+            invalidate_data_cache("monthly")
+        except Exception as e:  # noqa: BLE001
+            job_store.fail(job_id, str(e))
+            invalidate_data_cache("monthly")
+        finally:
+            release_run_slot()
+
+    asyncio.create_task(task())
+    return {"status": "started", "job_id": job_id}
+
+
+@router.post("/extend_monthly_history")
+async def extend_monthly_history(request: Request):
+    """向前扩展月 K 历史 (kline_monthly)。"""
+    import asyncio
+    import traceback as _tb
+
+    from app.api.data import invalidate_data_cache
+    from app.market_time import resolve_period_extend_range
+    from app.services.monthly_sync import KLINE_MONTHLY_SUBDIR, backfill_monthly_range
+    from app.services.pipeline_jobs import job_store, release_run_slot, try_acquire_run_slot
+
+    try:
+        body = await request.json()
+        value = body.get("value")
+        unit = body.get("unit", "year")
+        if not value or value <= 0:
+            raise HTTPException(status_code=400, detail="value 必须为正整数")
+        if unit != "year":
+            raise HTTPException(status_code=400, detail="unit 只支持 year")
+
+        repo = request.app.state.repo
+        capset = request.app.state.capabilities
+        if not _monthly_allowed(capset):
+            raise HTTPException(status_code=403, detail="未配置月 K 数据源")
+
+        job_id, is_new = job_store.create()
+        if not is_new:
+            return {"status": "reused", "job_id": job_id}
+
+        async def task() -> None:
+            if not try_acquire_run_slot():
+                job_store.fail(job_id, "已有数据任务在运行,请稍后再试")
+                return
+            loop = asyncio.get_event_loop()
+
+            def progress(stage: str, pct: int, msg: str,
+                         stage_pct: int | None = None, skip_log: bool = False) -> None:
+                job_store.progress(job_id, stage, pct, msg,
+                                   stage_pct=stage_pct, skip_log=skip_log)
+
+            try:
+                job_store.start(job_id)
+                earliest = repo.earliest_period_kline_date(KLINE_MONTHLY_SUBDIR)
+                if not earliest:
+                    job_store.fail(job_id, "本地无月K数据,请先点击「同步最近月K」")
+                    invalidate_data_cache("monthly")
+                    return
+                try:
+                    start_d, end_d = resolve_period_extend_range(
+                        years=value, earliest=earliest, min_span_days=31
+                    )
+                except ValueError:
+                    job_store.fail(job_id, "扩展范围无效")
+                    invalidate_data_cache("monthly")
+                    return
+
+                start_str = start_d.isoformat()
+                end_str = end_d.isoformat()
+                progress("extend_monthly", 5, "解析标的池…")
+                universe = _resolve_period_universe(repo)
+                progress("extend_monthly", 8, f"标的池: {len(universe)} 只")
+
+                def _run():
+                    def _chunk(cur: int, tot: int) -> None:
+                        progress("extend_monthly", 8 + int(85 * cur / tot),
+                                 f"月K 批次 {cur}/{tot}", stage_pct=int(100 * cur / tot), skip_log=True)
+
+                    return backfill_monthly_range(
+                        universe, repo, start_date=start_d, end_date=end_d, on_chunk_done=_chunk,
+                    )
+
+                progress(
+                    "extend_monthly", 10,
+                    f"获取月K [{start_str} ~ {end_str}] (早于本地最早 {earliest})…",
+                )
+                written, fetched = await loop.run_in_executor(_long_task_executor, _run)
+                if written <= 0:
+                    job_store.fail(
+                        job_id,
+                        f"月K [{start_str}~{end_str}] 未写入 (拉取 {fetched} 行);"
+                        "请检查网络/扩大范围",
+                    )
+                    invalidate_data_cache("monthly")
+                    return
+                monthly_dir = repo.store.data_dir / KLINE_MONTHLY_SUBDIR
+                month_count = len(list(monthly_dir.glob("date=*"))) if monthly_dir.exists() else 0
+                progress("extend_monthly", 95, f"月K 完成,{month_count} 月,{written} 行")
+                job_store.succeed(job_id, {
+                    "monthly_months": month_count,
+                    "monthly_rows": written,
+                    "universe_size": len(universe),
+                })
+                invalidate_data_cache("monthly")
+            except Exception as e:  # noqa: BLE001
+                logger.exception("extend_monthly_history failed: job_id=%s", job_id)
+                job_store.fail(job_id, str(e))
+                invalidate_data_cache("monthly")
+            finally:
+                release_run_slot()
+
+        asyncio.create_task(task())
+        return {"status": "started", "job_id": job_id}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("extend_monthly_history error: %s\n%s", e, _tb.format_exc())
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/sync_yearly")
+async def sync_yearly(request: Request):
+    """手动触发年 K 同步 (月线聚合 → kline_yearly)。"""
+    import asyncio
+
+    from app.api.data import invalidate_data_cache
+    from app.services.pipeline_jobs import job_store, release_run_slot, try_acquire_run_slot
+    from app.services.preferences import get_yearly_sync_years
+    from app.services.yearly_sync import refresh_yearly_view, sync_and_persist_yearly
+
+    repo = request.app.state.repo
+    capset = request.app.state.capabilities
+    if not _yearly_allowed(capset):
+        raise HTTPException(status_code=403, detail="未配置年 K 数据源 (如 stock-sdk)")
+
+    job_id, is_new = job_store.create()
+    if not is_new:
+        return {"status": "reused", "job_id": job_id}
+
+    async def task() -> None:
+        if not try_acquire_run_slot():
+            job_store.fail(job_id, "已有数据任务在运行,请稍后再试")
+            return
+        loop = asyncio.get_event_loop()
+
+        def progress(stage: str, pct: int, msg: str,
+                     stage_pct: int | None = None, skip_log: bool = False) -> None:
+            job_store.progress(job_id, stage, pct, msg,
+                               stage_pct=stage_pct, skip_log=skip_log)
+
+        try:
+            job_store.start(job_id)
+            progress("sync_yearly", 5, "解析标的池…")
+            universe = _resolve_period_universe(repo)
+            progress("sync_yearly", 10, f"标的池 {len(universe)} 只")
+            years = get_yearly_sync_years()
+
+            def _chunk(cur: int, tot: int) -> None:
+                progress("sync_yearly", 10 + int(85 * cur / tot),
+                         f"年K 批次 {cur}/{tot}", stage_pct=int(100 * cur / tot), skip_log=True)
+
+            written = await loop.run_in_executor(
+                _long_task_executor,
+                lambda: sync_and_persist_yearly(
+                    universe, repo, years=years, on_chunk_done=_chunk
+                ),
+            )
+            refresh_yearly_view(repo)
+            progress("done", 100, f"年K 同步完成,{written} 行")
+            job_store.succeed(job_id, {
+                "yearly_rows": written,
+                "universe_size": len(universe),
+            })
+            invalidate_data_cache("yearly")
+        except Exception as e:  # noqa: BLE001
+            job_store.fail(job_id, str(e))
+            invalidate_data_cache("yearly")
+        finally:
+            release_run_slot()
+
+    asyncio.create_task(task())
+    return {"status": "started", "job_id": job_id}
+
+
+@router.post("/extend_yearly_history")
+async def extend_yearly_history(request: Request):
+    """向前扩展年 K 历史 (kline_yearly)。"""
+    import asyncio
+    import traceback as _tb
+
+    from app.api.data import invalidate_data_cache
+    from app.market_time import resolve_period_extend_range
+    from app.services.pipeline_jobs import job_store, release_run_slot, try_acquire_run_slot
+    from app.services.yearly_sync import KLINE_YEARLY_SUBDIR, backfill_yearly_range
+
+    try:
+        body = await request.json()
+        value = body.get("value")
+        unit = body.get("unit", "year")
+        if not value or value <= 0:
+            raise HTTPException(status_code=400, detail="value 必须为正整数")
+        if unit != "year":
+            raise HTTPException(status_code=400, detail="unit 只支持 year")
+
+        repo = request.app.state.repo
+        capset = request.app.state.capabilities
+        if not _yearly_allowed(capset):
+            raise HTTPException(status_code=403, detail="未配置年 K 数据源")
+
+        job_id, is_new = job_store.create()
+        if not is_new:
+            return {"status": "reused", "job_id": job_id}
+
+        async def task() -> None:
+            if not try_acquire_run_slot():
+                job_store.fail(job_id, "已有数据任务在运行,请稍后再试")
+                return
+            loop = asyncio.get_event_loop()
+
+            def progress(stage: str, pct: int, msg: str,
+                         stage_pct: int | None = None, skip_log: bool = False) -> None:
+                job_store.progress(job_id, stage, pct, msg,
+                                   stage_pct=stage_pct, skip_log=skip_log)
+
+            try:
+                job_store.start(job_id)
+                earliest = repo.earliest_period_kline_date(KLINE_YEARLY_SUBDIR)
+                if not earliest:
+                    job_store.fail(job_id, "本地无年K数据,请先点击「同步最近年K」")
+                    invalidate_data_cache("yearly")
+                    return
+                try:
+                    start_d, end_d = resolve_period_extend_range(
+                        years=value, earliest=earliest, min_span_days=365
+                    )
+                except ValueError:
+                    job_store.fail(job_id, "扩展范围无效")
+                    invalidate_data_cache("yearly")
+                    return
+
+                start_str = start_d.isoformat()
+                end_str = end_d.isoformat()
+                progress("extend_yearly", 5, "解析标的池…")
+                universe = _resolve_period_universe(repo)
+                progress("extend_yearly", 8, f"标的池: {len(universe)} 只")
+
+                def _run():
+                    def _chunk(cur: int, tot: int) -> None:
+                        progress("extend_yearly", 8 + int(85 * cur / tot),
+                                 f"年K 批次 {cur}/{tot}", stage_pct=int(100 * cur / tot), skip_log=True)
+
+                    return backfill_yearly_range(
+                        universe, repo, start_date=start_d, end_date=end_d, on_chunk_done=_chunk,
+                    )
+
+                progress(
+                    "extend_yearly", 10,
+                    f"获取年K [{start_str} ~ {end_str}] (早于本地最早 {earliest})…",
+                )
+                written, fetched = await loop.run_in_executor(_long_task_executor, _run)
+                if written <= 0:
+                    job_store.fail(
+                        job_id,
+                        f"年K [{start_str}~{end_str}] 未写入 (拉取 {fetched} 行);"
+                        "请检查网络/扩大范围",
+                    )
+                    invalidate_data_cache("yearly")
+                    return
+                yearly_dir = repo.store.data_dir / KLINE_YEARLY_SUBDIR
+                year_count = len(list(yearly_dir.glob("date=*"))) if yearly_dir.exists() else 0
+                progress("extend_yearly", 95, f"年K 完成,{year_count} 年,{written} 行")
+                job_store.succeed(job_id, {
+                    "yearly_years": year_count,
+                    "yearly_rows": written,
+                    "universe_size": len(universe),
+                })
+                invalidate_data_cache("yearly")
+            except Exception as e:  # noqa: BLE001
+                logger.exception("extend_yearly_history failed: job_id=%s", job_id)
+                job_store.fail(job_id, str(e))
+                invalidate_data_cache("yearly")
+            finally:
+                release_run_slot()
+
+        asyncio.create_task(task())
+        return {"status": "started", "job_id": job_id}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("extend_yearly_history error: %s\n%s", e, _tb.format_exc())
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 @router.post("/extend_history")

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -23,18 +23,26 @@ def health() -> dict:
 @router.get("/api/capabilities")
 def capabilities() -> dict:
     """前端用来决定哪些功能可用、哪些灰显。"""
+    from app.services.period_kline_access import monthly_access_flags, yearly_access_flags
+
     capset = detect_capabilities()
     return {
         "label": tier_label(),
         "capabilities": capset.to_dict(),
+        **monthly_access_flags(capset),
+        **yearly_access_flags(capset),
     }
 
 
 @router.post("/api/capabilities/redetect")
 def redetect() -> dict:
     """用户在设置页"重新检测"按钮。"""
+    from app.services.period_kline_access import monthly_access_flags, yearly_access_flags
+
     capset = detect_capabilities(force=True)
     return {
         "label": tier_label(),
         "capabilities": capset.to_dict(),
+        **monthly_access_flags(capset),
+        **yearly_access_flags(capset),
     }

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -341,10 +341,22 @@ class MinuteSyncPrefs(BaseModel):
     minute_sync_segment_days: int | None = None
 
 
+class MonthlySyncPrefs(BaseModel):
+    monthly_sync_enabled: bool
+    monthly_sync_months: int = 24
+
+
+class YearlySyncPrefs(BaseModel):
+    yearly_sync_enabled: bool
+    yearly_sync_years: int = 10
+
+
 class DataProvidersIn(BaseModel):
     daily_data_provider: str | None = None
     adj_factor_provider: str | None = None
     minute_data_provider: str | None = None
+    monthly_data_provider: str | None = None
+    yearly_data_provider: str | None = None
     realtime_data_provider: str | None = None
     financial_data_provider: str | None = None
 
@@ -398,9 +410,15 @@ def get_preferences() -> dict:
         "minute_sync_enabled": preferences.get_minute_sync_enabled(),
         "minute_sync_days": preferences.get_minute_sync_days(),
         "minute_sync_segment_days": preferences.get_minute_sync_segment_days(),
+        "monthly_sync_enabled": preferences.get_monthly_sync_enabled(),
+        "monthly_sync_months": preferences.get_monthly_sync_months(),
+        "yearly_sync_enabled": preferences.get_yearly_sync_enabled(),
+        "yearly_sync_years": preferences.get_yearly_sync_years(),
         "daily_data_provider": preferences.get_daily_data_provider(),
         "adj_factor_provider": preferences.get_adj_factor_provider(),
         "minute_data_provider": preferences.get_minute_data_provider(),
+        "monthly_data_provider": preferences.get_monthly_data_provider(),
+        "yearly_data_provider": preferences.get_yearly_data_provider(),
         "realtime_data_provider": preferences.get_realtime_data_provider(),
         "financial_data_provider": preferences.get_financial_provider(),
         "realtime_watchlist_symbols": preferences.get_realtime_watchlist_symbols(),
@@ -497,6 +515,8 @@ def uninstall_plugin(name: str) -> dict:
     for getter, key, default in [
         (preferences.get_daily_data_provider, "daily_data_provider", "tickflow"),
         (preferences.get_minute_data_provider, "minute_data_provider", "tickflow"),
+        (preferences.get_monthly_data_provider, "monthly_data_provider", "stocksdk"),
+        (preferences.get_yearly_data_provider, "yearly_data_provider", "stocksdk"),
         (preferences.get_realtime_data_provider, "realtime_data_provider", "tickflow"),
         (preferences.get_financial_provider, "financial_data_provider", "tickflow"),
     ]:
@@ -552,6 +572,10 @@ def delete_data_source(name: str) -> dict:
         updates["daily_data_provider"] = "tickflow"
     if preferences.get_realtime_data_provider() == name:
         updates["realtime_data_provider"] = "tickflow"
+    if preferences.get_monthly_data_provider() == name:
+        updates["monthly_data_provider"] = "stocksdk"
+    if preferences.get_yearly_data_provider() == name:
+        updates["yearly_data_provider"] = "stocksdk"
     if preferences.get_financial_provider() == name:
         updates["financial_data_provider"] = "tickflow"
     adj = preferences.get_adj_factor_provider()
@@ -578,12 +602,17 @@ def update_data_providers(req: DataProvidersIn) -> dict:
     """保存数据源选择。"""
     from app.services import preferences
     updates = req.model_dump(exclude_none=True)
+    if updates.get("daily_data_provider") == "stocksdk":
+        updates.setdefault("monthly_data_provider", "stocksdk")
+        updates.setdefault("yearly_data_provider", "stocksdk")
     if updates:
         preferences.save(updates)
     return {
         "daily_data_provider": preferences.get_daily_data_provider(),
         "adj_factor_provider": preferences.get_adj_factor_provider(),
         "minute_data_provider": preferences.get_minute_data_provider(),
+        "monthly_data_provider": preferences.get_monthly_data_provider(),
+        "yearly_data_provider": preferences.get_yearly_data_provider(),
         "realtime_data_provider": preferences.get_realtime_data_provider(),
         "financial_data_provider": preferences.get_financial_provider(),
     }
@@ -667,6 +696,36 @@ def update_minute_sync(req: MinuteSyncPrefs) -> dict:
         "minute_sync_enabled": req.minute_sync_enabled,
         "minute_sync_days": days,
         "minute_sync_segment_days": preferences.get_minute_sync_segment_days(),
+    }
+
+
+@router.put("/preferences/monthly-sync")
+def update_monthly_sync(req: MonthlySyncPrefs) -> dict:
+    """保存月 K 同步偏好。"""
+    from app.services import preferences
+    months = max(1, min(120, req.monthly_sync_months))
+    preferences.save({
+        "monthly_sync_enabled": req.monthly_sync_enabled,
+        "monthly_sync_months": months,
+    })
+    return {
+        "monthly_sync_enabled": req.monthly_sync_enabled,
+        "monthly_sync_months": months,
+    }
+
+
+@router.put("/preferences/yearly-sync")
+def update_yearly_sync(req: YearlySyncPrefs) -> dict:
+    """保存年 K 同步偏好。"""
+    from app.services import preferences
+    years = max(1, min(40, req.yearly_sync_years))
+    preferences.save({
+        "yearly_sync_enabled": req.yearly_sync_enabled,
+        "yearly_sync_years": years,
+    })
+    return {
+        "yearly_sync_enabled": req.yearly_sync_enabled,
+        "yearly_sync_years": years,
     }
 
 

--- a/backend/app/market_time.py
+++ b/backend/app/market_time.py
@@ -28,6 +28,32 @@ def cn_today() -> date:
     return datetime.now(CN_TZ).date()
 
 
+def last_cn_weekday(on_or_before: date | None = None) -> date:
+    """回退到最近一个 A 股工作日 (Mon–Fri; 不含法定节假日)。"""
+    d = on_or_before or cn_today()
+    for _ in range(10):
+        if d.weekday() < 5:
+            return d
+        d -= timedelta(days=1)
+    return on_or_before or cn_today()
+
+
+def resolve_period_extend_range(
+    *,
+    years: int,
+    earliest: date,
+    min_span_days: int = 31,
+    max_span_days: int = 3650,
+) -> tuple[date, date]:
+    """月/年 K 历史扩展: 在本地最早 bar 之前再向前拉 years 年。"""
+    span_days = max(min_span_days, min(years * 365, max_span_days))
+    start = earliest - timedelta(days=span_days)
+    end = last_cn_weekday(earliest - timedelta(days=1))
+    if start >= end:
+        raise ValueError(f"扩展范围无效: {start} >= {end}")
+    return start, end
+
+
 def trading_minutes_elapsed_from_dt(dt: datetime) -> float:
     """根据北京时间 datetime 计算当日已交易分钟数。
 

--- a/backend/app/plugins/stocksdk/plugin.yaml
+++ b/backend/app/plugins/stocksdk/plugin.yaml
@@ -9,6 +9,6 @@ display_name: "stock-sdk（第三方行情·合规风险自负）"
 runtime: node
 entry: app.plugins.stocksdk.provider:StockSDKProvider
 check: app.plugins.stocksdk.bridge:availability
-datasets: [daily, adj_factor, minute, realtime]
-description: "抓取第三方财经网站行情接口(存在版权与反爬风险,使用需自行评估合规责任)。日K/除权/分钟/实时全市场。需运行环境含 Node.js 18+。Docker 默认不打包。"
+datasets: [daily, adj_factor, minute, monthly, yearly, realtime]
+description: "抓取第三方财经网站行情接口(存在版权与反爬风险,使用需自行评估合规责任)。日K/除权/分钟/月年K/实时全市场。年K由月线聚合。需运行环境含 Node.js 18+。Docker 默认不打包。"
 install_hint: "Docker 需 --build-arg INCLUDE_STOCKSDK=1 才打包;开发模式: cd backend/app/plugins/stocksdk && npm install"

--- a/backend/app/plugins/stocksdk/provider.py
+++ b/backend/app/plugins/stocksdk/provider.py
@@ -10,6 +10,7 @@ Original implementation by @forrany (PR #57), migrated to plugin architecture.
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass, field
 from datetime import datetime
 
@@ -21,8 +22,9 @@ from app.tickflow.rate_limits import chunked
 
 logger = logging.getLogger(__name__)
 
-# stock-sdk 支持的数据集(financial 不支持 → 不声明, 自动回退 tickflow)
-_DATASETS = ("daily", "adj_factor", "minute", "realtime")
+# stock-sdk 支持的数据集(financial 不支持 → 不声明, 自动回退 tickflow;
+# 年 K 由月线聚合 → yearly)
+_DATASETS = ("daily", "adj_factor", "minute", "monthly", "yearly", "realtime")
 
 # 每次桥接调用的符号数。桥接内部按 concurrency 并发, 分批仅为进度反馈与超时控制。
 _BATCH = 40
@@ -42,6 +44,20 @@ class _StockSDKConfig:
 
 def _yyyymmdd(dt: datetime | None) -> str | None:
     return dt.strftime("%Y%m%d") if dt else None
+
+
+def _minute_concurrency(override: int | None = None) -> int:
+    if override and override > 0:
+        return min(32, override)
+    try:
+        return max(1, min(32, int(os.getenv("STOCKSDK_MINUTE_CONCURRENCY", "10"))))
+    except ValueError:
+        return 10
+
+
+def _minute_bridge_timeout(chunk_len: int, concurrency: int) -> int:
+    waves = max(1, (chunk_len + concurrency - 1) // concurrency)
+    return min(900, max(300, 60 + waves * 40))
 
 
 class StockSDKProvider:
@@ -82,6 +98,83 @@ class StockSDKProvider:
                 result = bridge.run_job(job, timeout=180)
             except bridge.StockSDKBridgeError as e:
                 logger.warning("stock-sdk daily 拉取失败(%d symbols): %s", len(chunk), e)
+                result = {"rows": {}}
+            for sym, rows in (result.get("rows") or {}).items():
+                if not rows:
+                    continue
+                df = normalize_daily(rows, default_symbol=sym, source=self.name)
+                if not df.is_empty():
+                    frames.append(df)
+            if on_chunk_done:
+                on_chunk_done(i + 1, len(chunks))
+        return pl.concat(frames, how="diagonal_relaxed") if frames else pl.DataFrame()
+
+    # ---- monthly (stock-sdk 月 K → kline_monthly) ----
+    def get_monthly(
+        self,
+        symbols: list[str],
+        start_time: datetime | None,
+        end_time: datetime | None,
+        asset_type: str = "stock",  # noqa: ARG002
+        on_chunk_done=None,
+    ) -> pl.DataFrame:
+        return self._get_history_period(
+            symbols,
+            start_time,
+            end_time,
+            period="monthly",
+            label="monthly",
+            on_chunk_done=on_chunk_done,
+        )
+
+    # ---- yearly (月线聚合 → kline_yearly) ----
+    def get_yearly(
+        self,
+        symbols: list[str],
+        start_time: datetime | None,
+        end_time: datetime | None,
+        asset_type: str = "stock",  # noqa: ARG002
+        on_chunk_done=None,
+    ) -> pl.DataFrame:
+        df = self.get_monthly(
+            symbols,
+            start_time,
+            end_time,
+            asset_type=asset_type,
+            on_chunk_done=on_chunk_done,
+        )
+        return _aggregate_monthly_to_yearly(df)
+
+    def _get_history_period(
+        self,
+        symbols: list[str],
+        start_time: datetime | None,
+        end_time: datetime | None,
+        *,
+        period: str,
+        label: str,
+        on_chunk_done=None,
+    ) -> pl.DataFrame:
+        if not symbols:
+            return pl.DataFrame()
+        logger.info("stock-sdk %s 拉取开始(%d symbols)", label, len(symbols))
+        frames: list[pl.DataFrame] = []
+        chunks = chunked(symbols, _BATCH)
+        conc = _minute_concurrency()
+        for i, chunk in enumerate(chunks):
+            job = {
+                "op": "daily",
+                "symbols": chunk,
+                "period": period,
+                "adjust": "none",
+                "start": _yyyymmdd(start_time),
+                "end": _yyyymmdd(end_time),
+                "concurrency": conc,
+            }
+            try:
+                result = bridge.run_job(job, timeout=_minute_bridge_timeout(len(chunk), conc))
+            except bridge.StockSDKBridgeError as e:
+                logger.warning("stock-sdk %s 拉取失败(%d symbols): %s", label, len(chunk), e)
                 result = {"rows": {}}
             for sym, rows in (result.get("rows") or {}).items():
                 if not rows:
@@ -231,6 +324,12 @@ class StockSDKProvider:
         if dataset == "minute":
             df = self.get_minute(symbols, None, None)
             return _preview("minute", df)
+        if dataset == "monthly":
+            df = self.get_monthly(symbols, None, None)
+            return _preview("monthly", df)
+        if dataset == "yearly":
+            df = self.get_yearly(symbols, None, None)
+            return _preview("yearly", df)
         if dataset == "realtime":
             rows = self.get_realtime()
             head = rows[:5]
@@ -248,7 +347,37 @@ def _preview(dataset: str, df: pl.DataFrame) -> dict:
     return {
         "provider": "stocksdk",
         "dataset": dataset,
-        "rows": df.height,
-        "columns": df.columns,
+        "rows": int(df.height),
+        "columns": list(df.columns),
         "preview": df.head(5).to_dicts() if not df.is_empty() else [],
     }
+
+
+def _aggregate_monthly_to_yearly(df: pl.DataFrame) -> pl.DataFrame:
+    """把月 K 聚合成年 K（日历年）：首开/最高/最低/尾收，量额求和。"""
+    if df.is_empty() or "date" not in df.columns or "symbol" not in df.columns:
+        return df
+    work = df
+    if work.schema.get("date") != pl.Date:
+        work = work.with_columns(pl.col("date").cast(pl.Date))
+    aggs = [
+        pl.col("date").max().alias("date"),
+        pl.col("open").first().alias("open"),
+        pl.col("high").max().alias("high"),
+        pl.col("low").min().alias("low"),
+        pl.col("close").last().alias("close"),
+        pl.col("volume").sum().alias("volume"),
+    ]
+    if "amount" in work.columns:
+        aggs.append(pl.col("amount").sum().alias("amount"))
+    if "quote_ts" in work.columns:
+        aggs.append(pl.col("quote_ts").last().alias("quote_ts"))
+    out = (
+        work.sort(["symbol", "date"])
+        .with_columns(pl.col("date").dt.year().alias("_year"))
+        .group_by(["symbol", "_year"], maintain_order=True)
+        .agg(aggs)
+        .drop("_year")
+        .sort(["symbol", "date"])
+    )
+    return out

--- a/backend/app/services/monthly_sync.py
+++ b/backend/app/services/monthly_sync.py
@@ -1,0 +1,64 @@
+"""月 K 同步 (stock-sdk period=monthly → kline_monthly/)。"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import date
+
+from app.services.period_kline_sync import (
+    PeriodKlineKind,
+    backfill_period_range,
+    refresh_period_view,
+    sync_and_persist_period,
+)
+from app.services import preferences
+from app.services.period_kline_access import period_provider_active
+from app.tickflow.repository import KlineRepository
+
+KLINE_MONTHLY_SUBDIR = "kline_monthly"
+KLINE_MONTHLY_VIEW = "kline_monthly"
+
+_MONTHLY = PeriodKlineKind(
+    dataset="monthly",
+    subdir=KLINE_MONTHLY_SUBDIR,
+    view=KLINE_MONTHLY_VIEW,
+    getter_name="get_monthly",
+    provider_getter=preferences.get_monthly_data_provider,
+    provider_active=lambda: period_provider_active("monthly"),
+    default_window=24,
+    max_window=120,
+    approx_days=31,
+    chunk_env="STOCKSDK_MONTHLY_BATCH",
+)
+
+
+def refresh_monthly_view(repo: KlineRepository) -> None:
+    refresh_period_view(repo, subdir=KLINE_MONTHLY_SUBDIR, view=KLINE_MONTHLY_VIEW)
+
+
+def sync_and_persist_monthly(
+    symbols: list[str],
+    repo: KlineRepository,
+    months: int = 24,
+    on_chunk_done: Callable[[int, int], None] | None = None,
+) -> int:
+    return sync_and_persist_period(
+        _MONTHLY, symbols, repo, window=months, on_chunk_done=on_chunk_done
+    )
+
+
+def backfill_monthly_range(
+    symbols: list[str],
+    repo: KlineRepository,
+    *,
+    start_date: date,
+    end_date: date,
+    on_chunk_done: Callable[[int, int], None] | None = None,
+) -> tuple[int, int]:
+    return backfill_period_range(
+        _MONTHLY,
+        symbols,
+        repo,
+        start_date=start_date,
+        end_date=end_date,
+        on_chunk_done=on_chunk_done,
+    )

--- a/backend/app/services/period_kline_access.py
+++ b/backend/app/services/period_kline_access.py
@@ -1,0 +1,46 @@
+"""月/年 K 访问权限（TickFlow 不提供，仅插件源如 stock-sdk）。"""
+from __future__ import annotations
+
+
+def _provider_has(dataset: str, provider: str) -> bool:
+    if provider == "tickflow":
+        return False
+    from app.data_providers import custom as custom_sources
+
+    return custom_sources.provider_has_dataset(provider, dataset)
+
+
+def period_provider_active(dataset: str) -> bool:
+    from app.services import preferences
+
+    if dataset == "monthly":
+        provider = preferences.get_monthly_data_provider()
+    elif dataset == "yearly":
+        provider = preferences.get_yearly_data_provider()
+    else:
+        return False
+    if provider == "tickflow":
+        return False
+    return _provider_has(dataset, provider)
+
+
+def monthly_access_flags(capset) -> dict:  # noqa: ARG001
+    from app.services import preferences
+
+    active = period_provider_active("monthly")
+    return {
+        "monthly_access": active,
+        "monthly_provider": preferences.get_monthly_data_provider(),
+        "monthly_provider_active": active,
+    }
+
+
+def yearly_access_flags(capset) -> dict:  # noqa: ARG001
+    from app.services import preferences
+
+    active = period_provider_active("yearly")
+    return {
+        "yearly_access": active,
+        "yearly_provider": preferences.get_yearly_data_provider(),
+        "yearly_provider_active": active,
+    }

--- a/backend/app/services/period_kline_sync.py
+++ b/backend/app/services/period_kline_sync.py
@@ -1,0 +1,179 @@
+"""日/周以外周期 K 线（月/年）共用同步逻辑。按 date 分区，模型对齐 kline_weekly。"""
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+
+import polars as pl
+
+from app.market_time import cn_now, last_cn_weekday
+from app.tickflow.rate_limits import chunked
+from app.tickflow.repository import KlineRepository
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PeriodKlineKind:
+    dataset: str
+    subdir: str
+    view: str
+    getter_name: str
+    provider_getter: Callable[[], str]
+    provider_active: Callable[[], bool]
+    default_window: int
+    max_window: int
+    """最近同步向前看的自然日跨度 ≈ window * approx_days。"""
+    approx_days: int
+    chunk_env: str
+    default_chunk: int = 80
+
+
+def _chunk_size(kind: PeriodKlineKind) -> int:
+    try:
+        return max(20, int(os.getenv(kind.chunk_env, str(kind.default_chunk))))
+    except ValueError:
+        return kind.default_chunk
+
+
+def sync_period_batch(
+    kind: PeriodKlineKind,
+    symbols: list[str],
+    start_time: datetime | None = None,
+    end_time: datetime | None = None,
+    on_chunk_done: Callable[[int, int], None] | None = None,
+) -> pl.DataFrame:
+    if not kind.provider_active() or not symbols:
+        return pl.DataFrame()
+    provider_name = kind.provider_getter()
+    from app.data_providers import custom as custom_sources
+
+    if not custom_sources.provider_has_dataset(provider_name, kind.dataset):
+        return pl.DataFrame()
+    provider = custom_sources.get_provider(provider_name)
+    getter = getattr(provider, kind.getter_name, None)
+    if getter is None:
+        return pl.DataFrame()
+    return getter(
+        symbols,
+        start_time=start_time,
+        end_time=end_time,
+        on_chunk_done=on_chunk_done,
+    )
+
+
+def refresh_period_view(
+    repo: KlineRepository,
+    *,
+    subdir: str,
+    view: str,
+) -> None:
+    try:
+        d = repo.store.data_dir.as_posix()
+        repo.db.execute(
+            f"""CREATE OR REPLACE VIEW {view} AS
+                SELECT * FROM read_parquet('{d}/{subdir}/**/*.parquet', union_by_name=true)"""
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("refresh %s view failed: %s", view, e)
+
+
+def persist_period_frame(
+    df: pl.DataFrame,
+    repo: KlineRepository,
+    *,
+    subdir: str,
+    view: str,
+    refresh_view: bool = True,
+) -> int:
+    if df.is_empty() or "date" not in df.columns:
+        return 0
+    repo.append_period_kline(df, subdir)
+    if refresh_view:
+        refresh_period_view(repo, subdir=subdir, view=view)
+    return int(df.height)
+
+
+def _sync_persist_chunks(
+    kind: PeriodKlineKind,
+    symbols: list[str],
+    repo: KlineRepository,
+    *,
+    start_time: datetime,
+    end_time: datetime,
+    on_chunk_done: Callable[[int, int], None] | None = None,
+) -> tuple[int, int]:
+    chunks = list(chunked(symbols, _chunk_size(kind)))
+    if not chunks:
+        return 0, 0
+    total_written = 0
+    total_fetched = 0
+    for i, chunk in enumerate(chunks):
+        df = sync_period_batch(
+            kind,
+            chunk,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        total_fetched += int(df.height)
+        is_last = i == len(chunks) - 1
+        total_written += persist_period_frame(
+            df, repo, subdir=kind.subdir, view=kind.view, refresh_view=is_last
+        )
+        if on_chunk_done:
+            on_chunk_done(i + 1, len(chunks))
+    return total_written, total_fetched
+
+
+def sync_and_persist_period(
+    kind: PeriodKlineKind,
+    symbols: list[str],
+    repo: KlineRepository,
+    window: int,
+    on_chunk_done: Callable[[int, int], None] | None = None,
+) -> int:
+    if not kind.provider_active() or not symbols:
+        return 0
+    now = cn_now().replace(tzinfo=None)
+    end_d = min(last_cn_weekday(now.date()), repo.latest_daily_date() or now.date())
+    last_d = repo.latest_period_kline_date(kind.view)
+    step = max(7, kind.approx_days // 4)
+    if last_d:
+        start_d = last_d - timedelta(days=step)
+    else:
+        start_d = end_d - timedelta(days=max(step, max(1, window) * kind.approx_days))
+    start_time = datetime.combine(start_d, time.min)
+    end_time = datetime.combine(end_d, time(23, 59, 59))
+    written, _ = _sync_persist_chunks(
+        kind,
+        symbols,
+        repo,
+        start_time=start_time,
+        end_time=end_time,
+        on_chunk_done=on_chunk_done,
+    )
+    return written
+
+
+def backfill_period_range(
+    kind: PeriodKlineKind,
+    symbols: list[str],
+    repo: KlineRepository,
+    *,
+    start_date: date,
+    end_date: date,
+    on_chunk_done: Callable[[int, int], None] | None = None,
+) -> tuple[int, int]:
+    start_time = datetime.combine(start_date, time.min)
+    end_time = datetime.combine(end_date, time(23, 59, 59))
+    return _sync_persist_chunks(
+        kind,
+        symbols,
+        repo,
+        start_time=start_time,
+        end_time=end_time,
+        on_chunk_done=on_chunk_done,
+    )

--- a/backend/app/services/preferences.py
+++ b/backend/app/services/preferences.py
@@ -213,6 +213,36 @@ def get_minute_data_provider() -> str:
     return provider if provider in _allowed_data_providers() else "tickflow"
 
 
+def get_monthly_data_provider() -> str:
+    provider = str(load().get("monthly_data_provider", "stocksdk") or "stocksdk").lower()
+    if provider == "tickflow":
+        return "stocksdk"
+    return provider if provider in _allowed_data_providers() else "stocksdk"
+
+
+def get_monthly_sync_enabled() -> bool:
+    return load().get("monthly_sync_enabled", False)
+
+
+def get_monthly_sync_months() -> int:
+    return max(1, min(120, load().get("monthly_sync_months", 24)))
+
+
+def get_yearly_data_provider() -> str:
+    provider = str(load().get("yearly_data_provider", "stocksdk") or "stocksdk").lower()
+    if provider == "tickflow":
+        return "stocksdk"
+    return provider if provider in _allowed_data_providers() else "stocksdk"
+
+
+def get_yearly_sync_enabled() -> bool:
+    return load().get("yearly_sync_enabled", False)
+
+
+def get_yearly_sync_years() -> int:
+    return max(1, min(40, load().get("yearly_sync_years", 10)))
+
+
 def get_realtime_data_provider() -> str:
     provider = str(load().get("realtime_data_provider", "tickflow") or "tickflow").lower()
     return provider if provider in _allowed_data_providers() else "tickflow"

--- a/backend/app/services/yearly_sync.py
+++ b/backend/app/services/yearly_sync.py
@@ -1,0 +1,64 @@
+"""年 K 同步：由 stock-sdk 月线在 provider 内聚合 → kline_yearly/。"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import date
+
+from app.services.period_kline_sync import (
+    PeriodKlineKind,
+    backfill_period_range,
+    refresh_period_view,
+    sync_and_persist_period,
+)
+from app.services import preferences
+from app.services.period_kline_access import period_provider_active
+from app.tickflow.repository import KlineRepository
+
+KLINE_YEARLY_SUBDIR = "kline_yearly"
+KLINE_YEARLY_VIEW = "kline_yearly"
+
+_YEARLY = PeriodKlineKind(
+    dataset="yearly",
+    subdir=KLINE_YEARLY_SUBDIR,
+    view=KLINE_YEARLY_VIEW,
+    getter_name="get_yearly",
+    provider_getter=preferences.get_yearly_data_provider,
+    provider_active=lambda: period_provider_active("yearly"),
+    default_window=10,
+    max_window=40,
+    approx_days=365,
+    chunk_env="STOCKSDK_YEARLY_BATCH",
+)
+
+
+def refresh_yearly_view(repo: KlineRepository) -> None:
+    refresh_period_view(repo, subdir=KLINE_YEARLY_SUBDIR, view=KLINE_YEARLY_VIEW)
+
+
+def sync_and_persist_yearly(
+    symbols: list[str],
+    repo: KlineRepository,
+    years: int = 10,
+    on_chunk_done: Callable[[int, int], None] | None = None,
+) -> int:
+    return sync_and_persist_period(
+        _YEARLY, symbols, repo, window=years, on_chunk_done=on_chunk_done
+    )
+
+
+def backfill_yearly_range(
+    symbols: list[str],
+    repo: KlineRepository,
+    *,
+    start_date: date,
+    end_date: date,
+    on_chunk_done: Callable[[int, int], None] | None = None,
+) -> tuple[int, int]:
+    return backfill_period_range(
+        _YEARLY,
+        symbols,
+        repo,
+        start_date=start_date,
+        end_date=end_date,
+        on_chunk_done=on_chunk_done,
+    )

--- a/backend/app/tickflow/repository.py
+++ b/backend/app/tickflow/repository.py
@@ -158,6 +158,10 @@ class DataStore:
                 SELECT * FROM read_parquet('{d}/kline_etf_minute/**/*.parquet', union_by_name=true)""",
             f"""CREATE OR REPLACE VIEW kline_minute AS
                 SELECT * FROM read_parquet('{d}/kline_minute/**/*.parquet', union_by_name=true)""",
+            f"""CREATE OR REPLACE VIEW kline_monthly AS
+                SELECT * FROM read_parquet('{d}/kline_monthly/**/*.parquet', union_by_name=true)""",
+            f"""CREATE OR REPLACE VIEW kline_yearly AS
+                SELECT * FROM read_parquet('{d}/kline_yearly/**/*.parquet', union_by_name=true)""",
             f"""CREATE OR REPLACE VIEW adj_factor AS
                 SELECT * FROM read_parquet('{d}/adj_factor/**/*.parquet', union_by_name=true)""",
             f"""CREATE OR REPLACE VIEW adj_factor_etf AS
@@ -1612,6 +1616,38 @@ class KlineRepository:
         if df.is_empty():
             return
         self._write_daily_partition(df, "kline_daily")
+
+    def append_period_kline(self, df: pl.DataFrame, subdir: str) -> None:
+        """按 date 分区写入月/年等周期 K 线。"""
+        if df.is_empty():
+            return
+        self._write_daily_partition(df, subdir)
+
+    def earliest_period_kline_date(self, subdir: str) -> date | None:
+        """本地周期 K 最早分区 date=。"""
+        period_dir = self.store.data_dir / subdir
+        if not period_dir.exists():
+            return None
+        dates: list[str] = []
+        for d in period_dir.iterdir():
+            if d.is_dir() and d.name.startswith("date="):
+                dates.append(d.name[5:])
+        if not dates:
+            return None
+        dates.sort()
+        return date.fromisoformat(dates[0])
+
+    def latest_period_kline_date(self, view: str) -> date | None:
+        """本地周期 K 最新日期（DuckDB 视图）。"""
+        try:
+            with self._lock:
+                res = self.db.execute(f"SELECT max(date) FROM {view}").fetchone()
+            if res and res[0]:
+                d = res[0]
+                return d if isinstance(d, date) else date.fromisoformat(str(d))
+        except Exception:
+            return None
+        return None
 
     def append_enriched(self, df: pl.DataFrame) -> None:
         """按日分区写入 enriched 数据 (merge-upsert)。磁盘仅写入 14 列存储列。"""

--- a/backend/tests/test_period_kline_monthly_yearly.py
+++ b/backend/tests/test_period_kline_monthly_yearly.py
@@ -1,0 +1,66 @@
+"""月线聚合年线 + period access flags."""
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+
+from app.plugins.stocksdk.provider import _aggregate_monthly_to_yearly
+from app.services.period_kline_access import monthly_access_flags, yearly_access_flags
+
+
+def test_aggregate_monthly_to_yearly_ohlcv():
+    df = pl.DataFrame(
+        {
+            "symbol": ["600519.SH"] * 4,
+            "date": [
+                date(2024, 1, 31),
+                date(2024, 6, 30),
+                date(2024, 12, 31),
+                date(2025, 3, 31),
+            ],
+            "open": [100.0, 110.0, 120.0, 130.0],
+            "high": [105.0, 115.0, 125.0, 135.0],
+            "low": [95.0, 105.0, 115.0, 125.0],
+            "close": [102.0, 112.0, 122.0, 132.0],
+            "volume": [10.0, 20.0, 30.0, 40.0],
+            "amount": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+    out = _aggregate_monthly_to_yearly(df)
+    assert out.height == 2
+    y2024 = out.filter(pl.col("date").dt.year() == 2024).row(0, named=True)
+    assert y2024["open"] == 100.0
+    assert y2024["high"] == 125.0
+    assert y2024["low"] == 95.0
+    assert y2024["close"] == 122.0
+    assert y2024["volume"] == 60.0
+    assert y2024["amount"] == 6.0
+    assert y2024["date"].isoformat() == "2024-12-31"
+
+
+def test_aggregate_empty():
+    empty = pl.DataFrame({"symbol": [], "date": [], "open": [], "close": []})
+    assert _aggregate_monthly_to_yearly(empty).is_empty()
+
+
+def test_monthly_yearly_access_flags_structure(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.period_kline_access.period_provider_active",
+        lambda dataset: dataset in ("monthly", "yearly"),
+    )
+    monkeypatch.setattr(
+        "app.services.preferences.get_monthly_data_provider",
+        lambda: "stocksdk",
+    )
+    monkeypatch.setattr(
+        "app.services.preferences.get_yearly_data_provider",
+        lambda: "stocksdk",
+    )
+    m = monthly_access_flags(None)
+    assert m["monthly_access"] is True
+    assert m["monthly_provider"] == "stocksdk"
+    assert m["monthly_provider_active"] is True
+    y = yearly_access_flags(None)
+    assert y["yearly_access"] is True
+    assert y["yearly_provider"] == "stocksdk"

--- a/frontend/src/components/data/ActiveJobCard.tsx
+++ b/frontend/src/components/data/ActiveJobCard.tsx
@@ -13,8 +13,12 @@ export const STAGE_LABELS: Record<string, string> = {
   sync_adj: '同步除权因子',
   compute_enriched: '计算技术指标',
   sync_minute: '同步分钟 K',
+  sync_monthly: '同步月 K',
+  sync_yearly: '同步年 K',
   extend_history: '扩展日K历史',
   extend_minute: '扩展分钟K历史',
+  extend_monthly: '扩展月K历史',
+  extend_yearly: '扩展年K历史',
   rebuild_enriched: '全量计算',
   refresh_views: '刷新视图',
   done: '完成',
@@ -122,6 +126,8 @@ export function ActiveJobCard({ job }: { job: PipelineJob }) {
             <Pill label="除权因子" value={cell('sync_adj', `${job.result.adj_factor_symbols ?? 0} 只`)} />
             <Pill label="enriched" value={cell(null, `${job.result.enriched_days ?? 0} 行`)} />
             <Pill label="分钟K" value={cell('sync_minute', `${job.result.minute_rows ?? 0} 行`)} />
+            <Pill label="月K" value={cell('sync_monthly', `${job.result.monthly_rows ?? 0} 行`)} />
+            <Pill label="年K" value={cell('sync_yearly', `${job.result.yearly_rows ?? 0} 行`)} />
           </div>
         )
       })()}

--- a/frontend/src/components/data/MonthlySyncConfig.tsx
+++ b/frontend/src/components/data/MonthlySyncConfig.tsx
@@ -1,0 +1,250 @@
+import { useState, useEffect } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Loader2 } from 'lucide-react'
+import { api, type CapabilitiesResponse } from '@/lib/api'
+import { QK } from '@/lib/queryKeys'
+import { hasMonthlyAccess } from '@/lib/periodAccess'
+
+export function MonthlySyncConfig({
+  caps,
+  onJobStart,
+}: {
+  caps: CapabilitiesResponse | undefined
+  onJobStart?: (jobId: string) => void
+}) {
+  const qc = useQueryClient()
+  const prefs = useQuery({
+    queryKey: QK.preferences,
+    queryFn: api.preferences,
+  })
+  const update = useMutation({
+    mutationFn: ({ enabled, months }: { enabled: boolean; months: number }) =>
+      api.updateMonthlySync(enabled, months),
+    onSuccess: () => qc.invalidateQueries({ queryKey: QK.preferences }),
+  })
+
+  const hasAccess = hasMonthlyAccess(caps)
+  const enabled = prefs.data?.monthly_sync_enabled ?? false
+  const months = prefs.data?.monthly_sync_months ?? 24
+  const [localMonths, setLocalMonths] = useState(months)
+  const [isRunning, setIsRunning] = useState(false)
+
+  useEffect(() => { setLocalMonths(months) }, [months])
+
+  const handleToggle = () => {
+    if (!hasAccess) return
+    update.mutate({ enabled: !enabled, months: localMonths })
+  }
+
+  const handleJobStart = (jobId?: string) => {
+    setIsRunning(true)
+    if (jobId && onJobStart) onJobStart(jobId)
+  }
+
+  return (
+    <div className="px-4 pb-4 pt-3 border-t border-accent/20 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2.5">
+          <button
+            onClick={handleToggle}
+            disabled={!hasAccess}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors duration-200 shrink-0 ${
+              enabled ? 'bg-accent shadow-[0_0_6px_rgba(61,214,140,0.3)]' : 'bg-elevated'
+            } ${!hasAccess ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'}`}
+          >
+            <span
+              className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform duration-200 ${
+                enabled ? 'translate-x-[18px]' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+          <span className="text-xs text-foreground font-medium">
+            {enabled ? '自动同步' : '已关闭'}
+          </span>
+        </div>
+        {!hasAccess && (
+          <span className="text-[10px] text-warning/80 bg-warning/8 rounded px-1.5 py-px font-medium">
+            需 stock-sdk 等源
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] text-secondary">同步月数</span>
+        <div className="flex items-center gap-2">
+          <div className="flex items-center">
+            <button
+              onClick={() => { const v = Math.max(1, localMonths - 1); setLocalMonths(v); update.mutate({ enabled, months: v }) }}
+              disabled={!hasAccess || !enabled || localMonths <= 1}
+              className="h-6 w-6 flex items-center justify-center rounded-l-btn bg-elevated border border-border text-secondary hover:bg-border/50 disabled:opacity-30 transition-colors text-xs"
+            >
+              −
+            </button>
+            <div
+              className={`h-6 w-10 flex items-center justify-center border-y border-border text-[11px] font-mono tabular-nums ${
+                enabled ? 'text-foreground bg-base' : 'text-muted bg-elevated/50'
+              }`}
+            >
+              {localMonths}
+            </div>
+            <button
+              onClick={() => { const v = Math.min(120, localMonths + 1); setLocalMonths(v); update.mutate({ enabled, months: v }) }}
+              disabled={!hasAccess || !enabled || localMonths >= 120}
+              className="h-6 w-6 flex items-center justify-center rounded-r-btn bg-elevated border border-border text-secondary hover:bg-border/50 disabled:opacity-30 transition-colors text-xs"
+            >
+              +
+            </button>
+          </div>
+          <span className="text-[10px] text-muted">月</span>
+        </div>
+      </div>
+
+      <div className="pt-2 border-t border-border space-y-2.5">
+        <div className="text-[10px] text-secondary">向前扩展历史数据</div>
+        <MonthlyExtendControls
+          hasAccess={hasAccess}
+          isRunning={isRunning}
+          onStart={handleJobStart}
+        />
+      </div>
+
+      <div className="pt-2 border-t border-border space-y-2.5">
+        <div className="text-[10px] text-secondary">立即同步</div>
+        <MonthlySyncNow
+          hasAccess={hasAccess}
+          isRunning={isRunning}
+          onStart={handleJobStart}
+        />
+      </div>
+
+      <div className="text-[10px] text-muted">
+        月 K · 独立存储于 kline_monthly · stock-sdk period=monthly
+      </div>
+    </div>
+  )
+}
+
+function MonthlyExtendControls({
+  hasAccess,
+  isRunning,
+  onStart,
+}: {
+  hasAccess: boolean
+  isRunning: boolean
+  onStart: (jobId?: string) => void
+}) {
+  const qc = useQueryClient()
+  const [value, setValue] = useState(1)
+
+  const dataStatus = useQuery({
+    queryKey: QK.dataStatus,
+    queryFn: api.dataStatus,
+  })
+  const earliestDate = dataStatus.data?.monthly?.earliest_date ?? null
+  const hasData = !!earliestDate
+
+  const extend = useMutation({
+    mutationFn: () => api.extendMonthlyHistory(value, 'year'),
+    onSuccess: (data) => {
+      onStart(data.job_id)
+      qc.invalidateQueries({ queryKey: QK.pipelineJobs })
+      qc.invalidateQueries({ queryKey: QK.dataStatus })
+    },
+  })
+
+  const estimate = earliestDate
+    ? (() => {
+        const d = new Date(earliestDate)
+        d.setDate(d.getDate() - value * 365)
+        return d.toISOString().slice(0, 10)
+      })()
+    : null
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <div className="flex items-center">
+          <button
+            onClick={() => setValue(Math.max(1, value - 1))}
+            disabled={!hasAccess || isRunning || extend.isPending}
+            className="h-6 w-6 flex items-center justify-center rounded-l-btn bg-elevated border border-border text-secondary hover:bg-border/50 disabled:opacity-30 transition-colors text-xs"
+          >
+            −
+          </button>
+          <div className="h-6 w-8 flex items-center justify-center border-y border-border text-[11px] font-mono tabular-nums text-foreground bg-base">
+            {value}
+          </div>
+          <button
+            onClick={() => setValue(Math.min(10, value + 1))}
+            disabled={!hasAccess || isRunning || extend.isPending || value >= 10}
+            className="h-6 w-6 flex items-center justify-center rounded-r-btn bg-elevated border border-border text-secondary hover:bg-border/50 disabled:opacity-30 transition-colors text-xs"
+          >
+            +
+          </button>
+        </div>
+        <span className="text-[10px] text-muted">年</span>
+      </div>
+
+      {estimate && (
+        <div className="text-[10px] text-muted">
+          预计扩展至 <span className="font-mono text-secondary">{estimate}</span>
+          {earliestDate && (
+            <span> (当前最早: <span className="font-mono text-secondary">{earliestDate}</span>)</span>
+          )}
+        </div>
+      )}
+
+      {!hasData && (
+        <div className="text-[10px] text-muted">
+          请先使用下方「同步最近月 K」获取基础数据, 再向前扩展历史。
+        </div>
+      )}
+
+      <button
+        onClick={() => extend.mutate()}
+        disabled={!hasAccess || !hasData || isRunning || extend.isPending}
+        className="w-full inline-flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-btn bg-accent/90 text-base text-xs font-medium hover:bg-accent disabled:opacity-40 disabled:pointer-events-none transition-colors duration-150"
+      >
+        {extend.isPending ? (
+          <><Loader2 className="h-3 w-3 animate-spin" />请求中…</>
+        ) : (
+          <>获取数据</>
+        )}
+      </button>
+    </>
+  )
+}
+
+function MonthlySyncNow({
+  hasAccess,
+  isRunning,
+  onStart,
+}: {
+  hasAccess: boolean
+  isRunning: boolean
+  onStart: (jobId?: string) => void
+}) {
+  const qc = useQueryClient()
+  const sync = useMutation({
+    mutationFn: api.syncMonthly,
+    onSuccess: (data) => {
+      onStart(data.job_id)
+      qc.invalidateQueries({ queryKey: QK.pipelineJobs })
+      qc.invalidateQueries({ queryKey: QK.dataStatus })
+    },
+  })
+
+  return (
+    <button
+      onClick={() => sync.mutate()}
+      disabled={!hasAccess || isRunning || sync.isPending}
+      className="w-full inline-flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-btn bg-elevated border border-border text-secondary text-xs font-medium hover:bg-border/50 hover:text-foreground disabled:opacity-40 disabled:pointer-events-none transition-colors duration-150"
+    >
+      {sync.isPending ? (
+        <><Loader2 className="h-3 w-3 animate-spin" />启动中…</>
+      ) : (
+        <>同步最近月 K</>
+      )}
+    </button>
+  )
+}

--- a/frontend/src/components/data/PageSettingsModal.tsx
+++ b/frontend/src/components/data/PageSettingsModal.tsx
@@ -18,10 +18,12 @@ import {
 import { CSS } from '@dnd-kit/utilities'
 import { Check, GripVertical } from 'lucide-react'
 import { storage } from '@/lib/storage'
+import type { CapabilitiesResponse } from '@/lib/api'
+import { hasMonthlyAccess, hasYearlyAccess } from '@/lib/periodAccess'
 
 export type CardKey =
   | 'instruments' | 'daily' | 'adj_factor' | 'enriched'
-  | 'index' | 'etf' | 'minute' | 'financials'
+  | 'index' | 'etf' | 'minute' | 'monthly' | 'yearly' | 'financials'
 
 interface CardDef {
   key: CardKey
@@ -42,6 +44,8 @@ export const DATA_CARD_DEFS: CardDef[] = [
   { key: 'index',       label: '指数',     desc: '主要市场指数日K',        defaultHiddenIfNoCap: false },
   { key: 'etf',         label: 'ETF',      desc: '场内交易基金日K',         defaultHiddenIfNoCap: false, defaultHidden: true },
   { key: 'minute',      label: '分钟 K',   desc: '分钟级K线(需 Pro+)',     defaultHiddenIfNoCap: true },
+  { key: 'monthly',     label: '月 K',     desc: 'stock-sdk 月线',         defaultHiddenIfNoCap: true },
+  { key: 'yearly',      label: '年 K',     desc: '月线聚合年线',           defaultHiddenIfNoCap: true },
   { key: 'financials',  label: '财务数据', desc: '财报数据(需 Expert)',    defaultHiddenIfNoCap: true },
 ]
 
@@ -55,6 +59,13 @@ const CAP_KEY_MAP: Partial<Record<CardKey, string>> = {
   financials: 'financial',
 }
 
+function _hasCardAccess(key: CardKey, caps?: CapabilitiesResponse): boolean {
+  if (key === 'monthly') return hasMonthlyAccess(caps)
+  if (key === 'yearly') return hasYearlyAccess(caps)
+  const capKey = CAP_KEY_MAP[key] ?? ''
+  return !capKey || !!caps?.capabilities?.[capKey]
+}
+
 /**
  * 读取卡片显隐状态。结合档位能力决定默认值:
  * - 用户显式设置过 → 用设置值
@@ -63,9 +74,8 @@ const CAP_KEY_MAP: Partial<Record<CardKey, string>> = {
  * - 其他 → 显示
  */
 export function getCardVisibility(
-  caps: Record<string, unknown> | undefined,
+  caps: CapabilitiesResponse | undefined,
 ): Record<string, boolean> {
-  const has = (capKey: string) => !capKey || !!caps?.[capKey]
   const override = storage.dataCardVisible.get({})
   const result: Record<string, boolean> = {}
   for (const def of DATA_CARD_DEFS) {
@@ -74,7 +84,7 @@ export function getCardVisibility(
     } else if (def.defaultHidden) {
       result[def.key] = false
     } else {
-      result[def.key] = def.defaultHiddenIfNoCap ? has(CAP_KEY_MAP[def.key] ?? '') : true
+      result[def.key] = def.defaultHiddenIfNoCap ? _hasCardAccess(def.key, caps) : true
     }
   }
   return result
@@ -100,7 +110,7 @@ export function getCardOrder(): CardKey[] {
 export function PageSettingsModal({
   caps,
 }: {
-  caps: Record<string, unknown> | undefined
+  caps: CapabilitiesResponse | undefined
 }) {
   const [visible, setVisible] = useState<Record<string, boolean>>(() => getCardVisibility(caps))
   const [order, setOrder] = useState<CardKey[]>(() => getCardOrder())

--- a/frontend/src/components/data/SchemaModal.tsx
+++ b/frontend/src/components/data/SchemaModal.tsx
@@ -9,6 +9,8 @@ const TABLE_TITLES: Record<string, string> = {
   adj_factor: '除权因子',
   enriched: 'Enriched',
   minute: '分钟 K',
+  monthly: '月 K',
+  yearly: '年 K',
   index_instruments: '指数维表',
   index_daily: '指数日 K',
   index_enriched: '指数 Enriched',

--- a/frontend/src/components/data/SectionTitle.tsx
+++ b/frontend/src/components/data/SectionTitle.tsx
@@ -42,6 +42,8 @@ export function HistoryRow({ job, onClick }: { job: any; onClick: () => void }) 
           if (r.daily_days != null) parts.push(`日K ${r.daily_days}日`)
           if (r.enriched_days != null) parts.push(`enriched ${r.enriched_days}行`)
           if (r.minute_rows != null) parts.push(`分钟K ${r.minute_rows}行`)
+          if (r.monthly_rows != null) parts.push(`月K ${r.monthly_rows}行`)
+          if (r.yearly_rows != null) parts.push(`年K ${r.yearly_rows}行`)
           if (r.earliest_after && r.earliest_before) {
             const a = String(r.earliest_after).slice(0, 10)
             const b = String(r.earliest_before).slice(0, 10)

--- a/frontend/src/components/data/StatCard.tsx
+++ b/frontend/src/components/data/StatCard.tsx
@@ -18,6 +18,8 @@ export const CARD_META: Record<string, {
   // ETF 复用日K批量能力(免费档 kline.daily.batch 即可),不显示档位徽章
   etf:         { capKey: 'kline.daily.batch',       tierReq: '' },
   minute:      { capKey: 'kline.minute.batch',      tierReq: 'Pro+' },
+  monthly:     { capKey: '',                        tierReq: '' },
+  yearly:      { capKey: '',                        tierReq: '' },
   financials:  { capKey: 'financial',                tierReq: 'Expert' },
 }
 

--- a/frontend/src/components/data/YearlySyncConfig.tsx
+++ b/frontend/src/components/data/YearlySyncConfig.tsx
@@ -1,0 +1,250 @@
+import { useState, useEffect } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Loader2 } from 'lucide-react'
+import { api, type CapabilitiesResponse } from '@/lib/api'
+import { QK } from '@/lib/queryKeys'
+import { hasYearlyAccess } from '@/lib/periodAccess'
+
+export function YearlySyncConfig({
+  caps,
+  onJobStart,
+}: {
+  caps: CapabilitiesResponse | undefined
+  onJobStart?: (jobId: string) => void
+}) {
+  const qc = useQueryClient()
+  const prefs = useQuery({
+    queryKey: QK.preferences,
+    queryFn: api.preferences,
+  })
+  const update = useMutation({
+    mutationFn: ({ enabled, years }: { enabled: boolean; years: number }) =>
+      api.updateYearlySync(enabled, years),
+    onSuccess: () => qc.invalidateQueries({ queryKey: QK.preferences }),
+  })
+
+  const hasAccess = hasYearlyAccess(caps)
+  const enabled = prefs.data?.yearly_sync_enabled ?? false
+  const years = prefs.data?.yearly_sync_years ?? 10
+  const [localYears, setLocalYears] = useState(years)
+  const [isRunning, setIsRunning] = useState(false)
+
+  useEffect(() => { setLocalYears(years) }, [years])
+
+  const handleToggle = () => {
+    if (!hasAccess) return
+    update.mutate({ enabled: !enabled, years: localYears })
+  }
+
+  const handleJobStart = (jobId?: string) => {
+    setIsRunning(true)
+    if (jobId && onJobStart) onJobStart(jobId)
+  }
+
+  return (
+    <div className="px-4 pb-4 pt-3 border-t border-accent/20 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2.5">
+          <button
+            onClick={handleToggle}
+            disabled={!hasAccess}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors duration-200 shrink-0 ${
+              enabled ? 'bg-accent shadow-[0_0_6px_rgba(61,214,140,0.3)]' : 'bg-elevated'
+            } ${!hasAccess ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'}`}
+          >
+            <span
+              className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform duration-200 ${
+                enabled ? 'translate-x-[18px]' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+          <span className="text-xs text-foreground font-medium">
+            {enabled ? '自动同步' : '已关闭'}
+          </span>
+        </div>
+        {!hasAccess && (
+          <span className="text-[10px] text-warning/80 bg-warning/8 rounded px-1.5 py-px font-medium">
+            需 stock-sdk 等源
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] text-secondary">同步年数</span>
+        <div className="flex items-center gap-2">
+          <div className="flex items-center">
+            <button
+              onClick={() => { const v = Math.max(1, localYears - 1); setLocalYears(v); update.mutate({ enabled, years: v }) }}
+              disabled={!hasAccess || !enabled || localYears <= 1}
+              className="h-6 w-6 flex items-center justify-center rounded-l-btn bg-elevated border border-border text-secondary hover:bg-border/50 disabled:opacity-30 transition-colors text-xs"
+            >
+              −
+            </button>
+            <div
+              className={`h-6 w-10 flex items-center justify-center border-y border-border text-[11px] font-mono tabular-nums ${
+                enabled ? 'text-foreground bg-base' : 'text-muted bg-elevated/50'
+              }`}
+            >
+              {localYears}
+            </div>
+            <button
+              onClick={() => { const v = Math.min(40, localYears + 1); setLocalYears(v); update.mutate({ enabled, years: v }) }}
+              disabled={!hasAccess || !enabled || localYears >= 40}
+              className="h-6 w-6 flex items-center justify-center rounded-r-btn bg-elevated border border-border text-secondary hover:bg-border/50 disabled:opacity-30 transition-colors text-xs"
+            >
+              +
+            </button>
+          </div>
+          <span className="text-[10px] text-muted">年</span>
+        </div>
+      </div>
+
+      <div className="pt-2 border-t border-border space-y-2.5">
+        <div className="text-[10px] text-secondary">向前扩展历史数据</div>
+        <YearlyExtendControls
+          hasAccess={hasAccess}
+          isRunning={isRunning}
+          onStart={handleJobStart}
+        />
+      </div>
+
+      <div className="pt-2 border-t border-border space-y-2.5">
+        <div className="text-[10px] text-secondary">立即同步</div>
+        <YearlySyncNow
+          hasAccess={hasAccess}
+          isRunning={isRunning}
+          onStart={handleJobStart}
+        />
+      </div>
+
+      <div className="text-[10px] text-muted">
+        年 K · 独立存储于 kline_yearly · 由月线聚合（日历年）
+      </div>
+    </div>
+  )
+}
+
+function YearlyExtendControls({
+  hasAccess,
+  isRunning,
+  onStart,
+}: {
+  hasAccess: boolean
+  isRunning: boolean
+  onStart: (jobId?: string) => void
+}) {
+  const qc = useQueryClient()
+  const [value, setValue] = useState(1)
+
+  const dataStatus = useQuery({
+    queryKey: QK.dataStatus,
+    queryFn: api.dataStatus,
+  })
+  const earliestDate = dataStatus.data?.yearly?.earliest_date ?? null
+  const hasData = !!earliestDate
+
+  const extend = useMutation({
+    mutationFn: () => api.extendYearlyHistory(value, 'year'),
+    onSuccess: (data) => {
+      onStart(data.job_id)
+      qc.invalidateQueries({ queryKey: QK.pipelineJobs })
+      qc.invalidateQueries({ queryKey: QK.dataStatus })
+    },
+  })
+
+  const estimate = earliestDate
+    ? (() => {
+        const d = new Date(earliestDate)
+        d.setDate(d.getDate() - value * 365)
+        return d.toISOString().slice(0, 10)
+      })()
+    : null
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <div className="flex items-center">
+          <button
+            onClick={() => setValue(Math.max(1, value - 1))}
+            disabled={!hasAccess || isRunning || extend.isPending}
+            className="h-6 w-6 flex items-center justify-center rounded-l-btn bg-elevated border border-border text-secondary hover:bg-border/50 disabled:opacity-30 transition-colors text-xs"
+          >
+            −
+          </button>
+          <div className="h-6 w-8 flex items-center justify-center border-y border-border text-[11px] font-mono tabular-nums text-foreground bg-base">
+            {value}
+          </div>
+          <button
+            onClick={() => setValue(Math.min(10, value + 1))}
+            disabled={!hasAccess || isRunning || extend.isPending || value >= 10}
+            className="h-6 w-6 flex items-center justify-center rounded-r-btn bg-elevated border border-border text-secondary hover:bg-border/50 disabled:opacity-30 transition-colors text-xs"
+          >
+            +
+          </button>
+        </div>
+        <span className="text-[10px] text-muted">年</span>
+      </div>
+
+      {estimate && (
+        <div className="text-[10px] text-muted">
+          预计扩展至 <span className="font-mono text-secondary">{estimate}</span>
+          {earliestDate && (
+            <span> (当前最早: <span className="font-mono text-secondary">{earliestDate}</span>)</span>
+          )}
+        </div>
+      )}
+
+      {!hasData && (
+        <div className="text-[10px] text-muted">
+          请先使用下方「同步最近年 K」获取基础数据, 再向前扩展历史。
+        </div>
+      )}
+
+      <button
+        onClick={() => extend.mutate()}
+        disabled={!hasAccess || !hasData || isRunning || extend.isPending}
+        className="w-full inline-flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-btn bg-accent/90 text-base text-xs font-medium hover:bg-accent disabled:opacity-40 disabled:pointer-events-none transition-colors duration-150"
+      >
+        {extend.isPending ? (
+          <><Loader2 className="h-3 w-3 animate-spin" />请求中…</>
+        ) : (
+          <>获取数据</>
+        )}
+      </button>
+    </>
+  )
+}
+
+function YearlySyncNow({
+  hasAccess,
+  isRunning,
+  onStart,
+}: {
+  hasAccess: boolean
+  isRunning: boolean
+  onStart: (jobId?: string) => void
+}) {
+  const qc = useQueryClient()
+  const sync = useMutation({
+    mutationFn: api.syncYearly,
+    onSuccess: (data) => {
+      onStart(data.job_id)
+      qc.invalidateQueries({ queryKey: QK.pipelineJobs })
+      qc.invalidateQueries({ queryKey: QK.dataStatus })
+    },
+  })
+
+  return (
+    <button
+      onClick={() => sync.mutate()}
+      disabled={!hasAccess || isRunning || sync.isPending}
+      className="w-full inline-flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-btn bg-elevated border border-border text-secondary text-xs font-medium hover:bg-border/50 hover:text-foreground disabled:opacity-40 disabled:pointer-events-none transition-colors duration-150"
+    >
+      {sync.isPending ? (
+        <><Loader2 className="h-3 w-3 animate-spin" />启动中…</>
+      ) : (
+        <>同步最近年 K</>
+      )}
+    </button>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -46,6 +46,12 @@ export interface CapabilityLimits {
 export interface CapabilitiesResponse {
   label: string
   capabilities: Record<string, CapabilityLimits>
+  monthly_access?: boolean
+  monthly_provider?: string
+  monthly_provider_active?: boolean
+  yearly_access?: boolean
+  yearly_provider?: string
+  yearly_provider_active?: boolean
 }
 
 // ===== Financials =====
@@ -807,9 +813,15 @@ export interface Preferences {
   minute_sync_enabled: boolean
   minute_sync_days: number
   minute_sync_segment_days: number
+  monthly_sync_enabled?: boolean
+  monthly_sync_months?: number
+  yearly_sync_enabled?: boolean
+  yearly_sync_years?: number
   daily_data_provider?: string
   adj_factor_provider?: string
   minute_data_provider?: string
+  monthly_data_provider?: string
+  yearly_data_provider?: string
   realtime_data_provider?: string
   financial_data_provider?: string
   realtime_watchlist_symbols?: string[]
@@ -956,8 +968,8 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ provider, dataset, symbols }),
     }),
-  updateDataProviders: (cfg: Partial<Pick<Preferences, 'daily_data_provider' | 'adj_factor_provider' | 'minute_data_provider' | 'realtime_data_provider' | 'financial_data_provider'>>) =>
-    request<Pick<Preferences, 'daily_data_provider' | 'adj_factor_provider' | 'minute_data_provider' | 'realtime_data_provider'>>(
+  updateDataProviders: (cfg: Partial<Pick<Preferences, 'daily_data_provider' | 'adj_factor_provider' | 'minute_data_provider' | 'monthly_data_provider' | 'yearly_data_provider' | 'realtime_data_provider' | 'financial_data_provider'>>) =>
+    request<Pick<Preferences, 'daily_data_provider' | 'adj_factor_provider' | 'minute_data_provider' | 'monthly_data_provider' | 'yearly_data_provider' | 'realtime_data_provider'>>(
       '/api/settings/preferences/data-providers',
       { method: 'PUT', body: JSON.stringify(cfg) },
     ),
@@ -969,6 +981,16 @@ export const api = {
         minute_sync_days: days,
         ...(segmentDays != null ? { minute_sync_segment_days: segmentDays } : {}),
       }),
+    }),
+  updateMonthlySync: (enabled: boolean, months: number) =>
+    request<Preferences>('/api/settings/preferences/monthly-sync', {
+      method: 'PUT',
+      body: JSON.stringify({ monthly_sync_enabled: enabled, monthly_sync_months: months }),
+    }),
+  updateYearlySync: (enabled: boolean, years: number) =>
+    request<Preferences>('/api/settings/preferences/yearly-sync', {
+      method: 'PUT',
+      body: JSON.stringify({ yearly_sync_enabled: enabled, yearly_sync_years: years }),
     }),
   updatePipelinePullTypes: (cfg: Partial<Pick<Preferences, 'pipeline_pull_a_share' | 'pipeline_pull_etf' | 'pipeline_pull_index'>>) =>
     request<{
@@ -1278,6 +1300,20 @@ export const api = {
     request<{ status: string; removed: number }>('/api/kline/clear_minute', {
       method: 'POST',
       body: JSON.stringify({ confirm: true }),
+    }),
+  syncMonthly: () =>
+    request<{ status: string; job_id: string }>('/api/kline/sync_monthly', { method: 'POST' }),
+  extendMonthlyHistory: (value: number, unit: 'year') =>
+    request<{ status: string; job_id: string }>('/api/kline/extend_monthly_history', {
+      method: 'POST',
+      body: JSON.stringify({ value, unit }),
+    }),
+  syncYearly: () =>
+    request<{ status: string; job_id: string }>('/api/kline/sync_yearly', { method: 'POST' }),
+  extendYearlyHistory: (value: number, unit: 'year') =>
+    request<{ status: string; job_id: string }>('/api/kline/extend_yearly_history', {
+      method: 'POST',
+      body: JSON.stringify({ value, unit }),
     }),
   extendHistory: (value: number, unit: 'day' | 'month' | 'year') =>
     request<{ status: string; job_id: string }>('/api/kline/extend_history', {
@@ -2086,6 +2122,10 @@ export interface PipelineJob {
     index_count?: number
     index_daily_rows?: number
     minute_rows: number
+    monthly_rows?: number
+    monthly_months?: number
+    yearly_rows?: number
+    yearly_years?: number
     skipped_stages?: string[]
   } | null
   error: string | null
@@ -2119,6 +2159,8 @@ export interface DataStatus {
   etf_enriched: TableStats | null
   etf_instruments: InstrumentsStats | null
   minute: TableStats | null
+  monthly: TableStats | null
+  yearly: TableStats | null
   adj_factor: TableStats | null
   instruments: InstrumentsStats | null
   financials: { rows: number; tables: Record<string, { rows: number; symbols: number }> } | null
@@ -2143,6 +2185,10 @@ export interface DataStatus {
     etf_adj_factor_size_mb?: number
     minute_files: number
     minute_size_mb: number
+    monthly_files?: number
+    monthly_size_mb?: number
+    yearly_files?: number
+    yearly_size_mb?: number
     adj_factor_files: number
     adj_factor_size_mb: number
     instruments_files: number

--- a/frontend/src/lib/periodAccess.ts
+++ b/frontend/src/lib/periodAccess.ts
@@ -1,0 +1,9 @@
+import type { CapabilitiesResponse } from './api'
+
+export function hasMonthlyAccess(caps?: CapabilitiesResponse | null): boolean {
+  return !!caps?.monthly_access
+}
+
+export function hasYearlyAccess(caps?: CapabilitiesResponse | null): boolean {
+  return !!caps?.yearly_access
+}

--- a/frontend/src/pages/Data.tsx
+++ b/frontend/src/pages/Data.tsx
@@ -43,6 +43,8 @@ import { ExtendHistoryPanel } from '@/components/data/ExtendHistoryPanel'
 import { RepairDailyPanel } from '@/components/data/RepairDailyPanel'
 import { EnrichedRebuildPanel } from '@/components/data/EnrichedRebuildPanel'
 import { MinuteSyncConfig } from '@/components/data/MinuteSyncConfig'
+import { MonthlySyncConfig } from '@/components/data/MonthlySyncConfig'
+import { YearlySyncConfig } from '@/components/data/YearlySyncConfig'
 import { PipelineScopeConfig } from '@/components/data/PipelineScopeConfig'
 import { PageSettingsModal, getCardVisibility, getCardOrder, type CardKey } from '@/components/data/PageSettingsModal'
 import { QuoteConfigCard } from '@/components/data/QuoteConfigCard'
@@ -176,6 +178,8 @@ export function Data() {
     adj_factor: 'adj_factor',
     etf: 'daily',        // ETF 复用日K能力
     minute: 'minute',
+    monthly: 'monthly',
+    yearly: 'yearly',
     financials: 'financial',
   }
   // 当前 custom 源支持的数据集集合
@@ -184,6 +188,8 @@ export function Data() {
     : new Set<string>()
   // 给定 tierKey, 返回 custom provider 显示名 (走 custom 时) 或 null (走 TickFlow)
   const getCustomProviderName = (tierKey: string): string | null => {
+    if (tierKey === 'monthly' && prefs.data?.monthly_data_provider === 'stocksdk') return 'stock-sdk'
+    if (tierKey === 'yearly' && prefs.data?.yearly_data_provider === 'stocksdk') return 'stock-sdk'
     if (activeProvider === 'tickflow') return null
     const ds = TIERKEY_TO_DATASET[tierKey]
     if (ds && activeCustomDatasets.has(ds)) return activeDataSourceName
@@ -191,6 +197,8 @@ export function Data() {
   }
 
   const minuteAuto = prefs.data?.minute_sync_enabled ?? false
+  const monthlyAuto = prefs.data?.monthly_sync_enabled ?? false
+  const yearlyAuto = prefs.data?.yearly_sync_enabled ?? false
   const pipelineSched = prefs.data?.pipeline_schedule ?? { hour: 15, minute: 30 }
   const instrumentsSched = prefs.data?.instruments_schedule ?? { hour: 9, minute: 10 }
   const indexDailyBatchSize = prefs.data?.index_daily_batch_size ?? 100
@@ -252,7 +260,7 @@ export function Data() {
     window.addEventListener('data-card-visible-change', handler)
     return () => window.removeEventListener('data-card-visible-change', handler)
   }, [])
-  const cardVisible = getCardVisibility(caps.data?.capabilities)
+  const cardVisible = getCardVisibility(caps.data)
   // 引用 cardVisibleTick 触发重渲染(避免 lint 警告)
   void cardVisibleTick
 
@@ -323,6 +331,10 @@ export function Data() {
     sync_index: 'index_daily',
     sync_minute: 'minute',
     extend_minute: 'minute',
+    sync_monthly: 'monthly',
+    extend_monthly: 'monthly',
+    sync_yearly: 'yearly',
+    extend_yearly: 'yearly',
   }
   const activeCard = isRunning && job.data ? STAGE_CARD[job.data.stage] ?? null : null
 
@@ -510,6 +522,48 @@ export function Data() {
             onShowFields={() => setSchemaTable('minute')}
             onSettings={hasData ? () => setOpenSettings(v => v === 'minute' ? null : 'minute') : undefined}
             settingsOpen={openSettings === 'minute'}
+          />
+        )
+      case 'monthly':
+        return (
+          <StatCard
+            title="月 K"
+            hint="stock-sdk 月线"
+            stats={s?.monthly}
+            loading={isLoading}
+            active={activeCard === 'monthly'}
+            done={doneStages.has('monthly')}
+            skipped={skippedCards.has('monthly')}
+            stagePct={activeCard === 'monthly' ? (job.data?.stage_pct ?? 0) : 0}
+            tierKey="monthly"
+            capLimits={caps.data?.capabilities}
+            tierLabel={caps.data?.label}
+            customProvider={getCustomProviderName('monthly')}
+            auto={monthlyAuto}
+            onShowFields={() => setSchemaTable('monthly')}
+            onSettings={hasData ? () => setOpenSettings(v => v === 'monthly' ? null : 'monthly') : undefined}
+            settingsOpen={openSettings === 'monthly'}
+          />
+        )
+      case 'yearly':
+        return (
+          <StatCard
+            title="年 K"
+            hint="月线聚合"
+            stats={s?.yearly}
+            loading={isLoading}
+            active={activeCard === 'yearly'}
+            done={doneStages.has('yearly')}
+            skipped={skippedCards.has('yearly')}
+            stagePct={activeCard === 'yearly' ? (job.data?.stage_pct ?? 0) : 0}
+            tierKey="yearly"
+            capLimits={caps.data?.capabilities}
+            tierLabel={caps.data?.label}
+            customProvider={getCustomProviderName('yearly')}
+            auto={yearlyAuto}
+            onShowFields={() => setSchemaTable('yearly')}
+            onSettings={hasData ? () => setOpenSettings(v => v === 'yearly' ? null : 'yearly') : undefined}
+            settingsOpen={openSettings === 'yearly'}
           />
         )
       case 'financials':
@@ -820,6 +874,8 @@ export function Data() {
                 { label: '除权因子', files: s?.storage.adj_factor_files,  size: s?.storage.adj_factor_size_mb },
                 { label: 'Enriched', files: s?.storage.enriched_files,    size: s?.storage.enriched_size_mb },
                 { label: '分钟 K',   files: s?.storage.minute_files,      size: s?.storage.minute_size_mb },
+                { label: '月 K',     files: s?.storage.monthly_files ?? 0, size: s?.storage.monthly_size_mb ?? 0 },
+                { label: '年 K',     files: s?.storage.yearly_files ?? 0,  size: s?.storage.yearly_size_mb ?? 0 },
                 { label: '财务数据', files: s?.storage.financials_files,   size: s?.storage.financials_size_mb },
               ].map((item) => (
                 <div key={item.label} className="flex items-center justify-between text-[11px]">
@@ -974,7 +1030,7 @@ export function Data() {
       <AnimatePresence>
         {openSettings === 'page-settings' && (
           <SettingsModal title="页面设置 · 数据画像卡片" onClose={() => setOpenSettings(null)}>
-            <PageSettingsModal caps={caps.data?.capabilities} />
+            <PageSettingsModal caps={caps.data} />
           </SettingsModal>
         )}
       </AnimatePresence>
@@ -1086,6 +1142,22 @@ export function Data() {
         {openSettings === 'minute' && (
           <SettingsModal title="分钟 K · 同步设置" onClose={() => setOpenSettings(null)}>
             <MinuteSyncConfig caps={caps.data} onJobStart={(jobId) => { setActiveJobId(jobId); setOpenSettings(null) }} />
+          </SettingsModal>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {openSettings === 'monthly' && (
+          <SettingsModal title="月 K · 同步设置" onClose={() => setOpenSettings(null)}>
+            <MonthlySyncConfig caps={caps.data} onJobStart={(jobId) => { setActiveJobId(jobId); setOpenSettings(null) }} />
+          </SettingsModal>
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {openSettings === 'yearly' && (
+          <SettingsModal title="年 K · 同步设置" onClose={() => setOpenSettings(null)}>
+            <YearlySyncConfig caps={caps.data} onJobStart={(jobId) => { setActiveJobId(jobId); setOpenSettings(null) }} />
           </SettingsModal>
         )}
       </AnimatePresence>

--- a/frontend/src/pages/settings/DataSources.tsx
+++ b/frontend/src/pages/settings/DataSources.tsx
@@ -50,6 +50,8 @@ export function SettingsDataSourcesPanel() {
           adj_factor_provider: 'same_as_daily',
           realtime_data_provider: 'tickflow',
           minute_data_provider: 'tickflow',
+          monthly_data_provider: 'tickflow',
+          yearly_data_provider: 'tickflow',
           financial_data_provider: 'tickflow',
         })
       }
@@ -65,6 +67,8 @@ export function SettingsDataSourcesPanel() {
         adj_factor_provider: 'same_as_daily', // 除权始终跟随日K
         realtime_data_provider: pick('realtime'),
         minute_data_provider: pick('minute'),
+        monthly_data_provider: pick('monthly'),
+        yearly_data_provider: pick('yearly'),
         financial_data_provider: pick('financial'),
       })
     },


### PR DESCRIPTION
## Summary
- **月线**: stock-sdk `period=monthly` → `kline_monthly/` parquet + sync/extend APIs
- **年线**: provider 内由月线本地聚合（自然年 OHLCV）→ `kline_yearly/`（非 SDK 原生年周期）
- 数据页新增月 K / 年 K StatCards、同步设置面板、capabilities access flags

## Test plan
- [ ] `pytest backend/tests/test_period_kline_monthly_yearly.py`
- [ ] 启用 stock-sdk 后 `/api/capabilities` 返回 `monthly_access` / `yearly_access`
- [ ] 数据页显示月 K / 年 K 卡片；设置抽屉可改同步月数/年数
- [ ] `POST /api/kline/sync_monthly` 启动 job 并写入 `kline_monthly/`
- [ ] `POST /api/kline/sync_yearly` 写入聚合年线；extend endpoints 可向前扩展
