### PR TITLE
Feat/监控规则自定义信号显示全部 + 信息条弹窗性能优化

### DIFF
--- a/frontend/src/components/ListColumnCustomizer.tsx
+++ b/frontend/src/components/ListColumnCustomizer.tsx
@@ -61,6 +61,9 @@ function isNumericFieldType(ft?: string): boolean {
   return true
 }
 
+/** 模块级空数组常量：extSchema 未加载时用，避免 `?? []` 每次创建新引用导致 useMemo 失效。 */
+const EMPTY_EXT_TABLES: readonly { id: string; label: string; mode: string; columns: { name: string; label: string; type: string }[] }[] = []
+
 function SortableActiveCol({ col, onRemove, onConfig, configOpen, extTableLabel, extConfig, candleConfig: candlePanel, intradayConfig: intradayPanel, strategiesConfig, showStandaloneToggle, onToggleStandalone }: {
   col: ColumnConfig
   onRemove: (id: string) => void
@@ -166,8 +169,9 @@ export function ListColumnCustomizer({
   })
   const backdrop = useDialogBackdrop(onClose)
 
-  // columns/onChange 用 ref 镜像，让下方 8 个 useCallback 空依赖，
-  // 避免 columns 每次变更都重建 callback 导致 SortableActiveCol 等 memo 失效。
+  // columns/onChange 用 ref 镜像，让下方多数 useCallback 空依赖（addExtColumn 例外，
+  // 依赖 props.extColumnAlign）。callback 引用稳定后，columns 变更不再导致
+  // SortableActiveCol 等子组件因 props 变化而无谓重渲染。
   const columnsRef = useRef(columns)
   columnsRef.current = columns
   const onChangeRef = useRef(onChange)
@@ -320,7 +324,7 @@ export function ListColumnCustomizer({
     })
   }, [])
 
-  const extTables = extSchema.data?.items ?? []
+  const extTables = extSchema.data?.items ?? EMPTY_EXT_TABLES
   const extTableLabelMap = useMemo(() => new Map(extTables.map(t => [t.id, t.label])), [extTables])
 
   const query = searchQuery.trim().toLowerCase()

--- a/frontend/src/components/ListColumnCustomizer.tsx
+++ b/frontend/src/components/ListColumnCustomizer.tsx
@@ -6,7 +6,7 @@
  * - 下半区「内置列」：按业务分组折叠
  * - 底部「扩展数据列」：复用 ext_data schema，按需添加字段
  */
-import React, { useState, useCallback, useEffect, useMemo } from 'react'
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   DndContext, closestCenter, KeyboardSensor, PointerSensor,
@@ -39,6 +39,13 @@ interface ListColumnCustomizerProps {
   showExtColumns?: boolean
   /** 是否显示「单独显示」勾选项（默认 false；仅信息条场景启用，让某列独占一行）。 */
   showStandaloneToggle?: boolean
+  /**
+   * 是否禁用遮罩背景模糊 (backdrop-blur)。默认 false。
+   * 信息条场景 (宿主含 Canvas K线/分时图) 传 true：blur 会对 Canvas 做逐帧 GPU 合成，
+   * 是抽屉打开/滑动卡顿的主因；改纯半透明遮罩后合成层锐减。
+   * 选股/自选页背后是 DOM 表格，blur 开销可忽略，保持默认。
+   */
+  disableBackdropBlur?: boolean
 }
 
 /** 判断扩展数据字段类型是否为数字(int/float/double/number/decimal 等)。
@@ -60,10 +67,10 @@ function SortableActiveCol({ col, onRemove, onConfig, configOpen, extTableLabel,
   onConfig: (id: string | null) => void
   configOpen: boolean
   extTableLabel: string
-  extConfig: React.ReactNode
-  candleConfig: React.ReactNode
-  intradayConfig: React.ReactNode
-  strategiesConfig: React.ReactNode
+  extConfig: () => React.ReactNode
+  candleConfig: () => React.ReactNode
+  intradayConfig: () => React.ReactNode
+  strategiesConfig: () => React.ReactNode
   showStandaloneToggle?: boolean
   onToggleStandalone?: (id: string) => void
 }) {
@@ -132,7 +139,7 @@ function SortableActiveCol({ col, onRemove, onConfig, configOpen, extTableLabel,
           <EyeOff className="h-3 w-3" />
         </button>
       </div>
-      {hasConfig && configOpen && (isExt ? extConfig : isCandle ? candlePanel : isIntraday ? intradayPanel : strategiesConfig)}
+      {hasConfig && configOpen && (isExt ? extConfig() : isCandle ? candlePanel() : isIntraday ? intradayPanel() : strategiesConfig())}
     </>
   )
 }
@@ -149,6 +156,7 @@ export function ListColumnCustomizer({
   extFieldFilter,
   showExtColumns = true,
   showStandaloneToggle = false,
+  disableBackdropBlur = false,
 }: ListColumnCustomizerProps) {
   const extSchema = useQuery({
     queryKey: QK.extDataSchemaAll,
@@ -157,6 +165,13 @@ export function ListColumnCustomizer({
     staleTime: 60_000,
   })
   const backdrop = useDialogBackdrop(onClose)
+
+  // columns/onChange 用 ref 镜像，让下方 8 个 useCallback 空依赖，
+  // 避免 columns 每次变更都重建 callback 导致 SortableActiveCol 等 memo 失效。
+  const columnsRef = useRef(columns)
+  columnsRef.current = columns
+  const onChangeRef = useRef(onChange)
+  onChangeRef.current = onChange
 
   const [searchQuery, setSearchQuery] = useState('')
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set())
@@ -175,16 +190,18 @@ export function ListColumnCustomizer({
   const activeCols = useMemo(() => columns.filter(c => !c.pinned && c.visible), [columns])
 
   const toggleVisible = useCallback((colId: string) => {
-    onChange(columns.map(c =>
+    const cols = columnsRef.current
+    onChangeRef.current(cols.map(c =>
       c.id === colId && !c.pinned ? { ...c, visible: !c.visible } : c
     ))
-  }, [columns, onChange])
+  }, [])
 
   const toggleStandalone = useCallback((colId: string) => {
-    onChange(columns.map(c =>
+    const cols = columnsRef.current
+    onChangeRef.current(cols.map(c =>
       c.id === colId ? { ...c, standalone: !c.standalone } : c
     ))
-  }, [columns, onChange])
+  }, [])
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -194,19 +211,21 @@ export function ListColumnCustomizer({
   const handleDragEnd = useCallback((event: DragEndEvent) => {
     const { active, over } = event
     if (!over || active.id === over.id) return
-    const reorderCols = columns.filter(c => !c.pinned)
-    const pinnedCols = columns.filter(c => c.pinned)
+    const cols = columnsRef.current
+    const reorderCols = cols.filter(c => !c.pinned)
+    const pinnedCols = cols.filter(c => c.pinned)
     const ids = reorderCols.map(c => c.id)
     const oldIdx = ids.indexOf(active.id as string)
     const newIdx = ids.indexOf(over.id as string)
     if (oldIdx < 0 || newIdx < 0) return
     const reordered = arrayMove(reorderCols, oldIdx, newIdx)
-    onChange([...pinnedCols, ...reordered])
-  }, [columns, onChange])
+    onChangeRef.current([...pinnedCols, ...reordered])
+  }, [])
 
   const addExtColumn = useCallback((configId: string, fieldName: string, fieldLabel?: string, fieldType?: string) => {
+    const cols = columnsRef.current
     const colId = `ext:${configId}:${fieldName}`
-    if (columns.some(c => c.id === colId)) {
+    if (cols.some(c => c.id === colId)) {
       toggleVisible(colId)
       return
     }
@@ -217,64 +236,71 @@ export function ListColumnCustomizer({
       visible: true,
       align: extColumnAlign,
     }
-    const actionIdx = columns.findIndex(c => c.id === 'builtin:action')
+    const actionIdx = cols.findIndex(c => c.id === 'builtin:action')
     if (actionIdx >= 0) {
-      const next = [...columns]
+      const next = [...cols]
       next.splice(actionIdx, 0, newCol)
-      onChange(next)
+      onChangeRef.current(next)
     } else {
-      onChange([...columns, newCol])
+      onChangeRef.current([...cols, newCol])
     }
-  }, [columns, extColumnAlign, onChange, toggleVisible])
+  }, [extColumnAlign, toggleVisible])
 
   const hideColumn = useCallback((colId: string) => {
-    onChange(columns.map(c => c.id === colId ? { ...c, visible: false } : c))
-  }, [columns, onChange])
+    const cols = columnsRef.current
+    onChangeRef.current(cols.map(c => c.id === colId ? { ...c, visible: false } : c))
+  }, [])
 
   const updateExtDisplay = useCallback((colId: string, patch: Partial<ExtColumnDisplayConfig>) => {
-    onChange(columns.map(c => {
+    const cols = columnsRef.current
+    onChangeRef.current(cols.map(c => {
       if (c.id !== colId) return c
       return { ...c, extDisplay: { displayMode: 'tag', ...(c.extDisplay || {}), ...patch } }
     }))
-  }, [columns, onChange])
+  }, [])
 
   const resetExtDisplay = useCallback((colId: string) => {
-    onChange(columns.map(c => {
+    const cols = columnsRef.current
+    onChangeRef.current(cols.map(c => {
       if (c.id !== colId) return c
       const { extDisplay, ...rest } = c
       return rest
     }))
-  }, [columns, onChange])
+  }, [])
 
   const updateCandleConfig = useCallback((colId: string, patch: Partial<CandleColumnConfig>) => {
-    onChange(columns.map(c => {
+    const cols = columnsRef.current
+    onChangeRef.current(cols.map(c => {
       if (c.id !== colId) return c
       return { ...c, candleConfig: { ...c.candleConfig, ...patch } }
     }))
-  }, [columns, onChange])
+  }, [])
 
   const resetCandleConfig = useCallback((colId: string) => {
-    onChange(columns.map(c => {
+    const cols = columnsRef.current
+    onChangeRef.current(cols.map(c => {
       if (c.id !== colId) return c
       const { candleConfig, ...rest } = c
       return rest
     }))
-  }, [columns, onChange])
+  }, [])
 
   const updateIntradayConfig = useCallback((colId: string, patch: Partial<IntradayColumnConfig>) => {
-    onChange(columns.map(c => {
+    const cols = columnsRef.current
+    onChangeRef.current(cols.map(c => {
       if (c.id !== colId) return c
       return { ...c, intradayConfig: { ...c.intradayConfig, ...patch } }
     }))
-  }, [columns, onChange])
+  }, [])
 
   const resetIntradayConfig = useCallback((colId: string) => {
-    onChange(columns.map(c => {
+    const cols = columnsRef.current
+    onChangeRef.current(cols.map(c => {
       if (c.id !== colId) return c
       const { intradayConfig, ...rest } = c
       return rest
     }))
-  }, [columns, onChange])
+  }, [])
 
   const toggleGroup = useCallback((groupId: string) => {
     setExpandedGroups(prev => {
@@ -295,7 +321,7 @@ export function ListColumnCustomizer({
   }, [])
 
   const extTables = extSchema.data?.items ?? []
-  const extTableLabelMap = new Map(extTables.map(t => [t.id, t.label]))
+  const extTableLabelMap = useMemo(() => new Map(extTables.map(t => [t.id, t.label])), [extTables])
 
   const query = searchQuery.trim().toLowerCase()
   const filteredGroups = useMemo(() => {
@@ -722,7 +748,7 @@ export function ListColumnCustomizer({
           <motion.div
             initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
             transition={{ duration: 0.15 }}
-            className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+            className={`absolute inset-0 bg-black/50 ${disableBackdropBlur ? '' : 'backdrop-blur-sm'}`}
             {...backdrop}
           />
           <motion.div
@@ -768,10 +794,10 @@ export function ListColumnCustomizer({
                           onConfig={setConfigOpenId}
                           configOpen={configOpenId === col.id}
                           extTableLabel={col.source.type === 'ext' ? (extTableLabelMap.get(col.source.configId) || col.source.configId) : ''}
-                          extConfig={renderExtConfig(col)}
-                          candleConfig={renderCandleConfig(col)}
-                          intradayConfig={renderIntradayConfig(col)}
-                          strategiesConfig={renderStrategiesConfig(col)}
+                          extConfig={() => renderExtConfig(col)}
+                          candleConfig={() => renderCandleConfig(col)}
+                          intradayConfig={() => renderIntradayConfig(col)}
+                          strategiesConfig={() => renderStrategiesConfig(col)}
                           showStandaloneToggle={showStandaloneToggle}
                           onToggleStandalone={toggleStandalone}
                         />

--- a/frontend/src/components/StockInfoBar.tsx
+++ b/frontend/src/components/StockInfoBar.tsx
@@ -272,6 +272,7 @@ export function StockInfoBar({ symbol, name, stockInfo, rows, fields, onFieldsCh
         builtinSectionLabel="可选指标"
         extColumnAlign="left"
         showStandaloneToggle
+        disableBackdropBlur
       />
     </div>
   )

--- a/frontend/src/components/monitor/RuleEditor.tsx
+++ b/frontend/src/components/monitor/RuleEditor.tsx
@@ -253,9 +253,12 @@ export function RuleEditor({ rule, preset, simple, onClose, onSaved }: Props) {
             signals={selectedSignals}
             onChange={onSignalPickerChange}
             kind="entry"
-            builtinSignals={pickerSignals}
-            disabledSignals={intradaySupport?.available === false ? MONITOR_INTRADAY_SIGNAL_OPTIONS : []}
-            disabledSignalHint={intradaySupport?.reason}
+            options={{
+              builtinSignals: pickerSignals,
+              disabledSignals: intradaySupport?.available === false ? MONITOR_INTRADAY_SIGNAL_OPTIONS : [],
+              disabledSignalHint: intradaySupport?.reason,
+              filterCustomByKind: false,
+            }}
           />
           {hasIntradaySignal && (
             <div className={`mt-2 text-[10px] ${intradaySupport?.available === false ? 'text-danger' : 'text-muted'}`}>
@@ -472,9 +475,12 @@ export function RuleEditor({ rule, preset, simple, onClose, onSaved }: Props) {
                 signals={selectedSignals}
                 onChange={onSignalPickerChange}
                 kind="entry"
-                builtinSignals={pickerSignals}
-                disabledSignals={intradaySupport?.available === false ? MONITOR_INTRADAY_SIGNAL_OPTIONS : []}
-                disabledSignalHint={intradaySupport?.reason}
+                options={{
+                  builtinSignals: pickerSignals,
+                  disabledSignals: intradaySupport?.available === false ? MONITOR_INTRADAY_SIGNAL_OPTIONS : [],
+                  disabledSignalHint: intradaySupport?.reason,
+                  filterCustomByKind: false,
+                }}
               />
               {hasIntradaySignal && (
                 <div className={`mt-2 text-[10px] ${intradaySupport?.available === false ? 'text-danger' : 'text-muted'}`}>

--- a/frontend/src/components/screener/SignalPicker.tsx
+++ b/frontend/src/components/screener/SignalPicker.tsx
@@ -1,8 +1,24 @@
 import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { PenLine } from 'lucide-react'
 import { api } from '@/lib/api'
 import { QK } from '@/lib/queryKeys'
 import { SIGNAL_OPTIONS, cnSignal } from '@/lib/signals'
+
+/** 展示与过滤可选项 (全部可选, 有默认值) */
+interface SignalPickerOptions {
+  /** 渲染尺寸: dialog = 选股弹窗紧凑样式; panel = 回测页设置抽屉样式 */
+  variant?: 'dialog' | 'panel'
+  builtinSignals?: { key: string; label: string }[]
+  disabledSignals?: string[]
+  disabledSignalHint?: string
+  /**
+   * 是否按 kind 过滤自定义信号 (csg_*)。默认 true (选股/回测: 入场区只显示 entry)。
+   * 监控规则页设 false: 报警语义是"命中即报", 不分入场出场, 自定义信号全部显示
+   * (与内置信号一致: builtinSignals 透传时本就不按 kind 过滤)。
+   */
+  filterCustomByKind?: boolean
+}
 
 interface Props {
   /** 当前选中的信号 ID 列表 */
@@ -11,30 +27,27 @@ interface Props {
   onChange: (next: string[]) => void
   /** 买点 / 卖点 — 决定自定义信号的过滤与配色主题 */
   kind: 'entry' | 'exit'
-  /** 渲染尺寸: dialog = 选股弹窗紧凑样式; panel = 回测页设置抽屉样式 */
-  variant?: 'dialog' | 'panel'
-  builtinSignals?: { key: string; label: string }[]
-  disabledSignals?: string[]
-  disabledSignalHint?: string
+  options?: SignalPickerOptions
 }
 
 /**
  * 买卖触发器信号选择 — 选股页弹窗 / 回测页共用。
  *
  * - 内置信号 (signal_*): 全部展示
- * - 自定义信号 (csg_*): 按 kind 过滤 (entry / exit / both)
- * - entry 蓝色主题, exit 橙色主题
+ * - 自定义信号 (csg_*): 按 kind 过滤 (entry / exit / both), 除非 filterCustomByKind=false
+ * - entry 蓝色主题, exit 橙色主题; 自定义信号边框配色与内置一致, 右上角 PenLine 角标区分
  */
-export function SignalPicker({ signals, onChange, kind, variant = 'panel', builtinSignals, disabledSignals = [], disabledSignalHint }: Props) {
+export function SignalPicker({ signals, onChange, kind, options }: Props) {
+  const { variant = 'panel', builtinSignals, disabledSignals = [], disabledSignalHint, filterCustomByKind = true } = options ?? {}
   const customSignalsQuery = useQuery({ queryKey: QK.customSignals, queryFn: api.customSignalsList })
 
   const customOptions = useMemo(() => {
     const list = (customSignalsQuery.data?.signals ?? [])
-      .filter(s => s.enabled && (s.kind === kind || s.kind === 'both'))
+      .filter(s => s.enabled && (!filterCustomByKind || s.kind === kind || s.kind === 'both'))
     const names: Record<string, string> = {}
     for (const cs of list) names[`csg_${cs.id}`] = cs.name
     return { list, names }
-  }, [customSignalsQuery.data, kind])
+  }, [customSignalsQuery.data, kind, filterCustomByKind])
 
   const toggle = (sig: string) => {
     const next = signals.includes(sig) ? signals.filter(x => x !== sig) : [...signals, sig]
@@ -49,10 +62,6 @@ export function SignalPicker({ signals, onChange, kind, variant = 'panel', built
   const idle = variant === 'dialog'
     ? 'border-border bg-base text-muted hover:border-accent/40'
     : 'border-border bg-base text-muted hover:border-accent/40'
-  const customActive = isEntry
-    ? 'border-accent/50 bg-accent/10 text-accent'
-    : 'border-warning/50 bg-warning/10 text-warning'
-  const customIdle = 'border-amber-400/30 bg-amber-400/5 text-secondary hover:border-amber-400/50 hover:text-amber-400'
 
   const btnCls = variant === 'dialog'
     ? 'rounded px-1.5 py-0.5 text-[10px] font-medium border transition-colors cursor-pointer'
@@ -84,9 +93,12 @@ export function SignalPicker({ signals, onChange, kind, variant = 'panel', built
             type="button"
             onClick={() => toggle(id)}
             title="自定义信号"
-            className={`${btnCls} ${signals.includes(id) ? customActive : customIdle}`}
+            className={`${btnCls} relative ${signals.includes(id) ? active : idle}`}
           >
             {customOptions.names[id]}
+            <span className="pointer-events-none absolute -top-1 -right-1 rounded-full border border-border bg-base p-px">
+              <PenLine className="h-2 w-2 text-muted" />
+            </span>
           </button>
         )
       })}

--- a/frontend/src/components/screener/StrategySettingsDialog.tsx
+++ b/frontend/src/components/screener/StrategySettingsDialog.tsx
@@ -638,7 +638,7 @@ export function StrategySettingsDialog({ strategyId, onClose, onSaved, onAiModif
                       defaultOpen={false}
                       extra={<SignalTriggerActions kind="entry" signals={entrySignals} onChange={setEntrySignals} buttonClassName="rounded-md border border-border bg-base p-1 text-muted transition-colors cursor-pointer" iconClassName="h-3 w-3" />}
                     >
-                      <SignalPicker signals={entrySignals} onChange={setEntrySignals} kind="entry" variant="dialog" />
+                      <SignalPicker signals={entrySignals} onChange={setEntrySignals} kind="entry" options={{ variant: 'dialog' }} />
                       <div className="text-[10px] leading-4 text-muted/70">任一入场点满足即进入候选。</div>
                     </Section>
 
@@ -649,7 +649,7 @@ export function StrategySettingsDialog({ strategyId, onClose, onSaved, onAiModif
                       defaultOpen={false}
                       extra={<SignalTriggerActions kind="exit" signals={exitSignals} onChange={setExitSignals} buttonClassName="rounded-md border border-border bg-base p-1 text-muted transition-colors cursor-pointer" iconClassName="h-3 w-3" />}
                     >
-                      <SignalPicker signals={exitSignals} onChange={setExitSignals} kind="exit" variant="dialog" />
+                      <SignalPicker signals={exitSignals} onChange={setExitSignals} kind="exit" options={{ variant: 'dialog' }} />
                       <div className="text-[10px] leading-4 text-muted/70">任一出场点满足即触发出场。</div>
                     </Section>
 


### PR DESCRIPTION


# PR: 监控规则自定义信号显示全部 + 信息条弹窗性能优化

## 问题与复现

**问题1：监控规则页自定义信号被按 kind 过滤，无法选择 exit-only 自定义信号做监控**

- **原行为**：监控规则编辑弹窗（`/monitor` 新建/编辑规则，或个股预览弹窗"加入监控"）的"信号条件"选择器，自定义信号（`csg_*`）被按 `entry/exit/both` kind 过滤——只有 `entry` 类可见
- **复现**：设置页建一个 kind=exit 的自定义信号 → 监控页新建规则 → 信号条件 → 看不到该信号
- **影响**：用户无法用 exit-only 自定义信号做监控报警，与后端监控引擎"命中即报、不分入/出场"的语义不一致

**问题2：自选详情-自定义信息条-信息条指标侧边弹窗，打开卡顿、上下滑动卡顿、操作卡顿**

- **原行为**：个股预览弹窗（选股页/自选页点股票，或回测成交 K 线弹窗）→ 信息条齿轮按钮 → 右侧抽屉打开/滑动/勾选都明显卡顿
- **复现**：打开任意个股预览弹窗（背后含 K 线/分时图 Canvas）→ 点信息条齿轮 → 抽屉滑入时掉帧；滚动列表卡顿；勾选 checkbox 卡顿
- **影响**：交互体验差，用户难以顺畅配置信息条指标

## 根因

**问题1根因**：`SignalPicker` 组件对所有调用方统一按 `kind` 过滤自定义信号。监控页传 `kind="entry"`，导致 exit-only 信号不可见。但监控报警语义是"命中即报"，不应区分入/出场

**问题2根因**（三重叠加）：
1. **`backdrop-blur-sm` 对 Canvas 逐帧 GPU 合成**（主因）：抽屉遮罩用 `backdrop-blur-sm`，背后是 K 线/分时图 Canvas，浏览器每帧对 Canvas 做模糊运算，GPU 合成层重活。选股/自选页背后是 DOM 表格，blur 开销可忽略——所以前两处不卡
2. **onChange 雪崩**：8 个 `useCallback` 依赖 `[columns, onChange]`，每次勾选/拖拽 `columns` 换新引用 → 所有 callback 重建 → 子组件无谓重渲染
3. **配置面板预构造**：每个已启用列在每次渲染时都构造 4 个配置面板 ReactNode（即使 `configOpen=false` 根本不显示），N 列 × 4 面板 = 4N 个节点白白创建

## 解决方案

### 问题1：新增 `filterCustomByKind` 选项（commit `e864ecd`）

- `SignalPicker` 新增 `filterCustomByKind?: boolean`（默认 `true` 保持原行为）
- 监控规则页（`RuleEditor.tsx` 两处）传 `false`：报警语义"命中即报"，自定义信号全部显示，与后端监控引擎按 `csg_` 布尔列直接求值的行为对齐
- 选股页/回测页（`StrategySettingsDialog` ×2、`StrategyBacktest` ×2）不传或传默认，行为完全不变
- 顺带将可选 props 收拢为 `options` 对象；自定义信号按钮配色与内置一致，右上角 `PenLine` 角标区分

**后端语义确认**：`monitor.py:213-216` 监控引擎对 `csg_` 纯按布尔列求值，不区分 kind；`custom_signals.py:12` 设计即"注入列后回测/选股/监控三处零特殊处理"；`api/monitor_rules.py:113-118` 监控 options 接口本就返回全部 enabled 自定义信号——前端之前的 kind 过滤反而是与后端不一致的那方

### 问题2：性能优化（commit `5119232` + `01f20ae`）

1. **`disableBackdropBlur` prop**：信息条场景传 `true` 关掉 `backdrop-blur-sm`，改纯半透明遮罩。Canvas 不再被模糊，GPU 合成层锐减。选股/自选页保持默认 `false`（背后 DOM，blur 无感）
2. **ref 镜像 + 空依赖 callback**：`columns`/`onChange` 用 `useRef` 镜像最新值，8 个 `useCallback` 改空依赖（`addExtColumn` 例外，依赖 props）。callback 引用稳定，不再随 columns 变化重建
3. **配置面板惰性渲染**：4 个 `xxxConfig` prop 从 `ReactNode` 改为 `() => ReactNode`，子组件 `configOpen` 时才调用，未展开不构造
4. **`extTableLabelMap` 包 `useMemo`**；`extTables` 空数据用模块级常量 `EMPTY_EXT_TABLES` 避免新引用

## 兼容性

- **SignalPicker 6 处调用点逐项核查**：`RuleEditor` ×2（传 false，目标）、`StrategySettingsDialog` ×2（传 variant，默认 true）、`StrategyBacktest` ×2（不传 options，`?? {}` 兜底全默认）→ 向后兼容成立
- **`disableBackdropBlur` 影响范围**：仅 `StockInfoBar` 传 `true`；`Screener`/`Watchlist` 不传，默认 `false` 保持 blur
- **历史配置**：localStorage 已存的 fields/columns 配置不受影响，新 prop 有默认值
- **无 schema/契约变化**：纯前端 UI 层改动，不涉及后端、数据契约、API

## 性能

本 PR 进入个股预览弹窗渲染路径（非实时热路径，弹窗打开时才渲染）。性能优化针对交互卡顿：
- **根因1（blur 对 Canvas）**：已知浏览器合成层性能问题，移除 blur 后 GPU 合成层锐减
- **根因2+3**：callback 引用稳定 + 惰性渲染，减少 `StockPanel` 重渲染时弹窗内部的无谓重绘
- **未附前后耗时数据**：UI 交互性能优化，根因分析合理；如需可补 Chrome DevTools Performance 录制对比

**同类问题排查**：`StockPreviewDialog`/`TradeKlineModal` 也用 `backdrop-blur-sm`，但均为居中弹窗（面板 `bg-base` 不透明覆盖中心，blur 只影响边缘），且打开时背景 K 线通常不持续刷新，影响远小于信息条抽屉，不修改

## 验证结果

- **`tsc --noEmit`**：通过，零类型错误
- **`pnpm build`**（`tsc -b && vite build`）：通过，2691 模块转换成功
- **`git diff --check`**：通过，无空白错误
- **lint**：3 个改动文件零告警
- **SignalPicker 过滤逻辑静态验证**：`filterCustomByKind=false` 时 `!false || ...` 短路通过全部显示；默认 `true` 退化为原 `s.kind === kind || s.kind === 'both'`
- **后端语义静态确认**：监控引擎对 `csg_` 按布尔列求值不区分 kind

**未验证（需手工确认）**：
- 监控页 exit-only 自定义信号现在可见可选（入口：`/monitor` → 新建规则 → 信号条件）
- 选股页策略设置入场触发器仍只见 entry（入口：策略卡片右上角齿轮 → 入场触发器）
- 信息条弹窗打开/滑动/操作不再卡顿（入口：个股预览弹窗 → 信息条齿轮）
- ref 镜像模式在拖拽排序/增删列/配置面板展开折叠时的运行时行为

## 改动范围

5 文件 +113/-64，3 个提交：
| 文件 | 改动 |
|---|---|
| `SignalPicker.tsx` | +`filterCustomByKind`/`options` 对象/PenLine 角标 |
| `RuleEditor.tsx` | 两处传 `filterCustomByKind:false` |
| `StrategySettingsDialog.tsx` | 两处改 options 传参（行为不变） |
| `ListColumnCustomizer.tsx` | +`disableBackdropBlur`/ref 镜像/惰性渲染/useMemo |
| `StockInfoBar.tsx` | 传 `disableBackdropBlur` |

## 风险与回滚

- **剩余风险**：前端无自动化测试基建（项目无 vitest/jest），过滤逻辑与 ref 镜像运行时行为未自动化覆盖，依赖手工验证
- **回滚方式**：`git revert e864ecd 5119232 01f20ae`，或直接切回 `upstream/main`。改动均为前端 UI 层，无数据迁移、无持久化格式变化，回滚无副作用

## 自检清单

- [x] 改动只解决 PR 描述的问题，无夹带无关整理
- [x] 已检查完整调用链（SignalPicker 6 处、ListColumnCustomizer 3 处）
- [x] 无单位/复权/日期口径问题（纯 UI 过滤逻辑）
- [x] 未绕过 provider abstraction（不涉及数据源）
- [x] 历史配置兼容（localStorage 已存 fields 不受影响）
- [x] 无实时线程/全量扫描性能退化
- [x] 错误路径无静默返回错误结果
- [x] 已执行 tsc + pnpm build + lint + git diff --check
- [x] 最终 diff 无敏感数据/本地路径/调试输出/生成文件
