### PR TITLE
fix(index-quotes): compute change_pct for custom data source

### DIFF
--- a/backend/app/services/quote_service.py
+++ b/backend/app/services/quote_service.py
@@ -884,6 +884,20 @@ class QuoteService:
         if not keep or "symbol" not in keep:
             return pl.DataFrame()
         df = df.select(keep)
+        # 自定义源可能不提供 change_pct/change_amount, 按 last_price/prev_close 补算
+        # (TickFlow 路径在 _fetch_full_market_quotes 已算好, 此处只补缺失的)
+        if "change_pct" not in df.columns and "last_price" in df.columns and "prev_close" in df.columns:
+            # prev_close=0 → inf (非合法 JSON), prev_close=null → null; 用 when 守护
+            df = df.with_columns(
+                pl.when(pl.col("prev_close") != 0)
+                .then((pl.col("last_price") - pl.col("prev_close")) / pl.col("prev_close"))
+                .otherwise(None)
+                .alias("change_pct")
+            )
+        if "change_amount" not in df.columns and "last_price" in df.columns and "prev_close" in df.columns:
+            df = df.with_columns(
+                (pl.col("last_price") - pl.col("prev_close")).alias("change_amount")
+            )
         # change_pct / amplitude: 小数 → 百分比 (统一指数展示口径)
         for col in ("change_pct", "amplitude"):
             if col in df.columns:


### PR DESCRIPTION
## PR 文案

---

**标题:**
`fix(index-quotes): 自定义数据源指数行情缺失涨跌幅`

**正文:**

### 问题

使用自定义数据源提供实时指数行情时，`/api/intraday/indices` 返回的数据只有点位（`last_price`），没有涨跌幅（`change_pct`），前端指数页面和侧栏卡片涨跌幅显示为 `--`。

### 原因

`_build_index_quotes` 构建 `_index_quotes_cache` 时只保留 records 中已存在的列，不补算缺失字段。TickFlow 路径在 `_fetch_full_market_quotes` 中显式计算了 `change_pct`，但自定义源路径通过 `get_realtime()` 直接透传 field_map 映射的字段，`_REQUIRED` 不要求 `change_pct`，因此该列缺失。

### 修复

在 `_build_index_quotes` 的 `select(keep)` 之后、`*100` 百分比转换之前，当 `change_pct`/`change_amount` 缺失但有 `last_price`/`prev_close` 时补算：

- `change_pct = (last_price - prev_close) / prev_close`（小数制，与后续 `*100` 转换及 TickFlow 路径口径一致）
- `change_amount = last_price - prev_close`
- 守护 `prev_close = 0`：Polars 除法 `100 / 0` 产生 `inf`，`json.dumps` 序列化为 `Infinity`（非合法 JSON），用 `pl.when(prev_close != 0).then(...).otherwise(None)` 避免，与 TickFlow 路径 `prev_close not in (None, 0)` 守护对齐

### 测试

- Polars 边界验证：`prev_close=0` → `null`（非 `inf`），`prev_close=null` → `null`，正常值 → 正确计算
- 现有测试 `test_pipeline_and_monitor_fixes.py` / `test_realtime_turnover_rate.py` / `test_strategy_realtime_refresh.py` 均通过
- 不影响 TickFlow 路径（已有 `change_pct`，条件 `"change_pct" not in df.columns` 跳过）和日K兜底路径（独立函数 `_fallback_index_quotes_from_daily`）

---