### PR TITLE
fix(regime): 修复日历热力图交易日错位到周末列

### DIFF
--- a/frontend/src/pages/Regime.tsx
+++ b/frontend/src/pages/Regime.tsx
@@ -327,12 +327,19 @@ export function Regime() {
     return [...byMonth.entries()].sort().map(([ym, monthRows]) => {
       const [y, m] = ym.split('-')
       const year = Number(y), month = Number(m)
-      // 该月第一天是周几(0=周日 → 转成周一为起始: 周一=0)
-      const firstDay = new Date(year, month - 1, 1)
-      let dow = firstDay.getDay() // 0=Sun..6=Sat
-      dow = dow === 0 ? 6 : dow - 1 // 转成 周一=0..周日=6
-      const cells: (RegimeRow | null)[] = Array(dow).fill(null)
-      for (const r of monthRows) cells.push(r)
+      // 按自然日铺格子: 只有该日为交易日且有数据才填 RegimeRow, 其余日子填 null。
+      // 这样每个格子都对其正确的周几列, 不会因月内数据不连续而把交易日错位到周末列。
+      const dateToRow = new Map<string, RegimeRow>()
+      for (const r of monthRows) dateToRow.set(r.date, r)
+      // 月首的星期偏移(周一=0..周日=6), 与表头 ['一'..'日'] 列顺序一致
+      const firstDow = new Date(year, month - 1, 1).getDay()
+      const leadOffset = firstDow === 0 ? 6 : firstDow - 1
+      const cells: (RegimeRow | null)[] = Array(leadOffset).fill(null)
+      const dayCount = new Date(year, month, 0).getDate()
+      for (let day = 1; day <= dayCount; day++) {
+        const ds = `${y}-${m.padStart(2, '0')}-${String(day).padStart(2, '0')}`
+        cells.push(dateToRow.has(ds) ? dateToRow.get(ds)! : null)
+      }
       // 补齐到 7 的倍数(完整周)
       while (cells.length % 7 !== 0) cells.push(null)
       // 切成每周一组


### PR DESCRIPTION
## 问题与复现

市场环境页日历热力图出现错位：当某月数据不是从 1 号连续到月末（最早月份只有下半月数据，或中间缺几天）时，交易日格子整体左移，被挤到周末那一列，看起来像周六/周日也有数据。

## 根因

`Regime.tsx` 的 `calendarMonths` 只在月初用 `getDay()` 算了前导空位，之后把真实交易日逐个 `push` 进 `cells`，不按日期补齐缺失的天。月底再用 `while (cells.length % 7 !== 0) push(null)` 补齐，也只是按数量补，无法修正错位。

## 解决方案

改为遍历该月的每一个自然日：交易日且有数据的填 `RegimeRow`，其余日子填 `null`。这样每个格子都对齐到正确的周几列，月内数据不连续不再导致错位。周六/周日没有交易日，自然为空格。

- 仅改 `frontend/src/pages/Regime.tsx`（+13 -6）。
- 不改数据口径、后端、其他渲染逻辑。

## 验证结果

- `pnpm build` 通过（`✓ built in 13.70s`，`Regime-*.js` 正常产出）。
- `git diff --check` 无空白问题。

## 兼容性与风险

- 纯前端渲染对齐修复，不影响数据、API、监控、回测。
- 风险极低；唯一变化是月内缺数据时段不再把后续格子左移。