### PR TITLE
fix(test): 修复 test_live_enriched_metadata 硬编码日期导致的 time-bomb 失败

### DIFF
--- a/backend/tests/test_live_enriched_metadata.py
+++ b/backend/tests/test_live_enriched_metadata.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import timedelta
 from pathlib import Path
 
 import polars as pl
 
+from app.market_time import cn_today
 from app.strategy.engine import StrategyEngine
 from app.strategy.monitor import MonitorRuleEngine
 from app.tickflow.repository import DataStore, KlineRepository
@@ -24,7 +25,7 @@ def _repo(tmp_path) -> KlineRepository:
 def _live_row(symbol: str, close: float) -> pl.DataFrame:
     return pl.DataFrame({
         "symbol": [symbol],
-        "date": [date(2026, 7, 20)],
+        "date": [cn_today()],
         "open": [close],
         "high": [close],
         "low": [close],
@@ -44,7 +45,7 @@ def test_live_enriched_cache_keeps_instrument_metadata_without_persisting_it(tmp
     repo.merge_live_enriched_asset("stock", _live_row("000001.SZ", 12.0))
 
     cached, cached_date = repo.get_enriched_latest()
-    assert cached_date == date(2026, 7, 20)
+    assert cached_date == cn_today()
     assert cached.select("symbol", "name").sort("symbol").to_dicts() == [
         {"symbol": "000001.SZ", "name": "平安银行"},
         {"symbol": "600000.SH", "name": "浦发银行"},
@@ -53,7 +54,7 @@ def test_live_enriched_cache_keeps_instrument_metadata_without_persisting_it(tmp
     assert cached["float_shares"].null_count() == 0
 
     persisted = pl.read_parquet(
-        tmp_path / "kline_daily_enriched" / "date=2026-07-20" / "part.parquet"
+        tmp_path / "kline_daily_enriched" / f"date={cn_today().isoformat()}" / "part.parquet"
     )
     assert "name" not in persisted.columns
     assert "total_shares" not in persisted.columns
@@ -84,7 +85,7 @@ def filter_history(df: pl.DataFrame, params: dict) -> pl.DataFrame:
     )
     repo.flush_live_enriched_asset("stock", live)
     current, _ = repo.get_enriched_latest()
-    history = current.with_columns(pl.lit(date(2026, 7, 17)).alias("date"))
+    history = current.with_columns(pl.lit(cn_today() - timedelta(days=3)).alias("date"))
 
     monitor = MonitorRuleEngine()
     monitor.set_strategy_engine(StrategyEngine([Path(strategy_dir)]))


### PR DESCRIPTION
## 问题

`test_history_strategy_monitor_keeps_live_row_with_exclude_st_enabled` 使用硬编码日期 `date(2026, 7, 20)`，但 `MonitorRuleEngine.evaluate()` 内部通过 `cn_today()` 获取当前日期作为 `as_of`。

两者不一致时，`engine.py` 中的 `df.filter(pl.col("date") == as_of)` 会过滤掉所有行，导致选股结果 `total == 0`，断言失败。

这是一个 **time-bomb 测试**——写于 7/20 当天能通过，之后必然失败。

## 修复

将所有硬编码日期替换为基于 `cn_today()` 的动态计算：

| 原值 | 新值 |
|---|---|
| `date(2026, 7, 20)` (live date) | `cn_today()` |
| `date(2026, 7, 20)` (assertion) | `cn_today()` |
| `date=2026-07-20` (parquet path) | `f"date={cn_today().isoformat()}"` |
| `date(2026, 7, 17)` (history date) | `cn_today() - timedelta(days=3)` |

同时修复了同文件中 `test_live_enriched_cache_keeps_instrument_metadata_without_persisting_it` 的相同问题（该测试因恰好不依赖日期匹配而未被触发，但同样存在隐患）。

## 验证

```bash
$ uv run pytest -x -q
435 passed
```