### PR TITLE
feat(watchlist): add CSV/TXT import for watchlist

### DIFF
--- a/backend/app/api/watchlist.py
+++ b/backend/app/api/watchlist.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from app.db_safe import is_valid_ext_ident, quote_ident
 from app.services import watchlist
+from app.services.watchlist_csv import import_watchlist_csv
 from app.services.watchlist_ocr import import_watchlist_image
 from app.services.watchlist_ocr.provider import get_ocr_provider
 
@@ -28,6 +29,13 @@ _IMPORT_IMAGE_TYPES = {
     "image/webp",
     "image/bmp",
     "image/gif",
+}
+# CSV/TXT 导入：文本远小于截图，上限 5MB 足够
+_MAX_IMPORT_CSV_BYTES = 5 * 1024 * 1024
+_IMPORT_CSV_TYPES = {
+    "text/csv",
+    "text/plain",
+    "application/csv",
 }
 # OCR 独立并发上限：避免多张大图同时解码 + 多 Tesseract 子进程
 _OCR_LIMITER = anyio.CapacityLimiter(2)
@@ -87,22 +95,36 @@ def ocr_status():
     return {"provider": provider.name, "available": provider.available()}
 
 
-@router.post("/import-image")
-async def import_from_image(request: Request, file: UploadFile = File(...)):
-    """从自选截图识别股票代码，返回候选列表（不自动写入自选）。"""
+async def _read_upload(
+    file: UploadFile,
+    allowed_types: set[str],
+    allowed_exts: tuple[str, ...],
+    max_bytes: int,
+    reject_msg: str,
+) -> bytes:
+    """校验白名单（类型/扩展名）并读取上传字节，超限抛 400。"""
     content_type = (file.content_type or "").split(";")[0].strip().lower()
     filename = (file.filename or "").lower()
-    # 严格白名单：不接受任意 image/*（如 image/svg+xml）
-    ok_type = content_type in _IMPORT_IMAGE_TYPES
-    ok_ext = filename.endswith((".jpg", ".jpeg", ".png", ".webp", ".bmp", ".gif"))
-    if not ok_type and not ok_ext:
-        raise HTTPException(400, "仅支持 JPG / PNG / WebP / BMP / GIF 图片")
-
+    if content_type not in allowed_types and not filename.endswith(allowed_exts):
+        raise HTTPException(400, reject_msg)
     data = await file.read()
     if not data:
         raise HTTPException(400, "空文件")
-    if len(data) > _MAX_IMPORT_IMAGE_BYTES:
-        raise HTTPException(400, "图片过大（上限 12MB）")
+    if len(data) > max_bytes:
+        raise HTTPException(400, f"文件过大（上限 {max_bytes // (1024 * 1024)}MB）")
+    return data
+
+
+@router.post("/import-image")
+async def import_from_image(request: Request, file: UploadFile = File(...)):
+    """从自选截图识别股票代码，返回候选列表（不自动写入自选）。"""
+    data = await _read_upload(
+        file,
+        _IMPORT_IMAGE_TYPES,
+        (".jpg", ".jpeg", ".png", ".webp", ".bmp", ".gif"),
+        _MAX_IMPORT_IMAGE_BYTES,
+        "仅支持 JPG / PNG / WebP / BMP / GIF 图片",
+    )
 
     existing = {r["symbol"] for r in watchlist.list_symbols()}
     data_dir = request.app.state.repo.store.data_dir
@@ -121,6 +143,40 @@ async def import_from_image(request: Request, file: UploadFile = File(...)):
         raise HTTPException(500, f"识别失败: {e}") from e
 
     # 响应不回传整段 raw_text（可能很长）；调试时可开 query，这里默认省略
+    result.pop("raw_text", None)
+    return result
+
+
+@router.post("/import-csv")
+async def import_from_csv(request: Request, file: UploadFile = File(...)):
+    """从 CSV / TXT 导入自选候选列表（不自动写入自选）。
+
+    兼容同花顺/东财/通达信导出（逗号或 Tab 分隔、UTF-8 或 GBK 编码）。
+    """
+    data = await _read_upload(
+        file,
+        _IMPORT_CSV_TYPES,
+        (".csv", ".txt"),
+        _MAX_IMPORT_CSV_BYTES,
+        "仅支持 CSV / TXT 文件",
+    )
+
+    existing = {r["symbol"] for r in watchlist.list_symbols()}
+    data_dir = request.app.state.repo.store.data_dir
+    try:
+        # CSV 解析 + instruments parquet 读取为同步 CPU 操作，挪线程池避免卡事件循环（行情 SSE 等）
+        result = await anyio.to_thread.run_sync(
+            lambda: import_watchlist_csv(data, data_dir, existing_symbols=existing),
+        )
+    except ValueError as e:
+        raise HTTPException(400, str(e)) from e
+    except Exception as e:  # noqa: BLE001
+        logger.exception("watchlist import-csv failed")
+        raise HTTPException(500, f"解析失败: {e}") from e
+
+    if not result["candidates"]:
+        raise HTTPException(400, "文件中未识别到股票代码或名称")
+    # 与 import-image 一致：不回传整段文本
     result.pop("raw_text", None)
     return result
 

--- a/backend/app/services/watchlist_csv.py
+++ b/backend/app/services/watchlist_csv.py
@@ -1,0 +1,157 @@
+"""自选股 CSV/TXT 导入：解码 → 逐行抽代码/名称 → instruments 校验。
+
+国内行情软件（同花顺/东财/通达信）导出的自选多为 CSV/TXT，且常为 GBK 系编码
+（参见 ext_data.ensure_utf8_csv 的说明）。本模块负责把上传字节解析为与截图 OCR
+一致的候选结构，前端复用同一套勾选确认流程。
+"""
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from app.services.watchlist_ocr.pipeline import (
+    _CODE_RE,
+    ImportCandidate,
+    build_instrument_lookups,
+    resolve_candidates,
+)
+
+logger = logging.getLogger(__name__)
+
+_CJK_RE = re.compile(f"[{chr(0x4E00)}-{chr(0x9FFF)}]")  # CJK 统一表意文字块
+
+# 编码回退链：UTF-8（含 BOM）→ GB18030（GB18030 是 GBK 超集，无需单独回退）
+_ENCODINGS = ("utf-8-sig", "gb18030")
+
+
+def decode_csv_bytes(raw: bytes) -> str:
+    """把上传字节解码为文本，兼容 UTF-8 / GBK 系编码。"""
+    if not raw:
+        raise ValueError("空文件")
+    last_err: Exception | None = None
+    for enc in _ENCODINGS:
+        try:
+            return raw.decode(enc)
+        except (UnicodeDecodeError, LookupError) as e:
+            last_err = e
+    raise ValueError("无法识别文件编码，请另存为 UTF-8 或 GBK 后重试") from last_err
+
+
+def _is_code_cell(cell: str) -> bool:
+    # 调用方（parse_csv_rows）已 strip 过单元格
+    return bool(_CODE_RE.fullmatch(cell))
+
+
+def _pick_name(cells: list[str]) -> str | None:
+    """取行内首个含 ≥2 个汉字且非六位代码的单元格作为名称候选。"""
+    for cell in cells:
+        if not cell or _is_code_cell(cell):
+            continue
+        if len(_CJK_RE.findall(cell)) >= 2:
+            return cell
+    return None
+
+
+def parse_csv_rows(text: str) -> list[tuple[list[str], str | None]]:
+    """解析 CSV/TXT 文本为 [(行内代码列表, 名称候选), ...]。
+
+    - 自动识别逗号 / Tab 分隔（同花顺/通达信导出常见 Tab）。
+    - 逐行取所有六位数字作为代码候选；无代码行保留给名称兜底（是否输出由
+      import_watchlist_csv 决定：表头等名称命不中主数据的行会被忽略）。
+    - 返回列表保持文件行序。
+    """
+    if not text.strip():
+        return []
+
+    first = next((ln for ln in text.splitlines() if ln.strip()), "")
+    delimiter = "\t" if first.count("\t") > first.count(",") else ","
+    reader = csv.reader(io.StringIO(text), delimiter=delimiter)
+
+    rows: list[tuple[list[str], str | None]] = []
+    for raw_row in reader:
+        cells = [c.strip() for c in raw_row if c is not None]
+        if not cells:
+            continue
+        codes: list[str] = []
+        for cell in cells:
+            codes.extend(m.group(1) for m in _CODE_RE.finditer(cell))
+        rows.append((codes, _pick_name(cells)))
+    return rows
+
+
+def import_watchlist_csv(
+    raw: bytes,
+    data_dir: Path,
+    *,
+    existing_symbols: set[str] | None = None,
+) -> dict[str, Any]:
+    """解析 CSV/TXT 并返回候选列表（不写入自选）。返回结构与 OCR 一致。"""
+    text = decode_csv_bytes(raw)
+    rows = parse_csv_rows(text)
+
+    code_to_symbol, symbol_to_name = build_instrument_lookups(data_dir)
+    # 名称兜底反向表：CSV 可能只有名称列（无代码）
+    name_to_symbol: dict[str, str] = {}
+    for symbol, name in symbol_to_name.items():
+        name_to_symbol.setdefault(name, symbol)
+
+    existing = existing_symbols or set()
+    # 全部唯一代码按出现顺序一次性构建候选（复用 OCR 的构造逻辑，单一来源）
+    unique_codes: list[str] = []
+    for row_codes, _ in rows:
+        for c in row_codes:
+            if c not in unique_codes:
+                unique_codes.append(c)
+    cand_by_code = {
+        c.code: c
+        for c in resolve_candidates(unique_codes, code_to_symbol, symbol_to_name, existing)
+    }
+
+    candidates: list[dict[str, Any]] = []
+    seen_symbols: set[str] = set()       # 已发出的已匹配 symbol
+    emitted_unmatched: set[str] = set()  # 已发出的未匹配 code
+    for row_codes, row_name in rows:
+        # 行内代码优先：取第一个已匹配主数据的（避免价格/成交量数字误报）
+        matched = next((cand_by_code[c] for c in row_codes if cand_by_code[c].matched), None)
+        symbol = matched.symbol if matched else (name_to_symbol.get(row_name) if row_name else None)
+        if symbol:
+            if symbol in seen_symbols:
+                continue
+            seen_symbols.add(symbol)
+            cand = matched or ImportCandidate(
+                code=row_codes[0] if row_codes else "",
+                symbol=symbol,
+                name=symbol_to_name.get(symbol),
+                matched=True,
+                already_in_watchlist=symbol in existing,
+            )
+        else:
+            # 名称兜底失败且无代码 → 表头/杂项行，忽略
+            if not row_codes:
+                continue
+            code = row_codes[0]
+            if code in emitted_unmatched:
+                continue
+            emitted_unmatched.add(code)
+            cand = ImportCandidate(
+                code=code,
+                symbol=None,
+                name=row_name,
+                matched=False,
+                already_in_watchlist=False,
+            )
+        candidates.append(cand.to_dict())
+
+    matched_count = sum(1 for c in candidates if c["matched"])
+    return {
+        "provider": "csv",
+        "raw_text": text,
+        "codes": unique_codes,
+        "candidates": candidates,
+        "matched_count": matched_count,
+        "unmatched_count": len(candidates) - matched_count,
+    }

--- a/backend/tests/test_watchlist_csv.py
+++ b/backend/tests/test_watchlist_csv.py
@@ -1,0 +1,230 @@
+"""自选 CSV/TXT 导入：解码、逐行解析、主数据匹配与名称兜底、API 门禁。"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import polars as pl
+import pytest
+from fastapi import HTTPException
+
+from app.api import watchlist as watchlist_api
+from app.api.watchlist import import_from_csv
+from app.services import watchlist
+from app.services.watchlist_csv import (
+    decode_csv_bytes,
+    import_watchlist_csv,
+    parse_csv_rows,
+)
+
+
+def _write_instruments(data_dir: Path) -> None:
+    inst = data_dir / "instruments"
+    inst.mkdir()
+    pl.DataFrame(
+        {
+            "code": ["600036", "515880"],
+            "symbol": ["600036.SH", "515880.SH"],
+            "name": ["招商银行", "通信ETF国泰"],
+        }
+    ).write_parquet(inst / "instruments.parquet")
+
+
+def _mock_upload(*, content: bytes, content_type: str = "text/csv", filename: str = "watchlist.csv") -> MagicMock:
+    file = MagicMock()
+    file.content_type = content_type
+    file.filename = filename
+    file.read = AsyncMock(return_value=content)
+    return file
+
+
+def _mock_request(data_dir: Path) -> MagicMock:
+    request = MagicMock()
+    request.app.state.repo.store.data_dir = data_dir
+    request.app.state.repo.get_name_map = lambda _symbols: {}
+    return request
+
+
+# ---- 解码 ----
+
+def test_decode_utf8_bom_stripped():
+    raw = "代码,名称\n600036,招商银行\n".encode("utf-8-sig")
+    text = decode_csv_bytes(raw)
+    assert not text.startswith("﻿")
+    assert "招商银行" in text
+
+
+def test_decode_gbk_fallback():
+    raw = "600519,贵州茅台\n".encode("gbk")
+    assert "贵州茅台" in decode_csv_bytes(raw)
+
+
+def test_decode_unknown_encoding_raises():
+    # 同时破坏 UTF-8 与 GBK 系编码的字节序列
+    raw = b"\x00\x80\x00\x80\x00\x80"
+    with pytest.raises(ValueError, match="编码"):
+        decode_csv_bytes(raw)
+
+
+def test_decode_empty_raises():
+    with pytest.raises(ValueError, match="空文件"):
+        decode_csv_bytes(b"")
+
+
+# ---- 解析 ----
+
+def test_parse_comma_csv_with_header():
+    text = "股票代码,股票名称,最新价\n600036,招商银行,42.50\n515880,通信ETF,1.34\n"
+    rows = parse_csv_rows(text)
+    # 表头行保留（无代码），由 import 层按名称是否命中主数据过滤
+    assert rows[0] == ([], "股票代码")
+    assert [(codes, name) for codes, name in rows[1:]] == [
+        (["600036"], "招商银行"),
+        (["515880"], "通信ETF"),
+    ]
+
+
+def test_parse_tab_separated():
+    text = "600036\t招商银行\t42.50\n515880\t通信ETF\t1.34\n"
+    rows = parse_csv_rows(text)
+    assert [(codes, name) for codes, name in rows] == [
+        (["600036"], "招商银行"),
+        (["515880"], "通信ETF"),
+    ]
+
+
+def test_parse_plain_codes_one_per_line():
+    text = "600036\n515880\n"
+    assert [codes for codes, _ in parse_csv_rows(text)] == [["600036"], ["515880"]]
+
+
+def test_parse_concatenated_code_name_cell():
+    # 通达信风格：代码+名称在同一字段
+    text = "600036招商银行\n515880通信ETF国泰\n"
+    rows = parse_csv_rows(text)
+    assert [(codes, name) for codes, name in rows] == [
+        (["600036"], "600036招商银行"),
+        (["515880"], "515880通信ETF国泰"),
+    ]
+
+
+# ---- 主数据匹配 / 名称兜底 ----
+
+def test_import_matched_name_fallback_and_unmatched(tmp_path: Path):
+    _write_instruments(tmp_path)
+    raw = (
+        "代码,名称,现价\n"
+        "600036,招商银行,42.50\n"
+        "通信ETF国泰,1.34\n"
+        "000001,平安银行\n"
+        "999999,不存在,1.00\n"
+    ).encode()
+    res = import_watchlist_csv(raw, tmp_path, existing_symbols={"600036.SH"})
+
+    by_code = {c["code"]: c for c in res["candidates"]}
+    assert by_code["600036"]["matched"] and by_code["600036"]["already_in_watchlist"]
+    assert by_code["600036"]["name"] == "招商银行"
+    # 名称兜底命中（无代码行）
+    assert any(
+        c["symbol"] == "515880.SH" and c["matched"] and c["name"] == "通信ETF国泰"
+        for c in res["candidates"]
+    )
+    assert by_code["000001"]["matched"] is False
+    assert by_code["999999"]["matched"] is False
+    assert res["matched_count"] == 2
+    assert res["unmatched_count"] == 2
+    assert res["provider"] == "csv"
+    assert res["codes"] == ["600036", "000001", "999999"]
+
+
+def test_import_dedupe_and_header_skipped(tmp_path: Path):
+    _write_instruments(tmp_path)
+    raw = "代码,名称\n600036,招商银行\n600036,招商银行\n515880,通信ETF国泰\n".encode()
+    res = import_watchlist_csv(raw, tmp_path)
+    symbols = [c["symbol"] for c in res["candidates"]]
+    assert symbols == ["600036.SH", "515880.SH"]
+
+
+def test_import_junk_rows_ignored(tmp_path: Path):
+    _write_instruments(tmp_path)
+    raw = "hello,world\n600036,招商银行\n,,\n".encode()
+    res = import_watchlist_csv(raw, tmp_path)
+    assert [c["symbol"] for c in res["candidates"]] == ["600036.SH"]
+
+
+# ---- API 门禁 ----
+
+@pytest.mark.asyncio
+async def test_import_csv_rejects_bad_extension(tmp_path: Path):
+    request = _mock_request(tmp_path)
+    # 类型与扩展名都非白名单 → 拒绝
+    file = _mock_upload(
+        content=b"x",
+        content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        filename="watchlist.xlsx",
+    )
+    with pytest.raises(HTTPException) as ei:
+        await import_from_csv(request, file)
+    assert ei.value.status_code == 400
+    assert "仅支持" in str(ei.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_import_csv_rejects_oversized_bytes(tmp_path: Path):
+    request = _mock_request(tmp_path)
+    file = _mock_upload(content=b"x" * (5 * 1024 * 1024 + 1))
+    with pytest.raises(HTTPException) as ei:
+        await import_from_csv(request, file)
+    assert ei.value.status_code == 400
+    assert "过大" in str(ei.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_import_csv_rejects_empty(tmp_path: Path):
+    request = _mock_request(tmp_path)
+    file = _mock_upload(content=b"")
+    with pytest.raises(HTTPException) as ei:
+        await import_from_csv(request, file)
+    assert ei.value.status_code == 400
+    assert "空文件" in str(ei.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_import_csv_no_candidates_raises(tmp_path: Path, monkeypatch):
+    _write_instruments(tmp_path)
+    monkeypatch.setattr(watchlist, "list_symbols", lambda: [])
+    request = _mock_request(tmp_path)
+    file = _mock_upload(content=b"hello\nworld\n")
+    with pytest.raises(HTTPException) as ei:
+        await import_from_csv(request, file)
+    assert ei.value.status_code == 400
+    assert "未识别" in str(ei.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_import_csv_maps_value_error_to_400(tmp_path: Path, monkeypatch):
+    request = _mock_request(tmp_path)
+    monkeypatch.setattr(watchlist, "list_symbols", lambda: [])
+
+    def boom(*_a, **_k):
+        raise ValueError("无法识别文件编码")
+
+    monkeypatch.setattr(watchlist_api, "import_watchlist_csv", boom)
+    file = _mock_upload(content=b"x")
+    with pytest.raises(HTTPException) as ei:
+        await import_from_csv(request, file)
+    assert ei.value.status_code == 400
+    assert "编码" in str(ei.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_import_csv_success(tmp_path: Path, monkeypatch):
+    _write_instruments(tmp_path)
+    monkeypatch.setattr(watchlist, "list_symbols", lambda: [])
+    request = _mock_request(tmp_path)
+    file = _mock_upload(content="代码,名称\n600036,招商银行\n515880,通信ETF国泰\n".encode())
+    res = await import_from_csv(request, file)
+    assert res["provider"] == "csv"
+    assert res["matched_count"] == 2
+    assert {c["symbol"] for c in res["candidates"]} == {"600036.SH", "515880.SH"}
+    assert "raw_text" not in res

--- a/frontend/src/components/WatchlistImportDialog.tsx
+++ b/frontend/src/components/WatchlistImportDialog.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { ImagePlus, Loader2, Upload, X } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
+import { FileText, ImagePlus, Loader2, Upload, X, type LucideIcon } from 'lucide-react'
 import { Modal } from '@/components/Modal'
 import { toast } from '@/components/Toast'
 import { api, type WatchlistImportCandidate } from '@/lib/api'
@@ -11,11 +11,17 @@ interface Props {
   onClose: () => void
 }
 
+type ImportMode = 'image' | 'csv'
+
 /** 一次最多排队识别的图片数，避免误选大量文件拖垮小内存机器。 */
 const MAX_IMPORT_IMAGES = 10
 
 function isImageFile(file: File): boolean {
   return file.type.startsWith('image/') || /\.(jpe?g|png|webp|bmp|gif)$/i.test(file.name)
+}
+
+function isCsvFile(file: File): boolean {
+  return /\.(csv|txt)$/i.test(file.name)
 }
 
 /** 按 code 合并多图 OCR 结果：优先保留已匹配项，已在自选取并集。 */
@@ -47,16 +53,83 @@ export function mergeImportCandidates(
   return [...byCode.values()]
 }
 
+/** 默认勾选可添加的已匹配候选。 */
+function defaultSelected(list: WatchlistImportCandidate[]): Set<string> {
+  return new Set(
+    list.filter(c => c.matched && c.symbol && !c.already_in_watchlist).map(c => c.symbol!),
+  )
+}
+
+interface FileDropzoneProps {
+  inputRef: RefObject<HTMLInputElement>
+  accept: string
+  multiple?: boolean
+  icon: LucideIcon
+  label: string
+  busyLabel: string
+  busy: boolean
+  onPick: (list: FileList | File[] | null | undefined) => void
+}
+
+/** 隐藏 file input + 虚线拖拽上传按钮（截图 / CSV 两个页签共用）。 */
+function FileDropzone({
+  inputRef,
+  accept,
+  multiple,
+  icon: Icon,
+  label,
+  busyLabel,
+  busy,
+  onPick,
+}: FileDropzoneProps) {
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        multiple={multiple}
+        accept={accept}
+        className="hidden"
+        onChange={e => {
+          onPick(e.target.files)
+          e.target.value = ''
+        }}
+      />
+      <button
+        type="button"
+        disabled={busy}
+        onClick={() => inputRef.current?.click()}
+        onDragOver={e => { e.preventDefault(); e.stopPropagation() }}
+        onDrop={e => {
+          e.preventDefault()
+          onPick(e.dataTransfer.files)
+        }}
+        className="w-full flex flex-col items-center justify-center gap-2 rounded-btn border border-dashed border-border bg-elevated/40 hover:bg-elevated/70 px-4 py-6 text-secondary transition-colors disabled:opacity-50"
+      >
+        {busy ? (
+          <Loader2 className="h-6 w-6 animate-spin text-accent" />
+        ) : (
+          <Icon className="h-6 w-6 text-accent" />
+        )}
+        <span className="text-xs">{busy ? busyLabel : label}</span>
+      </button>
+    </>
+  )
+}
+
 export function WatchlistImportDialog({ open, onClose }: Props) {
   const inputRef = useRef<HTMLInputElement>(null)
+  const csvInputRef = useRef<HTMLInputElement>(null)
   const abortRef = useRef<AbortController | null>(null)
   const genRef = useRef(0)
+  const [mode, setMode] = useState<ImportMode>('image')
   const [busy, setBusy] = useState(false)
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(null)
   const [provider, setProvider] = useState<string>('')
   const [candidates, setCandidates] = useState<WatchlistImportCandidate[]>([])
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [previewUrls, setPreviewUrls] = useState<string[]>([])
+  const [csvFileName, setCsvFileName] = useState('')
   const [ocrAvailable, setOcrAvailable] = useState<boolean | null>(null)
   const [installHint, setInstallHint] = useState('')
   const batchAdd = useWatchlistBatchAdd()
@@ -73,11 +146,13 @@ export function WatchlistImportDialog({ open, onClose }: Props) {
 
   const reset = useCallback(() => {
     abortInFlight()
+    setMode('image')
     setBusy(false)
     setProgress(null)
     setCandidates([])
     setSelected(new Set())
     setProvider('')
+    setCsvFileName('')
     setOcrAvailable(null)
     setInstallHint('')
     setPreviewUrls(prev => {
@@ -85,6 +160,7 @@ export function WatchlistImportDialog({ open, onClose }: Props) {
       return []
     })
     if (inputRef.current) inputRef.current.value = ''
+    if (csvInputRef.current) csvInputRef.current.value = ''
   }, [abortInFlight, revokePreviews])
 
   useEffect(() => {
@@ -169,12 +245,7 @@ export function WatchlistImportDialog({ open, onClose }: Props) {
       const merged = mergeImportCandidates(mergedLists)
       setProvider(lastProvider)
       setCandidates(merged)
-      const defaults = new Set(
-        merged
-          .filter(c => c.matched && c.symbol && !c.already_in_watchlist)
-          .map(c => c.symbol!),
-      )
-      setSelected(defaults)
+      setSelected(defaultSelected(merged))
 
       if (merged.length === 0) {
         toast(
@@ -197,9 +268,45 @@ export function WatchlistImportDialog({ open, onClose }: Props) {
     }
   }
 
+  const runCsvImport = async (file: File) => {
+    if (!isCsvFile(file)) {
+      toast('请选择 CSV 或 TXT 文件', 'error')
+      return
+    }
+    abortInFlight()
+    const controller = new AbortController()
+    abortRef.current = controller
+    const gen = genRef.current
+
+    setBusy(true)
+    setCandidates([])
+    setSelected(new Set())
+    setCsvFileName(file.name)
+    try {
+      const res = await api.watchlistImportCsv(file, controller.signal, true)
+      if (gen !== genRef.current) return
+      setCandidates(res.candidates)
+      setSelected(defaultSelected(res.candidates))
+      if (res.candidates.every(c => !c.matched)) {
+        toast('识别到代码但未能匹配证券主数据', 'error')
+      }
+    } catch (err) {
+      if (gen !== genRef.current) return
+      if (controller.signal.aborted) return
+      toast(err instanceof Error ? err.message : 'CSV 解析失败', 'error')
+    } finally {
+      if (gen === genRef.current) setBusy(false)
+    }
+  }
+
   const onPick = (list: FileList | File[] | null | undefined) => {
     if (!list || list.length === 0) return
     void runRecognizeQueue(Array.from(list))
+  }
+
+  const onCsvPick = (list: FileList | File[] | null | undefined) => {
+    if (!list || list.length === 0) return
+    void runCsvImport(list[0])
   }
 
   const toggle = (symbol: string) => {
@@ -254,13 +361,15 @@ export function WatchlistImportDialog({ open, onClose }: Props) {
       <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
         <div>
           <h2 id="watchlist-import-title" className="text-sm font-semibold text-foreground">
-            从截图导入自选
+            导入自选
           </h2>
           <p className="text-[11px] text-muted mt-0.5">
-            {ocrBlocked
-              ? 'OCR 引擎不可用'
-              : '可多选截图，将逐张识别并合并结果后确认添加'}
-            {provider ? ` · ${provider}` : ''}
+            {mode === 'image'
+              ? (ocrBlocked
+                ? 'OCR 引擎不可用'
+                : '可多选截图，将逐张识别并合并结果后确认添加')
+              : '支持含证券代码或名称的 CSV / TXT（UTF-8 或 GBK）'}
+            {mode === 'image' && provider ? ` · ${provider}` : ''}
           </p>
         </div>
         <button
@@ -273,124 +382,147 @@ export function WatchlistImportDialog({ open, onClose }: Props) {
         </button>
       </div>
 
+      <div className="px-4 pt-3 shrink-0">
+        <div className="flex gap-1 rounded-lg bg-elevated/60 p-0.5">
+          <button
+            type="button"
+            onClick={() => setMode('image')}
+            className={`flex-1 inline-flex items-center justify-center gap-1.5 py-1.5 rounded-md text-[11px] font-medium transition-colors ${
+              mode === 'image' ? 'bg-surface text-foreground shadow-sm' : 'text-muted hover:text-secondary'
+            }`}
+          >
+            <ImagePlus className="h-3.5 w-3.5" />
+            截图识别
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode('csv')}
+            className={`flex-1 inline-flex items-center justify-center gap-1.5 py-1.5 rounded-md text-[11px] font-medium transition-colors ${
+              mode === 'csv' ? 'bg-surface text-foreground shadow-sm' : 'text-muted hover:text-secondary'
+            }`}
+          >
+            <FileText className="h-3.5 w-3.5" />
+            CSV 文件
+          </button>
+        </div>
+      </div>
+
       <div className="px-4 py-3 overflow-y-auto flex-1 space-y-3">
-        {ocrBlocked ? (
-          <div className="rounded-btn border border-border bg-elevated/40 px-4 py-5 text-xs text-secondary leading-relaxed whitespace-pre-wrap">
-            {installHint}
-          </div>
+        {mode === 'image' ? (
+          ocrBlocked ? (
+            <div className="rounded-btn border border-border bg-elevated/40 px-4 py-5 text-xs text-secondary leading-relaxed whitespace-pre-wrap">
+              {installHint}
+            </div>
+          ) : (
+            <>
+              <FileDropzone
+                inputRef={inputRef}
+                accept="image/jpeg,image/png,image/webp,image/bmp,image/gif,.jpg,.jpeg,.png"
+                multiple
+                icon={ImagePlus}
+                label={ocrAvailable === null ? '检查 OCR…' : '点击选择或拖拽截图（支持多选）'}
+                busyLabel={progressLabel ?? '检查 OCR…'}
+                busy={busy || ocrAvailable === null}
+                onPick={onPick}
+              />
+
+              {previewUrls.length > 0 && (
+                <div className="flex gap-2 overflow-x-auto pb-1">
+                  {previewUrls.map((url, i) => (
+                    <div
+                      key={url}
+                      className="shrink-0 w-20 h-20 rounded-btn overflow-hidden border border-border bg-black/40"
+                    >
+                      <img
+                        src={url}
+                        alt={`预览 ${i + 1}`}
+                        className="w-full h-full object-contain"
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
+          )
         ) : (
           <>
-            <input
-              ref={inputRef}
-              type="file"
-              multiple
-              accept="image/jpeg,image/png,image/webp,image/bmp,image/gif,.jpg,.jpeg,.png"
-              className="hidden"
-              onChange={e => {
-                onPick(e.target.files)
-                e.target.value = ''
-              }}
+            <FileDropzone
+              inputRef={csvInputRef}
+              accept=".csv,.txt,text/csv,text/plain"
+              icon={FileText}
+              label="点击选择或拖拽 CSV / TXT 文件"
+              busyLabel="解析中…"
+              busy={busy}
+              onPick={onCsvPick}
             />
 
-            <button
-              type="button"
-              disabled={busy || ocrAvailable === null}
-              onClick={() => inputRef.current?.click()}
-              onDragOver={e => { e.preventDefault(); e.stopPropagation() }}
-              onDrop={e => {
-                e.preventDefault()
-                onPick(e.dataTransfer.files)
-              }}
-              className="w-full flex flex-col items-center justify-center gap-2 rounded-btn border border-dashed border-border bg-elevated/40 hover:bg-elevated/70 px-4 py-6 text-secondary transition-colors disabled:opacity-50"
-            >
-              {busy || ocrAvailable === null ? (
-                <Loader2 className="h-6 w-6 animate-spin text-accent" />
-              ) : (
-                <ImagePlus className="h-6 w-6 text-accent" />
-              )}
-              <span className="text-xs">
-                {progressLabel
-                  ?? (ocrAvailable === null ? '检查 OCR…' : '点击选择或拖拽截图（支持多选）')}
-              </span>
-            </button>
-
-            {previewUrls.length > 0 && (
-              <div className="flex gap-2 overflow-x-auto pb-1">
-                {previewUrls.map((url, i) => (
-                  <div
-                    key={url}
-                    className="shrink-0 w-20 h-20 rounded-btn overflow-hidden border border-border bg-black/40"
-                  >
-                    <img
-                      src={url}
-                      alt={`预览 ${i + 1}`}
-                      className="w-full h-full object-contain"
-                    />
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {candidates.length > 0 && (
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <span className="text-xs text-secondary">
-                    识别 {candidates.length} 个代码 · 匹配 {matched.length} · 已选 {selected.size}
-                  </span>
-                  {selectable.length > 0 && (
-                    <button
-                      type="button"
-                      onClick={toggleAll}
-                      className="text-[11px] text-accent hover:underline"
-                    >
-                      {allSelected ? '取消全选' : '全选可添加'}
-                    </button>
-                  )}
-                </div>
-                <ul className="divide-y divide-border/60 rounded-btn border border-border overflow-hidden">
-                  {candidates.map(c => {
-                    const key = c.symbol || c.code
-                    const disabled = !c.matched || !c.symbol || c.already_in_watchlist
-                    const checked = !!(c.symbol && selected.has(c.symbol))
-                    return (
-                      <li key={key}>
-                        <label
-                          className={`flex items-center gap-3 px-3 py-2.5 text-sm ${
-                            disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:bg-elevated/50'
-                          }`}
-                        >
-                          <input
-                            type="checkbox"
-                            disabled={disabled}
-                            checked={checked}
-                            onChange={() => c.symbol && toggle(c.symbol)}
-                            className="rounded border-border"
-                          />
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-baseline gap-2">
-                              <span className="font-medium text-foreground truncate">
-                                {c.name || (c.matched ? c.symbol : '未匹配')}
-                              </span>
-                              <span className="text-[11px] text-muted tabular-nums shrink-0">
-                                {c.code}
-                                {c.symbol ? ` · ${c.symbol}` : ''}
-                              </span>
-                            </div>
-                            {c.already_in_watchlist && (
-                              <span className="text-[10px] text-muted">已在自选</span>
-                            )}
-                            {!c.matched && (
-                              <span className="text-[10px] text-warning/90">主数据未找到，已跳过</span>
-                            )}
-                          </div>
-                        </label>
-                      </li>
-                    )
-                  })}
-                </ul>
+            {csvFileName && (
+              <div className="flex items-center gap-2 rounded-btn border border-border bg-elevated/40 px-3 py-2 text-xs text-secondary">
+                <FileText className="h-3.5 w-3.5 shrink-0 text-accent" />
+                <span className="truncate flex-1">{csvFileName}</span>
               </div>
             )}
           </>
+        )}
+
+        {candidates.length > 0 && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-secondary">
+                {mode === 'csv' ? '解析' : '识别'} {candidates.length} 个代码 · 匹配 {matched.length} · 已选 {selected.size}
+              </span>
+              {selectable.length > 0 && (
+                <button
+                  type="button"
+                  onClick={toggleAll}
+                  className="text-[11px] text-accent hover:underline"
+                >
+                  {allSelected ? '取消全选' : '全选可添加'}
+                </button>
+              )}
+            </div>
+            <ul className="divide-y divide-border/60 rounded-btn border border-border overflow-hidden">
+              {candidates.map(c => {
+                const key = c.symbol || c.code
+                const disabled = !c.matched || !c.symbol || c.already_in_watchlist
+                const checked = !!(c.symbol && selected.has(c.symbol))
+                return (
+                  <li key={key}>
+                    <label
+                      className={`flex items-center gap-3 px-3 py-2.5 text-sm ${
+                        disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:bg-elevated/50'
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        disabled={disabled}
+                        checked={checked}
+                        onChange={() => c.symbol && toggle(c.symbol)}
+                        className="rounded border-border"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-baseline gap-2">
+                          <span className="font-medium text-foreground truncate">
+                            {c.name || (c.matched ? c.symbol : '未匹配')}
+                          </span>
+                          <span className="text-[11px] text-muted tabular-nums shrink-0">
+                            {c.code}
+                            {c.symbol ? ` · ${c.symbol}` : ''}
+                          </span>
+                        </div>
+                        {c.already_in_watchlist && (
+                          <span className="text-[10px] text-muted">已在自选</span>
+                        )}
+                        {!c.matched && (
+                          <span className="text-[10px] text-warning/90">主数据未找到，已跳过</span>
+                        )}
+                      </div>
+                    </label>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
         )}
       </div>
 
@@ -404,7 +536,7 @@ export function WatchlistImportDialog({ open, onClose }: Props) {
         </button>
         <button
           type="button"
-          disabled={ocrBlocked || selected.size === 0 || batchAdd.isPending || busy}
+          disabled={selected.size === 0 || batchAdd.isPending || busy}
           onClick={() => void confirmAdd()}
           className="h-8 px-3 rounded-btn text-xs inline-flex items-center gap-1.5 bg-accent text-white hover:bg-accent/90 disabled:opacity-40"
         >

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1071,6 +1071,13 @@ export interface StrategyAlertEvent {
 }
 
 // ===== API surface =====
+/** 上传单文件到 /api/watchlist/* 导入端点，返回候选结果。 */
+function uploadWatchlistFile(path: string, file: File, signal?: AbortSignal, quiet = false) {
+  const fd = new FormData()
+  fd.append('file', file)
+  return request<WatchlistImportResult>(path, { method: 'POST', body: fd, signal, quiet })
+}
+
 export const api = {
   health: () => request<{ status: string; version: string; mode: string }>('/health'),
 
@@ -1519,16 +1526,10 @@ export const api = {
     }),
   watchlistOcrStatus: () =>
     request<{ provider: string; available: boolean }>('/api/watchlist/ocr-status'),
-  watchlistImportImage: (file: File, signal?: AbortSignal, quiet = false) => {
-    const fd = new FormData()
-    fd.append('file', file)
-    return request<WatchlistImportResult>('/api/watchlist/import-image', {
-      method: 'POST',
-      body: fd,
-      signal,
-      quiet,
-    })
-  },
+  watchlistImportImage: (file: File, signal?: AbortSignal, quiet = false) =>
+    uploadWatchlistFile('/api/watchlist/import-image', file, signal, quiet),
+  watchlistImportCsv: (file: File, signal?: AbortSignal, quiet = false) =>
+    uploadWatchlistFile('/api/watchlist/import-csv', file, signal, quiet),
   watchlistRemove: (symbol: string) =>
     request<{ symbols: WatchlistEntry[] }>(
       `/api/watchlist/${encodeURIComponent(symbol)}`,

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Trash2, RefreshCw, Star, X, Search, LayoutGrid, List, Settings2, Plus, Check, Filter, Eye, EyeOff, Minus, ChevronsUp, Clock, RotateCcw, ImagePlus } from 'lucide-react'
+import { Trash2, RefreshCw, Star, X, Search, LayoutGrid, List, Settings2, Plus, Check, Filter, Eye, EyeOff, Minus, ChevronsUp, Clock, RotateCcw, Import } from 'lucide-react'
 import { api, type KlineRow, type MinuteKlineRow } from '@/lib/api'
 import { QK } from '@/lib/queryKeys'
 import { storage } from '@/lib/storage'
@@ -16,7 +16,6 @@ import {
   type DimensionMembersTarget,
 } from '@/components/DimensionMembersDialog'
 import { WatchlistImportDialog } from '@/components/WatchlistImportDialog'
-import { getOcrInstallHint } from '@/lib/ocrInstallHint'
 import { ColumnCustomizer } from '@/components/ColumnCustomizer'
 import { StockDataTable } from '@/components/stock-table/StockDataTable'
 import { VIRTUAL_LIST_THRESHOLD, useParentScroll } from '@/components/virtual-list/useParentScroll'
@@ -584,33 +583,12 @@ export function Watchlist() {
   const [columns, setColumns] = useState<ColumnConfig[]>([...BUILTIN_COLUMNS])
   const [customizerOpen, setCustomizerOpen] = useState(false)
   const [importOpen, setImportOpen] = useState(false)
-  const [ocrAvailable, setOcrAvailable] = useState<boolean | null>(null)
-  const [ocrInstallHint, setOcrInstallHint] = useState('')
   const columnsLoaded = useRef(false)
 
   useEffect(() => {
     if (columnsLoaded.current) return
     columnsLoaded.current = true
     loadColumnConfig().then(setColumns)
-  }, [])
-
-  useEffect(() => {
-    let cancelled = false
-    void api.watchlistOcrStatus().then(
-      res => {
-        if (cancelled) return
-        setOcrAvailable(res.available)
-        if (!res.available) setOcrInstallHint(getOcrInstallHint())
-      },
-      () => {
-        if (cancelled) return
-        setOcrAvailable(false)
-        setOcrInstallHint(getOcrInstallHint())
-      },
-    )
-    return () => {
-      cancelled = true
-    }
   }, [])
 
   const handleColumnsChange = useCallback((next: ColumnConfig[]) => {
@@ -1048,19 +1026,11 @@ export function Watchlist() {
               onAdd={(sym) => addMutation.mutate(sym)}
             />
             <button
-              onClick={() => {
-                if (ocrAvailable === false) return
-                setImportOpen(true)
-              }}
-              disabled={ocrAvailable === false}
-              className="inline-flex items-center justify-center h-8 w-8 rounded-btn bg-elevated hover:bg-elevated/80 text-secondary hover:text-foreground transition-colors duration-150 ease-smooth disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-elevated disabled:hover:text-secondary"
-              title={
-                ocrAvailable === false
-                  ? ocrInstallHint || 'OCR 不可用，请先安装 Tesseract'
-                  : '从截图导入自选'
-              }
+              onClick={() => setImportOpen(true)}
+              className="inline-flex items-center justify-center h-8 w-8 rounded-btn bg-elevated hover:bg-elevated/80 text-secondary hover:text-foreground transition-colors duration-150 ease-smooth"
+              title="导入自选（截图识别 / CSV 文件）"
             >
-              <ImagePlus className="h-4 w-4" />
+              <Import className="h-4 w-4" />
             </button>
             <div className="w-px h-5 bg-border" />
             {/* 视图 */}


### PR DESCRIPTION
## Summary

Adds CSV/TXT import for the stock watchlist, complementing the existing screenshot (OCR) import. Users can upload a watchlist exported from Chinese trading apps (comma- or tab-separated, UTF-8 or GBK) and review matched candidates before adding them.

## Backend

- New `POST /api/watchlist/import-csv` endpoint, mirroring the existing `import-image` route:
  - Content-type/extension whitelist (`text/csv`, `text/plain`, `.csv`, `.txt`) and a 5 MB size cap
  - Encoding fallback chain (UTF-8/BOM → GB18030), since trading-app exports are often GBK
  - Per-row parsing: extracts 6-digit codes from any column plus a Chinese-name fallback for code-less rows
  - Returns the same candidate shape as the OCR import, so the frontend reuses the existing review/confirm flow
- Parsing runs in a worker thread to avoid blocking the event loop

## Frontend

- Import dialog gains a "截图识别 / CSV 文件" tab; the CSV tab is not gated on OCR availability
- Toolbar import button is always enabled and uses a generic import icon
- Reuses the existing candidate checkbox + batch-add flow

## Reuse & cleanup

- Code-extraction regex and candidate resolution are imported from the OCR pipeline instead of being reimplemented
- The two drag-drop upload panes are unified into a shared `FileDropzone`
- Dead OCR-gating state removed from the Watchlist page

## Verification

- 31 backend tests pass (17 new CSV + 16 existing OCR)
- `tsc -b` and `vite build` pass
- Smoke-tested against real instrument data

🤖 Generated with [Claude Code](https://claude.com/claude-code)