### PR TITLE
feat(watchlist): add many-to-many tags

### DIFF
--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
@@ -952,6 +953,46 @@ def update_wecom_webhook(req: WecomWebhookPrefsIn) -> dict:
         )
     saved_url = preferences.set_wecom_webhook_url(url)
     return {"wecom_webhook_url": saved_url}
+
+
+class WebhookTestIn(BaseModel):
+    channel: Literal["feishu", "wecom"]
+
+
+@router.post("/preferences/webhook-test")
+def test_webhook(req: WebhookTestIn) -> dict:
+    """向已保存的 Webhook 地址发送一条测试消息，验证配置是否正确。
+
+    只测试已保存的配置（与生产推送同源），不测试未保存草稿。
+    未配置 / 地址非法 / 发送失败均返回 HTTP 200 + {ok: False}，
+    前端统一读 detail 渲染绿/红，不抛 400。
+    """
+    from app.services import preferences
+    from app.services import webhook_adapter
+
+    title = "TickFlow Stock Panel 推送测试"
+    body = "如果你看到这条消息，说明推送配置正确 🎉"
+
+    if req.channel == "feishu":
+        url = preferences.get_feishu_webhook_url()
+        if not url:
+            return {"ok": False, "detail": "尚未配置飞书 Webhook，请先保存"}
+        if not webhook_adapter.is_valid_feishu_url(url):
+            return {"ok": False, "detail": "已保存的飞书 Webhook 地址非法，请重新保存"}
+        secret = preferences.get_feishu_webhook_secret()
+        # 诊断用途单次尝试: 失败即返回, 不等生产退避重试 (~17s)
+        ok = webhook_adapter.send_feishu(url, title, body, secret, max_attempts=1)
+    else:  # wecom
+        url = preferences.get_wecom_webhook_url()
+        if not url:
+            return {"ok": False, "detail": "尚未配置企业微信 Webhook，请先保存"}
+        if not webhook_adapter.is_valid_wecom_url(url):
+            return {"ok": False, "detail": "已保存的企业微信 Webhook 地址非法，请重新保存"}
+        ok = webhook_adapter.send_wecom(url, title, body)
+
+    if ok:
+        return {"ok": True, "detail": "测试消息已发送，请到群内查收"}
+    return {"ok": False, "detail": "推送失败：网络不可达或地址/密钥不正确，详情见后端日志"}
 
 
 class WecomBotPrefsIn(BaseModel):

--- a/backend/app/api/watchlist.py
+++ b/backend/app/api/watchlist.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from app.db_safe import is_valid_ext_ident, quote_ident
 from app.services import watchlist
+from app.services.watchlist_csv import import_watchlist_csv
 from app.services.watchlist_ocr import import_watchlist_image
 from app.services.watchlist_ocr.provider import get_ocr_provider
 
@@ -28,6 +29,13 @@ _IMPORT_IMAGE_TYPES = {
     "image/webp",
     "image/bmp",
     "image/gif",
+}
+# CSV/TXT 导入：文本远小于截图，上限 5MB 足够
+_MAX_IMPORT_CSV_BYTES = 5 * 1024 * 1024
+_IMPORT_CSV_TYPES = {
+    "text/csv",
+    "text/plain",
+    "application/csv",
 }
 # OCR 独立并发上限：避免多张大图同时解码 + 多 Tesseract 子进程
 _OCR_LIMITER = anyio.CapacityLimiter(2)
@@ -87,22 +95,36 @@ def ocr_status():
     return {"provider": provider.name, "available": provider.available()}
 
 
-@router.post("/import-image")
-async def import_from_image(request: Request, file: UploadFile = File(...)):
-    """从自选截图识别股票代码，返回候选列表（不自动写入自选）。"""
+async def _read_upload(
+    file: UploadFile,
+    allowed_types: set[str],
+    allowed_exts: tuple[str, ...],
+    max_bytes: int,
+    reject_msg: str,
+) -> bytes:
+    """校验白名单（类型/扩展名）并读取上传字节，超限抛 400。"""
     content_type = (file.content_type or "").split(";")[0].strip().lower()
     filename = (file.filename or "").lower()
-    # 严格白名单：不接受任意 image/*（如 image/svg+xml）
-    ok_type = content_type in _IMPORT_IMAGE_TYPES
-    ok_ext = filename.endswith((".jpg", ".jpeg", ".png", ".webp", ".bmp", ".gif"))
-    if not ok_type and not ok_ext:
-        raise HTTPException(400, "仅支持 JPG / PNG / WebP / BMP / GIF 图片")
-
+    if content_type not in allowed_types and not filename.endswith(allowed_exts):
+        raise HTTPException(400, reject_msg)
     data = await file.read()
     if not data:
         raise HTTPException(400, "空文件")
-    if len(data) > _MAX_IMPORT_IMAGE_BYTES:
-        raise HTTPException(400, "图片过大（上限 12MB）")
+    if len(data) > max_bytes:
+        raise HTTPException(400, f"文件过大（上限 {max_bytes // (1024 * 1024)}MB）")
+    return data
+
+
+@router.post("/import-image")
+async def import_from_image(request: Request, file: UploadFile = File(...)):
+    """从自选截图识别股票代码，返回候选列表（不自动写入自选）。"""
+    data = await _read_upload(
+        file,
+        _IMPORT_IMAGE_TYPES,
+        (".jpg", ".jpeg", ".png", ".webp", ".bmp", ".gif"),
+        _MAX_IMPORT_IMAGE_BYTES,
+        "仅支持 JPG / PNG / WebP / BMP / GIF 图片",
+    )
 
     existing = {r["symbol"] for r in watchlist.list_symbols()}
     data_dir = request.app.state.repo.store.data_dir
@@ -121,6 +143,40 @@ async def import_from_image(request: Request, file: UploadFile = File(...)):
         raise HTTPException(500, f"识别失败: {e}") from e
 
     # 响应不回传整段 raw_text（可能很长）；调试时可开 query，这里默认省略
+    result.pop("raw_text", None)
+    return result
+
+
+@router.post("/import-csv")
+async def import_from_csv(request: Request, file: UploadFile = File(...)):
+    """从 CSV / TXT 导入自选候选列表（不自动写入自选）。
+
+    兼容同花顺/东财/通达信导出（逗号或 Tab 分隔、UTF-8 或 GBK 编码）。
+    """
+    data = await _read_upload(
+        file,
+        _IMPORT_CSV_TYPES,
+        (".csv", ".txt"),
+        _MAX_IMPORT_CSV_BYTES,
+        "仅支持 CSV / TXT 文件",
+    )
+
+    existing = {r["symbol"] for r in watchlist.list_symbols()}
+    data_dir = request.app.state.repo.store.data_dir
+    try:
+        # CSV 解析 + instruments parquet 读取为同步 CPU 操作，挪线程池避免卡事件循环（行情 SSE 等）
+        result = await anyio.to_thread.run_sync(
+            lambda: import_watchlist_csv(data, data_dir, existing_symbols=existing),
+        )
+    except ValueError as e:
+        raise HTTPException(400, str(e)) from e
+    except Exception as e:  # noqa: BLE001
+        logger.exception("watchlist import-csv failed")
+        raise HTTPException(500, f"解析失败: {e}") from e
+
+    if not result["candidates"]:
+        raise HTTPException(400, "文件中未识别到股票代码或名称")
+    # 与 import-image 一致：不回传整段文本
     result.pop("raw_text", None)
     return result
 

--- a/backend/app/api/watchlist.py
+++ b/backend/app/api/watchlist.py
@@ -51,6 +51,10 @@ class BatchAddRequest(BaseModel):
     note: str = ""
 
 
+class SetTagsRequest(BaseModel):
+    tags: list[str] = []
+
+
 def _with_names(rows: list[dict], request: Request) -> list[dict]:
     if not rows:
         return rows
@@ -86,6 +90,15 @@ def add_batch(req: BatchAddRequest, request: Request):
             existing.add(sym)
         watchlist.add(sym, req.note)
     return {"symbols": _with_names(watchlist.list_symbols(), request), "added": added}
+
+
+@router.post("/{symbol}/tags")
+def set_one_tags(symbol: str, req: SetTagsRequest, request: Request):
+    """整体替换某自选标的的标签(多对多, 逗号分隔存储)。"""
+    rows = watchlist.set_tags(symbol, req.tags)
+    if not any(r["symbol"] == symbol for r in rows):
+        raise HTTPException(404, f"自选里没有 {symbol}")
+    return {"symbols": _with_names(rows, request)}
 
 
 @router.get("/ocr-status")
@@ -237,7 +250,8 @@ def watchlist_enriched(
     t0 = time.perf_counter()
 
     repo = request.app.state.repo
-    symbols = [r["symbol"] for r in watchlist.list_symbols()]
+    wl_rows = watchlist.list_symbols()
+    symbols = [r["symbol"] for r in wl_rows]
     if not symbols:
         return {"rows": [], "as_of": None, "elapsed_ms": 0}
 
@@ -302,6 +316,11 @@ def watchlist_enriched(
         pl.col("symbol").replace_strict(name_map, default=None, return_dtype=pl.Utf8).alias("name")
     )
 
+    tag_map = {r["symbol"]: r.get("tags", "") for r in wl_rows}
+    df = df.with_columns(
+        pl.col("symbol").replace_strict(tag_map, default="").alias("tags")
+    )
+
     # 标注资产类型: 前端据此渲染徽标/豁免板块筛选/分时列降级
     asset_map = {**{s: "etf" for s in etf_symbols}, **{s: "index" for s in index_symbols}}
     df = df.with_columns(
@@ -309,7 +328,7 @@ def watchlist_enriched(
     )
 
     # 选择内置需要的列
-    keep = [c for c in _WATCHLIST_COLS + ["name", "float_shares", "asset_type"] if c in df.columns]
+    keep = [c for c in _WATCHLIST_COLS + ["name", "float_shares", "asset_type", "tags"] if c in df.columns]
     df = df.select(keep)
 
     # 动态 JOIN 扩展数据表

--- a/backend/app/services/watchlist.py
+++ b/backend/app/services/watchlist.py
@@ -1,10 +1,12 @@
 """自选股服务(§6.1)。
 
-存储:`data/user_data/watchlist.parquet`,字段 symbol + added_at + note。
+存储:`data/user_data/watchlist.parquet`,字段 symbol + added_at + note + tags。
+tags 为逗号分隔的 Utf8 字符串(空串 = 无标签), 支持多对多标注。
 """
 from __future__ import annotations
 
 import logging
+import threading
 from datetime import datetime
 from pathlib import Path
 
@@ -17,6 +19,13 @@ from app.tickflow.rate_limits import chunked, resolve_limit
 
 logger = logging.getLogger(__name__)
 
+_SCHEMA = {"symbol": pl.Utf8, "added_at": pl.Utf8, "note": pl.Utf8, "tags": pl.Utf8}
+
+_MAX_TAG_LEN = 20
+
+# 进程内互斥: parquet 是 read-modify-write, 防并发请求丢更新(如快速连续打标签)
+_write_lock = threading.Lock()
+
 
 def _path() -> Path:
     p = settings.data_dir / "user_data" / "watchlist.parquet"
@@ -24,70 +33,99 @@ def _path() -> Path:
     return p
 
 
-def list_symbols() -> list[dict]:
+def _read() -> pl.DataFrame:
+    """读取自选表, 兼容旧文件(缺 tags 列时补空列, null 标签归一化为空串)。"""
     p = _path()
-    if not p.exists():
-        return []
-    df = pl.read_parquet(p)
+    df = pl.read_parquet(p) if p.exists() else pl.DataFrame(schema=_SCHEMA)
+    for col, dtype in _SCHEMA.items():
+        if col not in df.columns:
+            df = df.with_columns(pl.lit(None, dtype=dtype).alias(col))
+    # 上面循环已保证 tags 列存在, 只把 null 归一化为空串
+    df = df.with_columns(pl.col("tags").fill_null(""))
+    return df
+
+
+def _write(df: pl.DataFrame) -> None:
+    df.write_parquet(_path())
+
+
+def list_symbols() -> list[dict]:
+    df = _read()
     if df.is_empty():
         return []
     return df.to_dicts()
 
 
 def add(symbol: str, note: str = "") -> list[dict]:
-    p = _path()
-    if p.exists():
-        df = pl.read_parquet(p)
-        # 已存在则先移除，后面重新插入到最前面
+    with _write_lock:
+        df = _read()
+        existing_tags = ""
         if symbol in df["symbol"].to_list():
+            existing_tags = df.filter(pl.col("symbol") == symbol)["tags"].first()
             df = df.filter(pl.col("symbol") != symbol)
-    else:
-        df = pl.DataFrame(schema={"symbol": pl.Utf8, "added_at": pl.Utf8, "note": pl.Utf8})
 
-    new_row = pl.DataFrame({
-        "symbol": [symbol],
-        "added_at": [datetime.utcnow().isoformat(timespec="seconds")],
-        "note": [note],
-    })
-    out = pl.concat([new_row, df], how="diagonal_relaxed")
-    out.write_parquet(p)
-    return out.to_dicts()
+        new_row = pl.DataFrame({
+            "symbol": [symbol],
+            "added_at": [datetime.utcnow().isoformat(timespec="seconds")],
+            "note": [note],
+            "tags": [existing_tags],
+        })
+        out = pl.concat([new_row, df], how="diagonal_relaxed")
+        _write(out)
+        return out.to_dicts()
 
 
 def remove(symbol: str) -> list[dict]:
-    p = _path()
-    if not p.exists():
-        return []
-    df = pl.read_parquet(p)
-    df = df.filter(pl.col("symbol") != symbol)
-    df.write_parquet(p)
-    return df.to_dicts()
+    with _write_lock:
+        df = _read()
+        df = df.filter(pl.col("symbol") != symbol)
+        _write(df)
+        return df.to_dicts()
 
 
 def move_to_top(symbol: str) -> list[dict]:
-    p = _path()
-    if not p.exists():
-        return []
-    df = pl.read_parquet(p)
-    if df.is_empty() or symbol not in df["symbol"].to_list():
-        return df.to_dicts()
-    target = df.filter(pl.col("symbol") == symbol)
-    rest = df.filter(pl.col("symbol") != symbol)
-    out = pl.concat([target, rest], how="diagonal_relaxed")
-    out.write_parquet(p)
-    return out.to_dicts()
+    with _write_lock:
+        df = _read()
+        if df.is_empty() or symbol not in df["symbol"].to_list():
+            return df.to_dicts()
+        target = df.filter(pl.col("symbol") == symbol)
+        rest = df.filter(pl.col("symbol") != symbol)
+        out = pl.concat([target, rest], how="diagonal_relaxed")
+        _write(out)
+        return out.to_dicts()
 
 
 def clear() -> int:
     """清空自选列表。返回移除的数量。"""
-    p = _path()
-    if not p.exists():
-        return 0
-    df = pl.read_parquet(p)
-    count = df.height
-    if count > 0:
-        pl.DataFrame(schema={"symbol": pl.Utf8, "added_at": pl.Utf8, "note": pl.Utf8}).write_parquet(p)
-    return count
+    with _write_lock:
+        df = _read()
+        count = df.height
+        if count > 0:
+            _write(pl.DataFrame(schema=_SCHEMA))
+        return count
+
+
+def _normalize_tags(tags: list[str]) -> list[str]:
+    """规范化标签: trim / 去空 / 去重 / 剥离中英文逗号(防分隔符碰撞), 超长截断到 _MAX_TAG_LEN。"""
+    cleaned = (str(t).strip().replace(",", "").replace("，", "")[:_MAX_TAG_LEN] for t in tags or [])  # noqa: RUF001 有意剥离全角逗号
+    return list(dict.fromkeys(t for t in cleaned if t))
+
+
+def set_tags(symbol: str, tags: list[str]) -> list[dict]:
+    """整体替换某自选标的的标签。symbol 不在自选则原样返回(由 API 层决定 404)。"""
+    with _write_lock:
+        df = _read()
+        if symbol not in df["symbol"].to_list():
+            return df.to_dicts()
+        cleaned = _normalize_tags(tags)
+        df = df.with_columns(
+            pl.when(pl.col("symbol") == symbol)
+              .then(pl.lit(",".join(cleaned)))
+              .otherwise(pl.col("tags"))
+              .alias("tags")
+        )
+        _write(df)
+        return df.to_dicts()
 
 
 def fetch_quotes(symbols: list[str], capset: CapabilitySet, timeout_s: float = 8.0) -> list[dict]:

--- a/backend/app/services/watchlist_csv.py
+++ b/backend/app/services/watchlist_csv.py
@@ -1,0 +1,157 @@
+"""自选股 CSV/TXT 导入：解码 → 逐行抽代码/名称 → instruments 校验。
+
+国内行情软件（同花顺/东财/通达信）导出的自选多为 CSV/TXT，且常为 GBK 系编码
+（参见 ext_data.ensure_utf8_csv 的说明）。本模块负责把上传字节解析为与截图 OCR
+一致的候选结构，前端复用同一套勾选确认流程。
+"""
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from app.services.watchlist_ocr.pipeline import (
+    _CODE_RE,
+    ImportCandidate,
+    build_instrument_lookups,
+    resolve_candidates,
+)
+
+logger = logging.getLogger(__name__)
+
+_CJK_RE = re.compile(f"[{chr(0x4E00)}-{chr(0x9FFF)}]")  # CJK 统一表意文字块
+
+# 编码回退链：UTF-8（含 BOM）→ GB18030（GB18030 是 GBK 超集，无需单独回退）
+_ENCODINGS = ("utf-8-sig", "gb18030")
+
+
+def decode_csv_bytes(raw: bytes) -> str:
+    """把上传字节解码为文本，兼容 UTF-8 / GBK 系编码。"""
+    if not raw:
+        raise ValueError("空文件")
+    last_err: Exception | None = None
+    for enc in _ENCODINGS:
+        try:
+            return raw.decode(enc)
+        except (UnicodeDecodeError, LookupError) as e:
+            last_err = e
+    raise ValueError("无法识别文件编码，请另存为 UTF-8 或 GBK 后重试") from last_err
+
+
+def _is_code_cell(cell: str) -> bool:
+    # 调用方（parse_csv_rows）已 strip 过单元格
+    return bool(_CODE_RE.fullmatch(cell))
+
+
+def _pick_name(cells: list[str]) -> str | None:
+    """取行内首个含 ≥2 个汉字且非六位代码的单元格作为名称候选。"""
+    for cell in cells:
+        if not cell or _is_code_cell(cell):
+            continue
+        if len(_CJK_RE.findall(cell)) >= 2:
+            return cell
+    return None
+
+
+def parse_csv_rows(text: str) -> list[tuple[list[str], str | None]]:
+    """解析 CSV/TXT 文本为 [(行内代码列表, 名称候选), ...]。
+
+    - 自动识别逗号 / Tab 分隔（同花顺/通达信导出常见 Tab）。
+    - 逐行取所有六位数字作为代码候选；无代码行保留给名称兜底（是否输出由
+      import_watchlist_csv 决定：表头等名称命不中主数据的行会被忽略）。
+    - 返回列表保持文件行序。
+    """
+    if not text.strip():
+        return []
+
+    first = next((ln for ln in text.splitlines() if ln.strip()), "")
+    delimiter = "\t" if first.count("\t") > first.count(",") else ","
+    reader = csv.reader(io.StringIO(text), delimiter=delimiter)
+
+    rows: list[tuple[list[str], str | None]] = []
+    for raw_row in reader:
+        cells = [c.strip() for c in raw_row if c is not None]
+        if not cells:
+            continue
+        codes: list[str] = []
+        for cell in cells:
+            codes.extend(m.group(1) for m in _CODE_RE.finditer(cell))
+        rows.append((codes, _pick_name(cells)))
+    return rows
+
+
+def import_watchlist_csv(
+    raw: bytes,
+    data_dir: Path,
+    *,
+    existing_symbols: set[str] | None = None,
+) -> dict[str, Any]:
+    """解析 CSV/TXT 并返回候选列表（不写入自选）。返回结构与 OCR 一致。"""
+    text = decode_csv_bytes(raw)
+    rows = parse_csv_rows(text)
+
+    code_to_symbol, symbol_to_name = build_instrument_lookups(data_dir)
+    # 名称兜底反向表：CSV 可能只有名称列（无代码）
+    name_to_symbol: dict[str, str] = {}
+    for symbol, name in symbol_to_name.items():
+        name_to_symbol.setdefault(name, symbol)
+
+    existing = existing_symbols or set()
+    # 全部唯一代码按出现顺序一次性构建候选（复用 OCR 的构造逻辑，单一来源）
+    unique_codes: list[str] = []
+    for row_codes, _ in rows:
+        for c in row_codes:
+            if c not in unique_codes:
+                unique_codes.append(c)
+    cand_by_code = {
+        c.code: c
+        for c in resolve_candidates(unique_codes, code_to_symbol, symbol_to_name, existing)
+    }
+
+    candidates: list[dict[str, Any]] = []
+    seen_symbols: set[str] = set()       # 已发出的已匹配 symbol
+    emitted_unmatched: set[str] = set()  # 已发出的未匹配 code
+    for row_codes, row_name in rows:
+        # 行内代码优先：取第一个已匹配主数据的（避免价格/成交量数字误报）
+        matched = next((cand_by_code[c] for c in row_codes if cand_by_code[c].matched), None)
+        symbol = matched.symbol if matched else (name_to_symbol.get(row_name) if row_name else None)
+        if symbol:
+            if symbol in seen_symbols:
+                continue
+            seen_symbols.add(symbol)
+            cand = matched or ImportCandidate(
+                code=row_codes[0] if row_codes else "",
+                symbol=symbol,
+                name=symbol_to_name.get(symbol),
+                matched=True,
+                already_in_watchlist=symbol in existing,
+            )
+        else:
+            # 名称兜底失败且无代码 → 表头/杂项行，忽略
+            if not row_codes:
+                continue
+            code = row_codes[0]
+            if code in emitted_unmatched:
+                continue
+            emitted_unmatched.add(code)
+            cand = ImportCandidate(
+                code=code,
+                symbol=None,
+                name=row_name,
+                matched=False,
+                already_in_watchlist=False,
+            )
+        candidates.append(cand.to_dict())
+
+    matched_count = sum(1 for c in candidates if c["matched"])
+    return {
+        "provider": "csv",
+        "raw_text": text,
+        "codes": unique_codes,
+        "candidates": candidates,
+        "matched_count": matched_count,
+        "unmatched_count": len(candidates) - matched_count,
+    }

--- a/backend/app/services/webhook_adapter.py
+++ b/backend/app/services/webhook_adapter.py
@@ -93,7 +93,7 @@ def _truncate_to_bytes(text: str, max_bytes: int, suffix: str = "…") -> str:
 _FEISHU_MAX_ATTEMPTS = 3
 
 
-def _post_feishu(webhook_url: str, payload: dict, secret: str) -> bool:
+def _post_feishu(webhook_url: str, payload: dict, secret: str, max_attempts: int = _FEISHU_MAX_ATTEMPTS) -> bool:
     """发送飞书 webhook 请求并判定成败 (供 text / card 共用)。
 
     成功响应: HTTP 200 且业务 code=0 (或非 JSON/非 dict 的 200)。
@@ -102,11 +102,14 @@ def _post_feishu(webhook_url: str, payload: dict, secret: str) -> bool:
     一次瞬时 5xx/timeout 若不重试, 该告警会被冷却窗口(默认 1h)压掉, 离屏用户彻底
     收不到推送。永久失败 (4xx / 业务 code≠0, 如签名错、URL 失效) 不重试。最终失败
     记 WARNING (而非之前的 debug), 保证「推送丢了」在日志里可见。
+
+    max_attempts: 尝试次数, 默认 3 (生产推送语义)。诊断用途(如手动测试配置)可传 1,
+    避免失败时等满退避重试。
     """
     import httpx
 
     last_err = ""
-    for attempt in range(1, _FEISHU_MAX_ATTEMPTS + 1):
+    for attempt in range(1, max_attempts + 1):
         try:
             # 启用签名校验时, 请求体须带 timestamp + sign (每次重试都重算, 防时间戳过期)
             if secret:
@@ -143,7 +146,7 @@ def _post_feishu(webhook_url: str, payload: dict, secret: str) -> bool:
     return False
 
 
-def send_feishu(webhook_url: str, title: str, body: str, secret: str = "") -> bool:
+def send_feishu(webhook_url: str, title: str, body: str, secret: str = "", max_attempts: int = _FEISHU_MAX_ATTEMPTS) -> bool:
     """推送一条文本消息到飞书群推送 Webhook。
 
     Args:
@@ -151,6 +154,7 @@ def send_feishu(webhook_url: str, title: str, body: str, secret: str = "") -> bo
         title:       消息标题 (与正文拼接为一条文本)
         body:        消息正文
         secret:      签名密钥 (机器人启用了「签名校验」时必填; 留空则不带签名)
+        max_attempts: 尝试次数 (诊断用途可传 1, 默认保持生产重试语义)
 
     Returns:
         True=成功送达, False=失败或 URL 非法。
@@ -164,7 +168,7 @@ def send_feishu(webhook_url: str, title: str, body: str, secret: str = "") -> bo
         return False
 
     payload: dict = {"msg_type": "text", "content": {"text": text}}
-    return _post_feishu(webhook_url, payload, secret)
+    return _post_feishu(webhook_url, payload, secret, max_attempts)
 
 
 def send_feishu_card(webhook_url: str, title: str, subtitle: str, body_md: str, secret: str = "") -> bool:

--- a/backend/tests/test_watchlist_csv.py
+++ b/backend/tests/test_watchlist_csv.py
@@ -1,0 +1,230 @@
+"""自选 CSV/TXT 导入：解码、逐行解析、主数据匹配与名称兜底、API 门禁。"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import polars as pl
+import pytest
+from fastapi import HTTPException
+
+from app.api import watchlist as watchlist_api
+from app.api.watchlist import import_from_csv
+from app.services import watchlist
+from app.services.watchlist_csv import (
+    decode_csv_bytes,
+    import_watchlist_csv,
+    parse_csv_rows,
+)
+
+
+def _write_instruments(data_dir: Path) -> None:
+    inst = data_dir / "instruments"
+    inst.mkdir()
+    pl.DataFrame(
+        {
+            "code": ["600036", "515880"],
+            "symbol": ["600036.SH", "515880.SH"],
+            "name": ["招商银行", "通信ETF国泰"],
+        }
+    ).write_parquet(inst / "instruments.parquet")
+
+
+def _mock_upload(*, content: bytes, content_type: str = "text/csv", filename: str = "watchlist.csv") -> MagicMock:
+    file = MagicMock()
+    file.content_type = content_type
+    file.filename = filename
+    file.read = AsyncMock(return_value=content)
+    return file
+
+
+def _mock_request(data_dir: Path) -> MagicMock:
+    request = MagicMock()
+    request.app.state.repo.store.data_dir = data_dir
+    request.app.state.repo.get_name_map = lambda _symbols: {}
+    return request
+
+
+# ---- 解码 ----
+
+def test_decode_utf8_bom_stripped():
+    raw = "代码,名称\n600036,招商银行\n".encode("utf-8-sig")
+    text = decode_csv_bytes(raw)
+    assert not text.startswith("﻿")
+    assert "招商银行" in text
+
+
+def test_decode_gbk_fallback():
+    raw = "600519,贵州茅台\n".encode("gbk")
+    assert "贵州茅台" in decode_csv_bytes(raw)
+
+
+def test_decode_unknown_encoding_raises():
+    # 同时破坏 UTF-8 与 GBK 系编码的字节序列
+    raw = b"\x00\x80\x00\x80\x00\x80"
+    with pytest.raises(ValueError, match="编码"):
+        decode_csv_bytes(raw)
+
+
+def test_decode_empty_raises():
+    with pytest.raises(ValueError, match="空文件"):
+        decode_csv_bytes(b"")
+
+
+# ---- 解析 ----
+
+def test_parse_comma_csv_with_header():
+    text = "股票代码,股票名称,最新价\n600036,招商银行,42.50\n515880,通信ETF,1.34\n"
+    rows = parse_csv_rows(text)
+    # 表头行保留（无代码），由 import 层按名称是否命中主数据过滤
+    assert rows[0] == ([], "股票代码")
+    assert [(codes, name) for codes, name in rows[1:]] == [
+        (["600036"], "招商银行"),
+        (["515880"], "通信ETF"),
+    ]
+
+
+def test_parse_tab_separated():
+    text = "600036\t招商银行\t42.50\n515880\t通信ETF\t1.34\n"
+    rows = parse_csv_rows(text)
+    assert [(codes, name) for codes, name in rows] == [
+        (["600036"], "招商银行"),
+        (["515880"], "通信ETF"),
+    ]
+
+
+def test_parse_plain_codes_one_per_line():
+    text = "600036\n515880\n"
+    assert [codes for codes, _ in parse_csv_rows(text)] == [["600036"], ["515880"]]
+
+
+def test_parse_concatenated_code_name_cell():
+    # 通达信风格：代码+名称在同一字段
+    text = "600036招商银行\n515880通信ETF国泰\n"
+    rows = parse_csv_rows(text)
+    assert [(codes, name) for codes, name in rows] == [
+        (["600036"], "600036招商银行"),
+        (["515880"], "515880通信ETF国泰"),
+    ]
+
+
+# ---- 主数据匹配 / 名称兜底 ----
+
+def test_import_matched_name_fallback_and_unmatched(tmp_path: Path):
+    _write_instruments(tmp_path)
+    raw = (
+        "代码,名称,现价\n"
+        "600036,招商银行,42.50\n"
+        "通信ETF国泰,1.34\n"
+        "000001,平安银行\n"
+        "999999,不存在,1.00\n"
+    ).encode()
+    res = import_watchlist_csv(raw, tmp_path, existing_symbols={"600036.SH"})
+
+    by_code = {c["code"]: c for c in res["candidates"]}
+    assert by_code["600036"]["matched"] and by_code["600036"]["already_in_watchlist"]
+    assert by_code["600036"]["name"] == "招商银行"
+    # 名称兜底命中（无代码行）
+    assert any(
+        c["symbol"] == "515880.SH" and c["matched"] and c["name"] == "通信ETF国泰"
+        for c in res["candidates"]
+    )
+    assert by_code["000001"]["matched"] is False
+    assert by_code["999999"]["matched"] is False
+    assert res["matched_count"] == 2
+    assert res["unmatched_count"] == 2
+    assert res["provider"] == "csv"
+    assert res["codes"] == ["600036", "000001", "999999"]
+
+
+def test_import_dedupe_and_header_skipped(tmp_path: Path):
+    _write_instruments(tmp_path)
+    raw = "代码,名称\n600036,招商银行\n600036,招商银行\n515880,通信ETF国泰\n".encode()
+    res = import_watchlist_csv(raw, tmp_path)
+    symbols = [c["symbol"] for c in res["candidates"]]
+    assert symbols == ["600036.SH", "515880.SH"]
+
+
+def test_import_junk_rows_ignored(tmp_path: Path):
+    _write_instruments(tmp_path)
+    raw = "hello,world\n600036,招商银行\n,,\n".encode()
+    res = import_watchlist_csv(raw, tmp_path)
+    assert [c["symbol"] for c in res["candidates"]] == ["600036.SH"]
+
+
+# ---- API 门禁 ----
+
+@pytest.mark.asyncio
+async def test_import_csv_rejects_bad_extension(tmp_path: Path):
+    request = _mock_request(tmp_path)
+    # 类型与扩展名都非白名单 → 拒绝
+    file = _mock_upload(
+        content=b"x",
+        content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        filename="watchlist.xlsx",
+    )
+    with pytest.raises(HTTPException) as ei:
+        await import_from_csv(request, file)
+    assert ei.value.status_code == 400
+    assert "仅支持" in str(ei.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_import_csv_rejects_oversized_bytes(tmp_path: Path):
+    request = _mock_request(tmp_path)
+    file = _mock_upload(content=b"x" * (5 * 1024 * 1024 + 1))
+    with pytest.raises(HTTPException) as ei:
+        await import_from_csv(request, file)
+    assert ei.value.status_code == 400
+    assert "过大" in str(ei.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_import_csv_rejects_empty(tmp_path: Path):
+    request = _mock_request(tmp_path)
+    file = _mock_upload(content=b"")
+    with pytest.raises(HTTPException) as ei:
+        await import_from_csv(request, file)
+    assert ei.value.status_code == 400
+    assert "空文件" in str(ei.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_import_csv_no_candidates_raises(tmp_path: Path, monkeypatch):
+    _write_instruments(tmp_path)
+    monkeypatch.setattr(watchlist, "list_symbols", lambda: [])
+    request = _mock_request(tmp_path)
+    file = _mock_upload(content=b"hello\nworld\n")
+    with pytest.raises(HTTPException) as ei:
+        await import_from_csv(request, file)
+    assert ei.value.status_code == 400
+    assert "未识别" in str(ei.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_import_csv_maps_value_error_to_400(tmp_path: Path, monkeypatch):
+    request = _mock_request(tmp_path)
+    monkeypatch.setattr(watchlist, "list_symbols", lambda: [])
+
+    def boom(*_a, **_k):
+        raise ValueError("无法识别文件编码")
+
+    monkeypatch.setattr(watchlist_api, "import_watchlist_csv", boom)
+    file = _mock_upload(content=b"x")
+    with pytest.raises(HTTPException) as ei:
+        await import_from_csv(request, file)
+    assert ei.value.status_code == 400
+    assert "编码" in str(ei.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_import_csv_success(tmp_path: Path, monkeypatch):
+    _write_instruments(tmp_path)
+    monkeypatch.setattr(watchlist, "list_symbols", lambda: [])
+    request = _mock_request(tmp_path)
+    file = _mock_upload(content="代码,名称\n600036,招商银行\n515880,通信ETF国泰\n".encode())
+    res = await import_from_csv(request, file)
+    assert res["provider"] == "csv"
+    assert res["matched_count"] == 2
+    assert {c["symbol"] for c in res["candidates"]} == {"600036.SH", "515880.SH"}
+    assert "raw_text" not in res

--- a/backend/tests/test_watchlist_tags.py
+++ b/backend/tests/test_watchlist_tags.py
@@ -1,0 +1,92 @@
+"""自选标签 (watchlist) 服务单测: set_tags 往返 + 旧文件 schema 兼容。
+
+存储是 `data/user_data/watchlist.parquet`, 通过 patch `_path()` 隔离到 tmp 目录。
+"""
+from unittest.mock import patch
+
+import polars as pl
+
+from app.services import watchlist
+
+
+def _patch_path(tmp_path):
+    return patch.object(watchlist, "_path", return_value=tmp_path / "watchlist.parquet")
+
+
+def test_set_tags_roundtrip_normalize(tmp_path):
+    with _patch_path(tmp_path):
+        watchlist.add("600519.SH")
+        watchlist.add("000858.SZ", note="茅台")
+
+        # 去重 / trim / 剥离中英文逗号 (chr(0xFF0C) = 全角逗号)
+        watchlist.set_tags("600519.SH", ["白酒", "白酒", " 短期 ", "困境,反转", chr(0xFF0C) + "测试"])
+        rows = watchlist.list_symbols()
+        by_symbol = {r["symbol"]: r for r in rows}
+        assert by_symbol["600519.SH"]["tags"] == "白酒,短期,困境反转,测试"
+        assert by_symbol["000858.SZ"]["tags"] == ""
+
+        # 整体替换清空
+        watchlist.set_tags("600519.SH", [])
+        rows = watchlist.list_symbols()
+        assert {r["symbol"]: r["tags"] for r in rows}["600519.SH"] == ""
+
+
+def test_normalize_truncates_to_max_len(tmp_path):
+    with _patch_path(tmp_path):
+        watchlist.add("600519.SH")
+        watchlist.set_tags("600519.SH", ["很" * 50])
+        rows = watchlist.list_symbols()
+        assert rows[0]["tags"] == "很" * 20
+
+
+def test_add_preserves_tags_on_readd(tmp_path):
+    with _patch_path(tmp_path):
+        watchlist.add("600519.SH")
+        watchlist.set_tags("600519.SH", ["白酒"])
+        # 重新插入到最前 (同 symbol), 标签应保留
+        watchlist.add("600519.SH")
+        rows = watchlist.list_symbols()
+        assert rows[0]["symbol"] == "600519.SH"
+        assert rows[0]["tags"] == "白酒"
+
+
+def test_old_file_without_tags_column_is_normalized(tmp_path):
+    p = tmp_path / "watchlist.parquet"
+    # 模拟旧版本文件: 只有 symbol/added_at/note, 无 tags 列
+    pl.DataFrame({
+        "symbol": ["600519.SH"],
+        "added_at": ["2026-01-01T00:00:00"],
+        "note": [""],
+    }).write_parquet(p)
+    with _patch_path(tmp_path):
+        rows = watchlist.list_symbols()
+        assert rows[0]["symbol"] == "600519.SH"
+        assert rows[0]["tags"] == ""
+
+        # 旧文件上的 set_tags 应正常工作且写出新列
+        watchlist.set_tags("600519.SH", ["白酒"])
+        rows = watchlist.list_symbols()
+        assert rows[0]["tags"] == "白酒"
+
+
+def test_clear_keeps_tags_column(tmp_path):
+    with _patch_path(tmp_path):
+        watchlist.add("600519.SH")
+        watchlist.set_tags("600519.SH", ["白酒"])
+        assert watchlist.clear() == 1
+        watchlist.add("000858.SZ")
+        rows = watchlist.list_symbols()
+        assert len(rows) == 1
+        assert rows[0]["tags"] == ""
+
+
+def test_remove_preserves_schema(tmp_path):
+    with _patch_path(tmp_path):
+        watchlist.add("600519.SH")
+        watchlist.add("000858.SZ")
+        watchlist.set_tags("600519.SH", ["白酒"])
+        watchlist.remove("000858.SZ")
+        rows = watchlist.list_symbols()
+        assert len(rows) == 1
+        assert rows[0]["symbol"] == "600519.SH"
+        assert rows[0]["tags"] == "白酒"

--- a/backend/tests/test_webhook_test.py
+++ b/backend/tests/test_webhook_test.py
@@ -1,0 +1,94 @@
+"""Webhook 测试消息功能 — 向已保存的 Webhook 地址发送测试消息验证配置。
+
+纯逻辑，不触网（monkeypatch webhook_adapter.send_*），直接调用 settings 端点函数。
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.settings import (
+    WebhookTestIn,
+)
+from app.api.settings import (
+    test_webhook as run_webhook_test,
+)
+
+FEISHU_URL = "https://open.feishu.cn/open-apis/bot/v2/hook/test"
+WECOM_URL = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=test-key"
+
+
+def test_feishu_sends_saved_url_and_secret(monkeypatch):
+    calls = {}
+    monkeypatch.setattr("app.services.preferences.get_feishu_webhook_url", lambda: FEISHU_URL)
+    monkeypatch.setattr("app.services.preferences.get_feishu_webhook_secret", lambda: "my-secret")
+    monkeypatch.setattr(
+        "app.services.webhook_adapter.send_feishu",
+        lambda url, title, body, secret="", max_attempts=3: calls.update(
+            url=url, title=title, body=body, secret=secret, max_attempts=max_attempts,
+        ) or True,
+    )
+
+    result = run_webhook_test(WebhookTestIn(channel="feishu"))
+
+    assert result["ok"] is True
+    assert calls["url"] == FEISHU_URL
+    assert calls["secret"] == "my-secret"
+    # 诊断路径单次尝试, 不等生产退避重试
+    assert calls["max_attempts"] == 1
+    assert calls["title"] == "TickFlow Stock Panel 推送测试"
+    assert "推送配置正确" in calls["body"]
+
+
+def test_feishu_send_failure_returns_ok_false(monkeypatch):
+    monkeypatch.setattr("app.services.preferences.get_feishu_webhook_url", lambda: FEISHU_URL)
+    monkeypatch.setattr("app.services.preferences.get_feishu_webhook_secret", lambda: "")
+    monkeypatch.setattr("app.services.webhook_adapter.send_feishu", lambda *a, **k: False)
+
+    result = run_webhook_test(WebhookTestIn(channel="feishu"))
+
+    assert result["ok"] is False
+    assert "推送失败" in result["detail"]
+
+
+@pytest.mark.parametrize("channel,url_getter", [
+    ("feishu", "app.services.preferences.get_feishu_webhook_url"),
+    ("wecom", "app.services.preferences.get_wecom_webhook_url"),
+])
+def test_not_configured_returns_ok_false(monkeypatch, channel, url_getter):
+    monkeypatch.setattr(url_getter, lambda: "")
+
+    result = run_webhook_test(WebhookTestIn(channel=channel))
+
+    assert result["ok"] is False
+    assert "尚未配置" in result["detail"]
+
+
+def test_invalid_saved_feishu_url_returns_ok_false(monkeypatch):
+    monkeypatch.setattr("app.services.preferences.get_feishu_webhook_url", lambda: "https://evil.example/hook/xx")
+
+    result = run_webhook_test(WebhookTestIn(channel="feishu"))
+
+    assert result["ok"] is False
+    assert "地址非法" in result["detail"]
+
+
+def test_wecom_sends_saved_url(monkeypatch):
+    calls = {}
+    monkeypatch.setattr("app.services.preferences.get_wecom_webhook_url", lambda: WECOM_URL)
+    monkeypatch.setattr(
+        "app.services.webhook_adapter.send_wecom",
+        lambda url, title, body: calls.update(url=url, title=title, body=body) or True,
+    )
+
+    result = run_webhook_test(WebhookTestIn(channel="wecom"))
+
+    assert result["ok"] is True
+    assert calls["url"] == WECOM_URL
+    assert calls["title"] == "TickFlow Stock Panel 推送测试"
+    assert "推送配置正确" in calls["body"]
+
+
+def test_unknown_channel_rejected_by_pydantic():
+    with pytest.raises(ValidationError):
+        WebhookTestIn(channel="wecom-bot")

--- a/frontend/src/components/DimensionMembersDialog.tsx
+++ b/frontend/src/components/DimensionMembersDialog.tsx
@@ -4,6 +4,7 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 import { Building2, ChevronRight, RefreshCw, Search, Tags, Users, X } from 'lucide-react'
 import { Modal } from '@/components/Modal'
 import { boardTag } from '@/components/stock-table/primitives'
+import { toNavItems, type NavItem } from '@/components/StockPreviewDialog'
 import { api, type MarketSnapshotRow } from '@/lib/api'
 import { QK } from '@/lib/queryKeys'
 import { fmtBigNum, fmtPct, fmtPrice, priceColorClass } from '@/lib/format'
@@ -29,7 +30,8 @@ export function dimensionKindForSourceField(sourceField: string): DimensionKind 
 interface Props {
   target: DimensionMembersTarget | null
   onClose: () => void
-  onStockClick?: (symbol: string, name?: string) => void
+  /** 第三参 navList: 该对话框当前成员列表 (供 K 线弹窗内切股) */
+  onStockClick?: (symbol: string, name?: string, navList?: NavItem[]) => void
 }
 
 interface ResolvedSource {
@@ -142,6 +144,9 @@ function DimensionMembersDialogContent({ target, onClose, onStockClick }: Omit<P
       return (bv ?? -Infinity) - (av ?? -Infinity)
     })
   }, [rows, search, sortMode])
+
+  // 切股导航列表: 当前可见成员 (随搜索/排序变化, 供 K 线弹窗内切股)
+  const navItems = useMemo(() => toNavItems(visibleRows), [visibleRows])
 
   const stats = useMemo(() => {
     const changes = rows.map(row => finite(row.change_pct)).filter((value): value is number => value != null)
@@ -259,7 +264,7 @@ function DimensionMembersDialogContent({ target, onClose, onStockClick }: Omit<P
                       key={virtualRow.key}
                       ref={rowVirtualizer.measureElement}
                       data-index={virtualRow.index}
-                      onClick={() => onStockClick?.(row.symbol, row.name)}
+                      onClick={() => onStockClick?.(row.symbol, row.name, navItems)}
                       disabled={!onStockClick}
                       className="absolute left-0 top-0 grid min-h-[54px] w-full grid-cols-[minmax(132px,1fr)_74px_74px_18px] items-center border-b border-border/60 px-4 text-left text-xs transition-colors hover:bg-elevated/50 disabled:cursor-default md:grid-cols-[minmax(180px,1fr)_90px_84px_88px_100px_18px]"
                       style={{ transform: `translateY(${virtualRow.start}px)` }}

--- a/frontend/src/components/EChartsCandlestick.tsx
+++ b/frontend/src/components/EChartsCandlestick.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback, useMemo } from 'react'
 import { chartTheme, getTheme, useTheme } from '@/lib/theme'
+import { fmtPct } from '@/lib/format'
 import * as echarts from 'echarts'
 import type { ECharts, EChartsOption } from 'echarts'
 
@@ -808,6 +809,8 @@ export function EChartsCandlestick({
   const infoIdxRef = useRef<number>(data.length - 1)
   const compactRef = useRef(false)
   const userZoomRef = useRef<{ start: number; end: number } | null>(null)
+  // 竖虚线(crosshair)是否可见: 控制信息栏「至今」字段的显隐。鼠标移出图表区即 false。
+  const hoverActiveRef = useRef(false)
 
   // 需要在闭包中访问最新值的变量 — 先声明占位，后面赋值
   const activeIndicatorsRef = useRef(activeIndicators)
@@ -887,7 +890,7 @@ export function EChartsCandlestick({
     const floatShares = stockInfo?.float_shares
     const turnoverRate = floatShares && d.volume ? (d.volume * 100 / floatShares * 100) : null
 
-    let html = `<div style="display:flex;align-items:center;gap:6px;padding:0 8px;font:11px 'JetBrains Mono',monospace;select:none;height:20px;flex-wrap:wrap">`
+    let html = `<div style="display:flex;align-items:center;gap:6px;padding:0 8px;font:11px 'JetBrains Mono',monospace;select:none;min-height:20px;flex-wrap:wrap">`
     html += `<span style="color:${CT().text}">${d.date}</span>`
     html += `<span style="color:${CT().text}">开</span>`
     html += `<span style="color:${d.open >= d.close ? THEME.bear : THEME.bull}">${d.open.toFixed(2)}</span>`
@@ -906,11 +909,25 @@ export function EChartsCandlestick({
       html += `<span style="color:${CT().text}">换手</span>`
       html += `<span style="color:${CT().text}">${turnoverRate.toFixed(2)}%</span>`
     }
+    // 至今: 仅当竖虚线(crosshair)在图上且鼠标悬停某根 K 线时显示。
+    // 最新价取最后一根K线收盘 (后端 _maybe_inject_live_candle 盘中注入实时价, 收盘后即最近收盘)。
+    // 基准取该K线昨收(前一日收盘), 与同花顺及全市场涨幅口径一致; 数据第一根K线无昨收则跳过。
+    if (hoverActiveRef.current && prev && Number.isFinite(prev.close) && prev.close > 0) {
+      const latestPrice = data[data.length - 1].close
+      if (Number.isFinite(latestPrice)) {
+        const sinceRatio = (latestPrice - prev.close) / prev.close
+        const sinceClr = sinceRatio >= 0 ? THEME.bull : THEME.bear
+        html += `<span style="color:${CT().text}">至今</span>`
+        html += `<span style="color:${sinceClr}">${fmtPct(sinceRatio)}</span>`
+        // 周期数: 从该K线(含)到最新一根K线共多少根; 悬停最后一根时为 1
+        html += `<span style="color:${CT().text}">周期 ${data.length - idx}</span>`
+      }
+    }
     html += `</div>`
 
     // 第二行: MA + BOLL
     if (showMA) {
-      html += `<div style="display:flex;align-items:center;gap:10px;padding:0 8px;font:11px 'JetBrains Mono',monospace;select:none;height:20px;flex-wrap:wrap">`
+      html += `<div style="display:flex;align-items:center;gap:10px;padding:0 8px;font:11px 'JetBrains Mono',monospace;select:none;min-height:20px;flex-wrap:wrap">`
       if (d.ma5 != null) html += `<span style="color:${THEME.ma5}">MA5:${Number(d.ma5).toFixed(2)}</span>`
       if (d.ma10 != null) html += `<span style="color:${THEME.ma10}">MA10:${Number(d.ma10).toFixed(2)}</span>`
       if (d.ma20 != null) html += `<span style="color:${THEME.ma20}">MA20:${Number(d.ma20).toFixed(2)}</span>`
@@ -930,6 +947,8 @@ export function EChartsCandlestick({
     infoIdxRef.current = data.length - 1
     compactRef.current = false
     userZoomRef.current = null
+    // 新数据无悬停上下文, 隐藏「至今」; 下次鼠标移动时由 updateAxisPointer 重新置位
+    hoverActiveRef.current = false
   }, [data.length])
 
   // ===== 初始化 chart (只在 chartHeight 变化时重建) =====
@@ -941,32 +960,36 @@ export function EChartsCandlestick({
     chartRef.current = chart
 
     // 鼠标移动 → 只更新 ref + DOM，不触发 React re-render
-    // 设计原则: 找不到有效数据时保持上次显示，永远不清空信息栏
+    // 设计原则: 找不到有效数据时保持上次显示，永远不清空信息栏; 鼠标移出时仅隐藏「至今」。
     chart.on('updateAxisPointer', (event: any) => {
       const axesInfo = event.axesInfo
-      if (!axesInfo) return // 鼠标移出图表区域，保持当前显示
-      for (const info of Object.values(axesInfo)) {
-        const val = (info as any)?.value
-        if (val == null) continue
-        const d = dataRef.current
-        const idx = typeof val === 'number' ? val : d.findIndex(x => x.date === val)
-        if (idx >= 0 && idx < d.length) {
-          if (infoIdxRef.current === idx) return
-          infoIdxRef.current = idx
-
-          // 直接更新信息栏 DOM (通过 ref 读取最新的生成函数)
-          const infoEl = infoBarRef.current
-          if (infoEl) {
-            const html = getInfoBarHTMLRef.current()
-            if (html) infoEl.innerHTML = html  // 只在有内容时更新
-          }
-
-          // 更新子图 graphic
-          triggerInfoBarUpdate()
-          return
+      const d = dataRef.current
+      // 竖虚线是否正落在某根有效 K 线上 (鼠标在图表数据区内)
+      let foundIdx = -1
+      if (axesInfo) {
+        for (const info of Object.values(axesInfo)) {
+          const val = (info as any)?.value
+          if (val == null) continue
+          const idx = typeof val === 'number' ? val : d.findIndex(x => x.date === val)
+          if (idx >= 0 && idx < d.length) { foundIdx = idx; break }
         }
       }
-      // 没有找到有效数据 — 不做任何操作，保持上次显示
+      const active = foundIdx >= 0
+      const idxChanged = foundIdx >= 0 && infoIdxRef.current !== foundIdx
+      const visChanged = active !== hoverActiveRef.current
+      hoverActiveRef.current = active
+      if (idxChanged) infoIdxRef.current = foundIdx
+      // 竖虚线显隐或悬停 K 线变化 → 重绘一次信息栏 (控制「至今」字段显隐 + 当前 K 线数据)
+      if (visChanged || idxChanged) {
+        const infoEl = infoBarRef.current
+        if (infoEl) {
+          const html = getInfoBarHTMLRef.current()
+          if (html) infoEl.innerHTML = html  // 只在有内容时更新
+        }
+      }
+      if (foundIdx < 0) return
+      // 更新子图 graphic (仅悬停 K 线变化时; 纯显隐切换不影响副图)
+      if (idxChanged) triggerInfoBarUpdate()
     })
 
     chart.on('click', (params: any) => {
@@ -1122,7 +1145,7 @@ export function EChartsCandlestick({
     if (!d) return ''
     const floatShares = stockInfo?.float_shares
     const turnoverRate = floatShares && d.volume ? (d.volume * 100 / floatShares * 100) : null
-    let html = `<div style="display:flex;align-items:center;gap:6px;padding:0 8px;font:11px 'JetBrains Mono',monospace;height:20px;flex-wrap:wrap">`
+    let html = `<div style="display:flex;align-items:center;gap:6px;padding:0 8px;font:11px 'JetBrains Mono',monospace;min-height:20px;flex-wrap:wrap">`
     html += `<span style="color:${CT().text}">${d.date}</span>`
     html += `<span style="color:${CT().text}">开</span>`
     html += `<span style="color:${d.open >= d.close ? THEME.bear : THEME.bull}">${d.open.toFixed(2)}</span>`
@@ -1145,7 +1168,7 @@ export function EChartsCandlestick({
     }
     html += `</div>`
     if (showMA) {
-      html += `<div style="display:flex;align-items:center;gap:10px;padding:0 8px;font:11px 'JetBrains Mono',monospace;height:20px;flex-wrap:wrap">`
+      html += `<div style="display:flex;align-items:center;gap:10px;padding:0 8px;font:11px 'JetBrains Mono',monospace;min-height:20px;flex-wrap:wrap">`
       if (d.ma5 != null) html += `<span style="color:${THEME.ma5}">MA5:${Number(d.ma5).toFixed(2)}</span>`
       if (d.ma10 != null) html += `<span style="color:${THEME.ma10}">MA10:${Number(d.ma10).toFixed(2)}</span>`
       if (d.ma20 != null) html += `<span style="color:${THEME.ma20}">MA20:${Number(d.ma20).toFixed(2)}</span>`

--- a/frontend/src/components/StockDailyKChart.tsx
+++ b/frontend/src/components/StockDailyKChart.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { api, type KlineRow } from '@/lib/api'
-import { QK } from '@/lib/queryKeys'
+import { type KlineRow } from '@/lib/api'
+import { klineDailyQueryOptions } from '@/lib/kline'
 import { storage } from '@/lib/storage'
 import {
   EChartsCandlestick,
@@ -11,13 +11,11 @@ import {
   type ChartPriceLine,
   type ChartRange,
   type OHLC,
-  type StockInfo,
   type VolumeCompareConfig,
 } from '@/components/EChartsCandlestick'
 
 const SUB_INFO_H = 16
 const SUB_GAP = 4
-const MAX_DAYS = 2000
 const DEFAULT_VOLUME_COMPARE: VolumeCompareConfig = { enabled: true, days: 1 }
 
 function normalizeVolumeCompare(config: VolumeCompareConfig): VolumeCompareConfig {
@@ -25,13 +23,6 @@ function normalizeVolumeCompare(config: VolumeCompareConfig): VolumeCompareConfi
     enabled: config.enabled !== false,
     days: Math.max(1, Math.min(20, Math.round(Number(config.days) || 1))),
   }
-}
-
-export interface StockDailyKChartResult {
-  rows: OHLC[]
-  rawRows: KlineRow[]
-  stockInfo?: StockInfo
-  name?: string
 }
 
 interface Props {
@@ -50,7 +41,6 @@ interface Props {
   visibleBars?: number
   linkedPrice?: number | null
   onDateClick?: (date: string) => void
-  onDataChange?: (result: StockDailyKChartResult) => void
   /** 扩展数据列参数（逗号分隔 config_id.field_name），透传给 klineDaily 接口 */
   extColumns?: string
 }
@@ -59,7 +49,7 @@ function isValidRow(r: any): boolean {
   return r && r.date != null && r.open != null && r.close != null
 }
 
-export function toOHLC(rows: KlineRow[]): OHLC[] {
+function toOHLC(rows: KlineRow[]): OHLC[] {
   return rows
     .filter(isValidRow)
     .map(r => ({
@@ -110,12 +100,6 @@ export function getDefaultRange(): { start: string; end: string } {
   return { start, end }
 }
 
-function rangeDays(range: { start: string; end: string }): number {
-  const start = new Date(range.start)
-  const end = new Date(range.end)
-  return Math.min(Math.ceil((end.getTime() - start.getTime()) / 86400000) + 30, MAX_DAYS)
-}
-
 export function StockDailyKChart({
   symbol,
   height = 520,
@@ -132,7 +116,6 @@ export function StockDailyKChart({
   visibleBars = 60,
   linkedPrice,
   onDateClick,
-  onDataChange,
   extColumns,
 }: Props) {
   const [activeIndicators, setActiveIndicators] = useState<string[]>(['vol'])
@@ -141,20 +124,9 @@ export function StockDailyKChart({
     normalizeVolumeCompare(storage.stockVolumeCompare.get(DEFAULT_VOLUME_COMPARE)),
   )
   const dateRange = externalDateRange ?? getDefaultRange()
-  const days = useMemo(() => rangeDays(dateRange), [dateRange])
 
-  // extColumns 纳入 query key：勾选/取消扩展字段时需重新请求（带 ext_columns 参数）
-  const kline = useQuery({
-    queryKey: QK.kline(symbol, dateRange.start, dateRange.end, extColumns),
-    queryFn: () => api.klineDaily(symbol, days, dateRange, extColumns),
-    enabled: !!symbol,
-    // 仅同 symbol 的占位数据可用于 refetch (改日期范围/扩展字段时图表不闪), 跨 symbol 时不透传旧数据,
-    // 避免切股瞬间信息条/图表短暂显示上一只股票的价格。queryKey 恒为 ['kline', symbol, ...], 只需比 symbol。
-    placeholderData: (prev, prevQuery) => {
-      const prevKey = prevQuery?.queryKey as readonly unknown[] | undefined
-      return prevKey?.[1] === symbol ? prev : undefined
-    },
-  })
+  // 查询配置 (key/fn/placeholderData) 统一来自 klineDailyQueryOptions, 与 StockPanel 信息条共享同一 cache
+  const kline = useQuery({ ...klineDailyQueryOptions(symbol, dateRange, extColumns), enabled: !!symbol })
 
   const rows = useMemo(() => toOHLC(kline.data?.rows ?? []), [kline.data?.rows])
   const stockInfo = kline.data?.stock_info
@@ -183,10 +155,6 @@ export function StockDailyKChart({
   activeSubDefs.forEach(def => { subExtraH += SUB_INFO_H + def.height })
   if (activeSubDefs.length > 0) subExtraH += activeSubDefs.length * SUB_GAP + 14
   const chartHeight = height + subExtraH
-
-  useEffect(() => {
-    onDataChange?.({ rows, rawRows: kline.data?.rows ?? [], stockInfo, name: kline.data?.name })
-  }, [kline.data?.name, kline.data?.rows, onDataChange, rows, stockInfo])
 
   if (!symbol) return null
 

--- a/frontend/src/components/StockDailyKChart.tsx
+++ b/frontend/src/components/StockDailyKChart.tsx
@@ -148,7 +148,12 @@ export function StockDailyKChart({
     queryKey: QK.kline(symbol, dateRange.start, dateRange.end, extColumns),
     queryFn: () => api.klineDaily(symbol, days, dateRange, extColumns),
     enabled: !!symbol,
-    placeholderData: (prev) => prev,
+    // 仅同 symbol 的占位数据可用于 refetch (改日期范围/扩展字段时图表不闪), 跨 symbol 时不透传旧数据,
+    // 避免切股瞬间信息条/图表短暂显示上一只股票的价格。queryKey 恒为 ['kline', symbol, ...], 只需比 symbol。
+    placeholderData: (prev, prevQuery) => {
+      const prevKey = prevQuery?.queryKey as readonly unknown[] | undefined
+      return prevKey?.[1] === symbol ? prev : undefined
+    },
   })
 
   const rows = useMemo(() => toOHLC(kline.data?.rows ?? []), [kline.data?.rows])
@@ -260,7 +265,6 @@ export function StockDailyKChart({
           )}
         </div>
       )}
-      {kline.isLoading && <div className="text-sm text-muted py-4">加载中…</div>}
       {kline.isError && <div className="text-sm text-danger py-2">日K加载失败</div>}
       {!kline.isLoading && !kline.isError && (kline.data?.rows?.length ?? 0) > 0 && rows.length === 0 && (
         <div className="text-sm text-danger py-2">数据格式异常，请刷新页面</div>

--- a/frontend/src/components/StockInfoBar.tsx
+++ b/frontend/src/components/StockInfoBar.tsx
@@ -106,7 +106,21 @@ export function StockInfoBar({ symbol, name, stockInfo, rows, fields, onFieldsCh
     })
   }
 
-  if (rows.length === 0) return null
+  // 无数据时保持信息条挂载 (切股/首次加载): 只留 symbol+名称+小 spinner 作为加载态,
+  // 不渲染假占位值; 数据到位后价格/市值等原位填充, 避免整行消失造成布局跳动。
+  if (rows.length === 0) {
+    return (
+      <div className="px-2 pb-3 font-mono text-[12px] select-none">
+        <div className="flex items-baseline gap-x-3 flex-wrap">
+          <span className="text-foreground font-bold text-sm tracking-wide">{symbol}</span>
+          {name && <span className="text-secondary font-medium">{name}</span>}
+          <span className="ml-auto self-center text-muted">
+            <span className="inline-block h-2.5 w-2.5 animate-spin rounded-full border-[1.5px] border-current border-t-transparent" />
+          </span>
+        </div>
+      </div>
+    )
+  }
 
   const latest = rows[rows.length - 1]
   const prev = rows.length >= 2 ? rows[rows.length - 2] : null

--- a/frontend/src/components/StockInfoBar.tsx
+++ b/frontend/src/components/StockInfoBar.tsx
@@ -1,9 +1,10 @@
 import { useState, type ReactNode } from 'react'
-import { Settings2, RadioTower, Star } from 'lucide-react'
+import { Settings2, RadioTower, Star, ExternalLink } from 'lucide-react'
 import type { KlineRow, FinancialMetricRecord } from '@/lib/api'
 import { fmtPrice, fmtBigNum, fmtVolume } from '@/lib/format'
 import { ListColumnCustomizer } from '@/components/ListColumnCustomizer'
 import { INFO_GROUPS, type ColumnConfig } from '@/lib/stock-info-fields'
+import { buildStockExternalUrl, loadStockExternalTemplate } from '@/lib/stock-external-link'
 
 const BULL = '#C74040'
 const BEAR = '#2D9B65'
@@ -199,6 +200,8 @@ export function StockInfoBar({ symbol, name, stockInfo, rows, fields, onFieldsCh
     )
   }
 
+  const extUrl = buildStockExternalUrl(loadStockExternalTemplate(), symbol)
+
   return (
     <div className="px-2 pb-3 font-mono text-[12px] select-none space-y-1">
       {/* Row 1: code, name, price, change, change% */}
@@ -214,8 +217,18 @@ export function StockInfoBar({ symbol, name, stockInfo, rows, fields, onFieldsCh
         <span style={{ color: clr }} className="tabular-nums">
           {isUp ? '+' : ''}{fmtPrice(chgPct)}%
         </span>
-        {/* 右侧操作按钮：加自选 + 加监控 + 信息条配置 */}
         <div className="ml-auto self-center flex items-center gap-1">
+          {extUrl && (
+            <a
+              href={extUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={extUrl}
+              className="p-1 rounded-btn text-muted hover:text-foreground hover:bg-elevated transition-colors"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          )}
           {onToggleWatchlist && (
             <button
               onClick={onToggleWatchlist}

--- a/frontend/src/components/StockInfoBar.tsx
+++ b/frontend/src/components/StockInfoBar.tsx
@@ -106,18 +106,29 @@ export function StockInfoBar({ symbol, name, stockInfo, rows, fields, onFieldsCh
     })
   }
 
+  // 字段分组: 加载态预留高度与完整态渲染共用同一规则
+  const visibleFields = fields.filter(f => f.visible)
+  const inlineFields = visibleFields.filter(f => !f.standalone)
+  const standaloneFields = visibleFields.filter(f => f.standalone)
+
   // 无数据时保持信息条挂载 (切股/首次加载): 只留 symbol+名称+小 spinner 作为加载态,
   // 不渲染假占位值; 数据到位后价格/市值等原位填充, 避免整行消失造成布局跳动。
+  // 同时按字段配置预留与完整态相同的行数, 切股瞬间弹窗整体高度不塌陷 (不抖动)。
   if (rows.length === 0) {
+    const reserveLines = (inlineFields.length > 0 ? 1 : 0) + standaloneFields.length
     return (
-      <div className="px-2 pb-3 font-mono text-[12px] select-none">
-        <div className="flex items-baseline gap-x-3 flex-wrap">
+      <div className="px-2 pb-3 font-mono text-[12px] select-none space-y-1">
+        {/* 首行 min-h-7 对齐完整态的 text-lg 价格行高, 加载中不整体变矮 */}
+        <div className="flex min-h-7 items-baseline gap-x-3 flex-wrap">
           <span className="text-foreground font-bold text-sm tracking-wide">{symbol}</span>
           {name && <span className="text-secondary font-medium">{name}</span>}
           <span className="ml-auto self-center text-muted">
             <span className="inline-block h-2.5 w-2.5 animate-spin rounded-full border-[1.5px] border-current border-t-transparent" />
           </span>
         </div>
+        {Array.from({ length: reserveLines }).map((_, i) => (
+          <div key={i} className="h-4" />
+        ))}
       </div>
     )
   }
@@ -180,11 +191,6 @@ export function StockInfoBar({ symbol, name, stockInfo, rows, fields, onFieldsCh
       default: return null
     }
   }
-
-  const visibleFields = fields.filter(f => f.visible)
-  // 按是否单独显示分组：普通列共一行，standalone 列各占一行
-  const inlineFields = visibleFields.filter(f => !f.standalone)
-  const standaloneFields = visibleFields.filter(f => f.standalone)
 
   // 渲染单个字段（builtin / ext 通用）
   const renderField = (f: ColumnConfig): ReactNode => {

--- a/frontend/src/components/StockPanel.tsx
+++ b/frontend/src/components/StockPanel.tsx
@@ -57,7 +57,11 @@ export function StockPanel({
 }: Props) {
   const [linkedPrice, setLinkedPrice] = useState<number | null>(null)
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
-  const [dailyResult, setDailyResult] = useState<StockDailyKChartResult | null>(null)
+  // 按 symbol 记录日K结果: 切股时用 symbol 门控显示, 旧股结果不误显示, 也不被父 effect 清掉而卡在加载态
+  const [dailyResult, setDailyResult] = useState<{ symbol: string; result: StockDailyKChartResult | null }>({ symbol, result: null })
+  const handleDataChange = useCallback((result: StockDailyKChartResult) => {
+    setDailyResult({ symbol, result })
+  }, [symbol])
   // 信息条指标配置提升到此层：同时供 StockInfoBar 渲染与 StockDailyKChart 请求 ext 数据
   const [fields, setFields] = useState<ColumnConfig[]>(loadInfoFields)
   const extColumns = useMemo(() => buildInfoExtColumnsParam(fields), [fields])
@@ -85,21 +89,23 @@ export function StockPanel({
     onSelectDate?.(date)
   }, [onSelectDate])
 
-  const rows = dailyResult?.rows ?? []
-  const stockInfo = dailyResult?.stockInfo
-  const rawRows: KlineRow[] = dailyResult?.rawRows ?? []
+  // 仅当结果属于当前 symbol 时才用于显示 (切股瞬间旧股结果不会误显示)
+  const daily = dailyResult.symbol === symbol ? dailyResult.result : null
+  const rows = daily?.rows ?? []
+  const stockInfo = daily?.stockInfo
+  const rawRows: KlineRow[] = daily?.rawRows ?? []
+  const name = daily?.name
 
   // symbol 变化时重置分时相关状态，避免切股后残留旧日期。
-  // 注意：必须跳过首次挂载——重开弹窗时 kline 命中 react-query 缓存，
-  // 子组件 onDataChange effect（先于父 effect 执行）会把 dailyResult 置为有效数据，
-  // 若此处再无条件清空，会把刚加载的数据抹掉，导致信息条整行消失。
+  // 注意：不再清空 dailyResult —— 预取后新 symbol 数据与切股同 commit 到达,
+  // 若父 effect 在此无条件清空 (子 effect 先执行, 父 effect 后执行), 会把刚到的数据抹掉,
+  // 且没有下一次 onDataChange 触发, 导致信息条永久卡在加载态。改由 symbol 门控显示。
   const prevSymbol = useRef<string | null>(symbol)
   useEffect(() => {
     if (prevSymbol.current === symbol) return
     prevSymbol.current = symbol
     setSelectedDate(null)
     setLinkedPrice(null)
-    setDailyResult(null)
   }, [symbol])
 
   // 当分时开启、无选中日期时，自动选中最新日期
@@ -124,7 +130,7 @@ export function StockPanel({
     <div className={className}>
       <StockInfoBar
         symbol={symbol}
-        name={dailyResult?.name}
+        name={name}
         stockInfo={stockInfo}
         rows={rawRows}
         fields={fields}
@@ -148,7 +154,7 @@ export function StockPanel({
           showMarkerToggle={showMarkerToggle}
           linkedPrice={linkedPrice}
           onDateClick={handleDateClick}
-          onDataChange={setDailyResult}
+          onDataChange={handleDataChange}
           visibleBars={showIntraday ? 40 : 60}
           extColumns={extColumns}
         />

--- a/frontend/src/components/StockPanel.tsx
+++ b/frontend/src/components/StockPanel.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState, useCallback, useRef, useMemo } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { type KlineRow, type FinancialMetricRecord } from '@/lib/api'
+import { klineDailyQueryOptions } from '@/lib/kline'
 import { StockInfoBar } from '@/components/StockInfoBar'
-import { StockDailyKChart, getDefaultRange, type StockDailyKChartResult } from '@/components/StockDailyKChart'
+import { StockDailyKChart, getDefaultRange } from '@/components/StockDailyKChart'
 import { StockIntradayChart } from '@/components/StockIntradayChart'
-import { useFinancialMetrics } from '@/lib/useFinancials'
+import { financialMetricsQueryOptions, useFinancialMetrics } from '@/lib/useFinancials'
 import { useCapabilities } from '@/lib/useSharedQueries'
 import type { ChartMarker, ChartPriceLine, ChartRange } from '@/components/EChartsCandlestick'
 import {
@@ -34,6 +36,8 @@ interface Props {
   onToggleWatchlist?: () => void
   /** 分时图自动刷新间隔(ms)。undefined = 不轮询。个股对话框盘中实时刷新时传入。 */
   refetchIntervalMs?: number
+  /** 邻近预取目标 (切股导航的左右邻股): 提前拉取其日K/财务指标缓存, 切换瞬间免 loading */
+  prefetchSymbols?: string[]
 }
 
 export { getDefaultRange }
@@ -54,14 +58,10 @@ export function StockPanel({
   inWatchlist,
   onToggleWatchlist,
   refetchIntervalMs,
+  prefetchSymbols,
 }: Props) {
   const [linkedPrice, setLinkedPrice] = useState<number | null>(null)
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
-  // 按 symbol 记录日K结果: 切股时用 symbol 门控显示, 旧股结果不误显示, 也不被父 effect 清掉而卡在加载态
-  const [dailyResult, setDailyResult] = useState<{ symbol: string; result: StockDailyKChartResult | null }>({ symbol, result: null })
-  const handleDataChange = useCallback((result: StockDailyKChartResult) => {
-    setDailyResult({ symbol, result })
-  }, [symbol])
   // 信息条指标配置提升到此层：同时供 StockInfoBar 渲染与 StockDailyKChart 请求 ext 数据
   const [fields, setFields] = useState<ColumnConfig[]>(loadInfoFields)
   const extColumns = useMemo(() => buildInfoExtColumnsParam(fields), [fields])
@@ -84,22 +84,37 @@ export function StockPanel({
 
   const dateRange = externalDateRange ?? getDefaultRange()
 
+  // 日K查询由本组件持有 (与 StockDailyKChart 共享同一 cache key/配置, 只发一次请求),
+  // 信息条直接读 query data, 切股到已预取邻股时首帧即有数据, 避免信息条塌陷导致弹窗高度抖动。
+  const kline = useQuery({ ...klineDailyQueryOptions(symbol, dateRange, extColumns), enabled: !!symbol })
+  const rawRows: KlineRow[] = kline.data?.rows ?? []
+  const stockInfo = kline.data?.stock_info
+  const name = kline.data?.name
+
+  // 邻近预取: 对切股导航的左右邻股提前拉取缓存, 切股瞬间免 loading。
+  // 日K预取 staleTime 30s 防来回切换重复请求; 成为当前股后 useQuery(staleTime=0) 会立即后台刷新,
+  // SSE 也只按焦点股精准失效, 实时性不受影响。财务指标与正式查询同 staleTime, 5min 内不重复拉取。
+  // prefetchKey 按内容 join: 自选页 navList 随行情 tick 重建但邻股集合通常不变, 避免 effect 每次 tick 重跑。
+  const qc = useQueryClient()
+  const prefetchKey = prefetchSymbols?.join(',') ?? ''
+  useEffect(() => {
+    if (!prefetchKey) return
+    for (const s of prefetchKey.split(',')) {
+      if (s === symbol) continue
+      qc.prefetchQuery({ ...klineDailyQueryOptions(s, dateRange, extColumns), staleTime: 30_000 })
+      if (hasFinanceField && hasFinancialCap) {
+        qc.prefetchQuery(financialMetricsQueryOptions(s))
+      }
+    }
+  }, [prefetchKey, symbol, dateRange, extColumns, hasFinanceField, hasFinancialCap, qc])
+
   const handleDateClick = useCallback((date: string) => {
     setSelectedDate(date)
     onSelectDate?.(date)
   }, [onSelectDate])
 
-  // 仅当结果属于当前 symbol 时才用于显示 (切股瞬间旧股结果不会误显示)
-  const daily = dailyResult.symbol === symbol ? dailyResult.result : null
-  const rows = daily?.rows ?? []
-  const stockInfo = daily?.stockInfo
-  const rawRows: KlineRow[] = daily?.rawRows ?? []
-  const name = daily?.name
-
   // symbol 变化时重置分时相关状态，避免切股后残留旧日期。
-  // 注意：不再清空 dailyResult —— 预取后新 symbol 数据与切股同 commit 到达,
-  // 若父 effect 在此无条件清空 (子 effect 先执行, 父 effect 后执行), 会把刚到的数据抹掉,
-  // 且没有下一次 onDataChange 触发, 导致信息条永久卡在加载态。改由 symbol 门控显示。
+  // 日K信息直接读 query data (切股到已预取邻股首帧即有), 无需清空或门控。
   const prevSymbol = useRef<string | null>(symbol)
   useEffect(() => {
     if (prevSymbol.current === symbol) return
@@ -110,16 +125,16 @@ export function StockPanel({
 
   // 当分时开启、无选中日期时，自动选中最新日期
   useEffect(() => {
-    if (showIntraday && !selectedDate && rows.length > 0) {
-      setSelectedDate(rows[rows.length - 1].date)
+    if (showIntraday && !selectedDate && rawRows.length > 0) {
+      setSelectedDate(rawRows[rawRows.length - 1].date)
     }
-  }, [showIntraday, selectedDate, rows])
+  }, [showIntraday, selectedDate, rawRows])
 
-  const selectedIdx = selectedDate ? rows.findIndex(r => r.date === selectedDate) : -1
+  const selectedIdx = selectedDate ? rawRows.findIndex(r => r.date === selectedDate) : -1
   const prevClose = selectedIdx > 0
-    ? rows[selectedIdx - 1].close
-    : rows.length >= 2
-      ? rows[rows.length - 2].close
+    ? rawRows[selectedIdx - 1].close
+    : rawRows.length >= 2
+      ? rawRows[rawRows.length - 2].close
       : undefined
   if (!symbol) return null
 
@@ -154,7 +169,6 @@ export function StockPanel({
           showMarkerToggle={showMarkerToggle}
           linkedPrice={linkedPrice}
           onDateClick={handleDateClick}
-          onDataChange={handleDataChange}
           visibleBars={showIntraday ? 40 : 60}
           extColumns={extColumns}
         />

--- a/frontend/src/components/StockPreviewDialog.tsx
+++ b/frontend/src/components/StockPreviewDialog.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { motion, AnimatePresence } from 'framer-motion'
-import { X, RefreshCw, Clock } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Clock, RefreshCw, X } from 'lucide-react'
 import { api } from '@/lib/api'
 import { QK } from '@/lib/queryKeys'
 import { cnSignal } from '@/lib/signals'
@@ -11,6 +11,7 @@ import { RuleEditor } from '@/components/monitor/RuleEditor'
 import { usePreferences, useQuoteStatus } from '@/lib/useSharedQueries'
 import { setFocusSymbol, clearFocusSymbol } from '@/lib/useQuoteStream'
 import { useDialogBackdrop } from '@/lib/useDialogBackdrop'
+import { boardTag } from '@/components/stock-table/primitives'
 
 interface Props {
   symbol: string | null
@@ -24,9 +25,19 @@ interface Props {
     signals?: string[]
     message?: string
   } | null
+  /** 有序候选列表: 提供后支持左右键/顶栏按钮切股, 标题栏显示 n/N */
+  navList?: NavItem[]
+  /** 切股回调: 收到目标 symbol/name, 由调用方更新预览状态 */
+  onNavigate?: (symbol: string, name?: string) => void
 }
 
-// ===== 板块标识（与 Screener 列表一致）=====
+/** 切股导航列表项 */
+export interface NavItem { symbol: string; name?: string }
+
+/** 把 symbol+name 的列表转成切股导航列表项 (统一 name 归一化为 undefined, 免去各处重复 map + as 断言) */
+export function toNavItems<T extends { symbol: string; name?: string | null }>(xs: T[]): NavItem[] {
+  return xs.map(x => ({ symbol: x.symbol, name: x.name ?? undefined }))
+}
 
 // 预设快捷范围（只保留半年和1年）
 const PRESETS: { label: string; months: number }[] = [
@@ -34,14 +45,7 @@ const PRESETS: { label: string; months: number }[] = [
   { label: '1年', months: 12 },
 ]
 
-function boardTag(symbol: string): { label: string; color: string } | null {
-  if (/^(300|301)/.test(symbol)) return { label: '创', color: 'text-[#f97316] bg-[#f97316]/12 border-[#f97316]/25' }
-  if (/^688/.test(symbol))       return { label: '科', color: 'text-purple-400 bg-purple-400/12 border-purple-400/25' }
-  if (/^[48]/.test(symbol))      return { label: '北', color: 'text-cyan-400 bg-cyan-400/12 border-cyan-400/25' }
-  return null
-}
-
-export function StockPreviewDialog({ symbol, name, onClose, triggerInfo }: Props) {
+export function StockPreviewDialog({ symbol, name, onClose, triggerInfo, navList, onNavigate }: Props) {
   const [showIntraday, setShowIntraday] = useState(false)
   const [dateRange, setDateRange] = useState(getDefaultRange)
   const [showMonitorEditor, setShowMonitorEditor] = useState(false)
@@ -63,15 +67,57 @@ export function StockPreviewDialog({ symbol, name, onClose, triggerInfo }: Props
     },
   })
 
-  // ESC 关闭
+  // ===== 切股导航 =====
+  // 当前 symbol 在 navList 中的位置 (不在列表则为 -1, 此时不显示计数/按钮)
+  const navIdx = navList ? navList.findIndex(n => n.symbol === symbol) : -1
+  const navTotal = navList?.length ?? 0
+  const navEnabled = navTotal >= 2 && navIdx >= 0
+
+  // 首↔尾循环的弱提示 (自显 ~1.5s, 不引全局 Toast)
+  const [wrapMsg, setWrapMsg] = useState<string | null>(null)
+  const wrapTimer = useRef<number | null>(null)
+  useEffect(() => {
+    return () => { if (wrapTimer.current) window.clearTimeout(wrapTimer.current) }
+  }, [])
+
+  // 父级 onNavigate/onClose 多为内联 lambda, 用最新值 ref 承接, 避免每次父渲染重建 go/键盘监听
+  const onNavigateRef = useRef(onNavigate)
+  onNavigateRef.current = onNavigate
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+
+  // 前后切股: 返回是否真正导航 (供键盘判断是否要 preventDefault)
+  const go = useCallback((delta: 1 | -1): boolean => {
+    if (!navList || navIdx < 0 || navTotal < 2) return false
+    const nextIdx = (navIdx + delta + navTotal) % navTotal
+    const wrapped = nextIdx === (delta === 1 ? 0 : navTotal - 1)
+    if (wrapped) {
+      // 提示词描述切股后的落点 (而非起点)
+      setWrapMsg(delta === 1 ? '已到榜首' : '已到末尾')
+      if (wrapTimer.current) window.clearTimeout(wrapTimer.current)
+      wrapTimer.current = window.setTimeout(() => setWrapMsg(null), 1500)
+    }
+    const next = navList[nextIdx]
+    onNavigateRef.current?.(next.symbol, next.name)
+    return true
+  }, [navList, navIdx, navTotal])
+
+  // ESC 关闭 + 左右键切股
   useEffect(() => {
     if (!symbol) return
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') { onCloseRef.current(); return }
+      if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+        // 焦点在输入框/编辑器时方向键让位给光标/输入, 不切股
+        const t = e.target as HTMLElement | null
+        if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT' || t.isContentEditable)) return
+        if (showMonitorEditor) return
+        if (go(e.key === 'ArrowRight' ? 1 : -1)) e.preventDefault()
+      }
     }
     document.addEventListener('keydown', handler)
     return () => document.removeEventListener('keydown', handler)
-  }, [symbol, onClose])
+  }, [symbol, go, showMonitorEditor])
 
   // 焦点股票注册: SSE quotes_updated 推送时精准 invalidate 当前股票日K,
   // 让对话框日K最后一根蜡烛随实时价变化 (后端只读内存, 不调 TickFlow)。
@@ -135,6 +181,30 @@ export function StockPreviewDialog({ symbol, name, onClose, triggerInfo }: Props
                 })()}
                 <span className="font-mono text-sm font-medium text-foreground">{symbol}</span>
                 {name && <span className="text-xs text-muted">{name}</span>}
+
+                {/* 切股导航: 上一只 / n·N / 下一只 */}
+                {navEnabled && (
+                  <>
+                    <span className="text-muted/20 mx-0.5">|</span>
+                    <button
+                      onClick={() => go(-1)}
+                      title="上一只 (←)"
+                      className="p-1 rounded-btn text-secondary hover:text-foreground hover:bg-elevated transition-colors cursor-pointer"
+                    >
+                      <ChevronLeft className="h-3.5 w-3.5" />
+                    </button>
+                    <span className="font-mono text-[11px] text-secondary tabular-nums whitespace-nowrap">
+                      {navIdx + 1} / {navTotal}
+                    </span>
+                    <button
+                      onClick={() => go(1)}
+                      title="下一只 (→)"
+                      className="p-1 rounded-btn text-secondary hover:text-foreground hover:bg-elevated transition-colors cursor-pointer"
+                    >
+                      <ChevronRight className="h-3.5 w-3.5" />
+                    </button>
+                  </>
+                )}
               </div>
 
               <div className="flex items-center gap-1.5">
@@ -292,6 +362,21 @@ export function StockPreviewDialog({ symbol, name, onClose, triggerInfo }: Props
                       onSaved={() => setShowMonitorEditor(false)}
                     />
                   </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+
+            {/* 首↔尾循环弱提示 */}
+            <AnimatePresence>
+              {wrapMsg && (
+                <motion.div
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: 8 }}
+                  transition={{ duration: 0.2 }}
+                  className="pointer-events-none absolute bottom-4 left-1/2 z-30 -translate-x-1/2 rounded-full border border-border bg-surface/95 px-3 py-1.5 text-[11px] text-secondary shadow-lg backdrop-blur"
+                >
+                  {wrapMsg}
                 </motion.div>
               )}
             </AnimatePresence>

--- a/frontend/src/components/StockPreviewDialog.tsx
+++ b/frontend/src/components/StockPreviewDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { motion, AnimatePresence } from 'framer-motion'
 import { ChevronLeft, ChevronRight, Clock, RefreshCw, X } from 'lucide-react'
@@ -39,6 +39,11 @@ export function toNavItems<T extends { symbol: string; name?: string | null }>(x
   return xs.map(x => ({ symbol: x.symbol, name: x.name ?? undefined }))
 }
 
+/** 首↔尾循环的索引换算: go(delta) 与 邻近预取 共用, 保证换行规则单源 */
+function wrapNavIndex(navIdx: number, delta: number, navTotal: number): number {
+  return (navIdx + delta + navTotal) % navTotal
+}
+
 // 预设快捷范围（只保留半年和1年）
 const PRESETS: { label: string; months: number }[] = [
   { label: '半年', months: 6 },
@@ -73,6 +78,15 @@ export function StockPreviewDialog({ symbol, name, onClose, triggerInfo, navList
   const navTotal = navList?.length ?? 0
   const navEnabled = navTotal >= 2 && navIdx >= 0
 
+  // 邻近预取目标: 当前股左右相邻两只 (首↔尾循环), 交由 StockPanel 提前拉取日K/财务指标缓存
+  const prefetchSymbols = useMemo(() => {
+    if (!navEnabled) return []
+    return [
+      navList![wrapNavIndex(navIdx, -1, navTotal)].symbol,
+      navList![wrapNavIndex(navIdx, 1, navTotal)].symbol,
+    ]
+  }, [navEnabled, navIdx, navTotal, navList])
+
   // 首↔尾循环的弱提示 (自显 ~1.5s, 不引全局 Toast)
   const [wrapMsg, setWrapMsg] = useState<string | null>(null)
   const wrapTimer = useRef<number | null>(null)
@@ -88,8 +102,8 @@ export function StockPreviewDialog({ symbol, name, onClose, triggerInfo, navList
 
   // 前后切股: 返回是否真正导航 (供键盘判断是否要 preventDefault)
   const go = useCallback((delta: 1 | -1): boolean => {
-    if (!navList || navIdx < 0 || navTotal < 2) return false
-    const nextIdx = (navIdx + delta + navTotal) % navTotal
+    if (!navList || !navEnabled) return false
+    const nextIdx = wrapNavIndex(navIdx, delta, navTotal)
     const wrapped = nextIdx === (delta === 1 ? 0 : navTotal - 1)
     if (wrapped) {
       // 提示词描述切股后的落点 (而非起点)
@@ -335,6 +349,7 @@ export function StockPreviewDialog({ symbol, name, onClose, triggerInfo, navList
                 inWatchlist={inWatchlist}
                 onToggleWatchlist={() => toggleWatchlist.mutate()}
                 refetchIntervalMs={intradayRefetchMs}
+                prefetchSymbols={prefetchSymbols}
               />
             </div>
 

--- a/frontend/src/components/WatchlistImportDialog.tsx
+++ b/frontend/src/components/WatchlistImportDialog.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { ImagePlus, Loader2, Upload, X } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
+import { FileText, ImagePlus, Loader2, Upload, X, type LucideIcon } from 'lucide-react'
 import { Modal } from '@/components/Modal'
 import { toast } from '@/components/Toast'
 import { api, type WatchlistImportCandidate } from '@/lib/api'
@@ -11,11 +11,17 @@ interface Props {
   onClose: () => void
 }
 
+type ImportMode = 'image' | 'csv'
+
 /** 一次最多排队识别的图片数，避免误选大量文件拖垮小内存机器。 */
 const MAX_IMPORT_IMAGES = 10
 
 function isImageFile(file: File): boolean {
   return file.type.startsWith('image/') || /\.(jpe?g|png|webp|bmp|gif)$/i.test(file.name)
+}
+
+function isCsvFile(file: File): boolean {
+  return /\.(csv|txt)$/i.test(file.name)
 }
 
 /** 按 code 合并多图 OCR 结果：优先保留已匹配项，已在自选取并集。 */
@@ -47,16 +53,83 @@ export function mergeImportCandidates(
   return [...byCode.values()]
 }
 
+/** 默认勾选可添加的已匹配候选。 */
+function defaultSelected(list: WatchlistImportCandidate[]): Set<string> {
+  return new Set(
+    list.filter(c => c.matched && c.symbol && !c.already_in_watchlist).map(c => c.symbol!),
+  )
+}
+
+interface FileDropzoneProps {
+  inputRef: RefObject<HTMLInputElement>
+  accept: string
+  multiple?: boolean
+  icon: LucideIcon
+  label: string
+  busyLabel: string
+  busy: boolean
+  onPick: (list: FileList | File[] | null | undefined) => void
+}
+
+/** 隐藏 file input + 虚线拖拽上传按钮（截图 / CSV 两个页签共用）。 */
+function FileDropzone({
+  inputRef,
+  accept,
+  multiple,
+  icon: Icon,
+  label,
+  busyLabel,
+  busy,
+  onPick,
+}: FileDropzoneProps) {
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        multiple={multiple}
+        accept={accept}
+        className="hidden"
+        onChange={e => {
+          onPick(e.target.files)
+          e.target.value = ''
+        }}
+      />
+      <button
+        type="button"
+        disabled={busy}
+        onClick={() => inputRef.current?.click()}
+        onDragOver={e => { e.preventDefault(); e.stopPropagation() }}
+        onDrop={e => {
+          e.preventDefault()
+          onPick(e.dataTransfer.files)
+        }}
+        className="w-full flex flex-col items-center justify-center gap-2 rounded-btn border border-dashed border-border bg-elevated/40 hover:bg-elevated/70 px-4 py-6 text-secondary transition-colors disabled:opacity-50"
+      >
+        {busy ? (
+          <Loader2 className="h-6 w-6 animate-spin text-accent" />
+        ) : (
+          <Icon className="h-6 w-6 text-accent" />
+        )}
+        <span className="text-xs">{busy ? busyLabel : label}</span>
+      </button>
+    </>
+  )
+}
+
 export function WatchlistImportDialog({ open, onClose }: Props) {
   const inputRef = useRef<HTMLInputElement>(null)
+  const csvInputRef = useRef<HTMLInputElement>(null)
   const abortRef = useRef<AbortController | null>(null)
   const genRef = useRef(0)
+  const [mode, setMode] = useState<ImportMode>('image')
   const [busy, setBusy] = useState(false)
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(null)
   const [provider, setProvider] = useState<string>('')
   const [candidates, setCandidates] = useState<WatchlistImportCandidate[]>([])
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [previewUrls, setPreviewUrls] = useState<string[]>([])
+  const [csvFileName, setCsvFileName] = useState('')
   const [ocrAvailable, setOcrAvailable] = useState<boolean | null>(null)
   const [installHint, setInstallHint] = useState('')
   const batchAdd = useWatchlistBatchAdd()
@@ -73,11 +146,13 @@ export function WatchlistImportDialog({ open, onClose }: Props) {
 
   const reset = useCallback(() => {
     abortInFlight()
+    setMode('image')
     setBusy(false)
     setProgress(null)
     setCandidates([])
     setSelected(new Set())
     setProvider('')
+    setCsvFileName('')
     setOcrAvailable(null)
     setInstallHint('')
     setPreviewUrls(prev => {
@@ -85,6 +160,7 @@ export function WatchlistImportDialog({ open, onClose }: Props) {
       return []
     })
     if (inputRef.current) inputRef.current.value = ''
+    if (csvInputRef.current) csvInputRef.current.value = ''
   }, [abortInFlight, revokePreviews])
 
   useEffect(() => {
@@ -169,12 +245,7 @@ export function WatchlistImportDialog({ open, onClose }: Props) {
       const merged = mergeImportCandidates(mergedLists)
       setProvider(lastProvider)
       setCandidates(merged)
-      const defaults = new Set(
-        merged
-          .filter(c => c.matched && c.symbol && !c.already_in_watchlist)
-          .map(c => c.symbol!),
-      )
-      setSelected(defaults)
+      setSelected(defaultSelected(merged))
 
       if (merged.length === 0) {
         toast(
@@ -197,9 +268,45 @@ export function WatchlistImportDialog({ open, onClose }: Props) {
     }
   }
 
+  const runCsvImport = async (file: File) => {
+    if (!isCsvFile(file)) {
+      toast('请选择 CSV 或 TXT 文件', 'error')
+      return
+    }
+    abortInFlight()
+    const controller = new AbortController()
+    abortRef.current = controller
+    const gen = genRef.current
+
+    setBusy(true)
+    setCandidates([])
+    setSelected(new Set())
+    setCsvFileName(file.name)
+    try {
+      const res = await api.watchlistImportCsv(file, controller.signal, true)
+      if (gen !== genRef.current) return
+      setCandidates(res.candidates)
+      setSelected(defaultSelected(res.candidates))
+      if (res.candidates.every(c => !c.matched)) {
+        toast('识别到代码但未能匹配证券主数据', 'error')
+      }
+    } catch (err) {
+      if (gen !== genRef.current) return
+      if (controller.signal.aborted) return
+      toast(err instanceof Error ? err.message : 'CSV 解析失败', 'error')
+    } finally {
+      if (gen === genRef.current) setBusy(false)
+    }
+  }
+
   const onPick = (list: FileList | File[] | null | undefined) => {
     if (!list || list.length === 0) return
     void runRecognizeQueue(Array.from(list))
+  }
+
+  const onCsvPick = (list: FileList | File[] | null | undefined) => {
+    if (!list || list.length === 0) return
+    void runCsvImport(list[0])
   }
 
   const toggle = (symbol: string) => {
@@ -254,13 +361,15 @@ export function WatchlistImportDialog({ open, onClose }: Props) {
       <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
         <div>
           <h2 id="watchlist-import-title" className="text-sm font-semibold text-foreground">
-            从截图导入自选
+            导入自选
           </h2>
           <p className="text-[11px] text-muted mt-0.5">
-            {ocrBlocked
-              ? 'OCR 引擎不可用'
-              : '可多选截图，将逐张识别并合并结果后确认添加'}
-            {provider ? ` · ${provider}` : ''}
+            {mode === 'image'
+              ? (ocrBlocked
+                ? 'OCR 引擎不可用'
+                : '可多选截图，将逐张识别并合并结果后确认添加')
+              : '支持含证券代码或名称的 CSV / TXT（UTF-8 或 GBK）'}
+            {mode === 'image' && provider ? ` · ${provider}` : ''}
           </p>
         </div>
         <button
@@ -273,124 +382,147 @@ export function WatchlistImportDialog({ open, onClose }: Props) {
         </button>
       </div>
 
+      <div className="px-4 pt-3 shrink-0">
+        <div className="flex gap-1 rounded-lg bg-elevated/60 p-0.5">
+          <button
+            type="button"
+            onClick={() => setMode('image')}
+            className={`flex-1 inline-flex items-center justify-center gap-1.5 py-1.5 rounded-md text-[11px] font-medium transition-colors ${
+              mode === 'image' ? 'bg-surface text-foreground shadow-sm' : 'text-muted hover:text-secondary'
+            }`}
+          >
+            <ImagePlus className="h-3.5 w-3.5" />
+            截图识别
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode('csv')}
+            className={`flex-1 inline-flex items-center justify-center gap-1.5 py-1.5 rounded-md text-[11px] font-medium transition-colors ${
+              mode === 'csv' ? 'bg-surface text-foreground shadow-sm' : 'text-muted hover:text-secondary'
+            }`}
+          >
+            <FileText className="h-3.5 w-3.5" />
+            CSV 文件
+          </button>
+        </div>
+      </div>
+
       <div className="px-4 py-3 overflow-y-auto flex-1 space-y-3">
-        {ocrBlocked ? (
-          <div className="rounded-btn border border-border bg-elevated/40 px-4 py-5 text-xs text-secondary leading-relaxed whitespace-pre-wrap">
-            {installHint}
-          </div>
+        {mode === 'image' ? (
+          ocrBlocked ? (
+            <div className="rounded-btn border border-border bg-elevated/40 px-4 py-5 text-xs text-secondary leading-relaxed whitespace-pre-wrap">
+              {installHint}
+            </div>
+          ) : (
+            <>
+              <FileDropzone
+                inputRef={inputRef}
+                accept="image/jpeg,image/png,image/webp,image/bmp,image/gif,.jpg,.jpeg,.png"
+                multiple
+                icon={ImagePlus}
+                label={ocrAvailable === null ? '检查 OCR…' : '点击选择或拖拽截图（支持多选）'}
+                busyLabel={progressLabel ?? '检查 OCR…'}
+                busy={busy || ocrAvailable === null}
+                onPick={onPick}
+              />
+
+              {previewUrls.length > 0 && (
+                <div className="flex gap-2 overflow-x-auto pb-1">
+                  {previewUrls.map((url, i) => (
+                    <div
+                      key={url}
+                      className="shrink-0 w-20 h-20 rounded-btn overflow-hidden border border-border bg-black/40"
+                    >
+                      <img
+                        src={url}
+                        alt={`预览 ${i + 1}`}
+                        className="w-full h-full object-contain"
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
+          )
         ) : (
           <>
-            <input
-              ref={inputRef}
-              type="file"
-              multiple
-              accept="image/jpeg,image/png,image/webp,image/bmp,image/gif,.jpg,.jpeg,.png"
-              className="hidden"
-              onChange={e => {
-                onPick(e.target.files)
-                e.target.value = ''
-              }}
+            <FileDropzone
+              inputRef={csvInputRef}
+              accept=".csv,.txt,text/csv,text/plain"
+              icon={FileText}
+              label="点击选择或拖拽 CSV / TXT 文件"
+              busyLabel="解析中…"
+              busy={busy}
+              onPick={onCsvPick}
             />
 
-            <button
-              type="button"
-              disabled={busy || ocrAvailable === null}
-              onClick={() => inputRef.current?.click()}
-              onDragOver={e => { e.preventDefault(); e.stopPropagation() }}
-              onDrop={e => {
-                e.preventDefault()
-                onPick(e.dataTransfer.files)
-              }}
-              className="w-full flex flex-col items-center justify-center gap-2 rounded-btn border border-dashed border-border bg-elevated/40 hover:bg-elevated/70 px-4 py-6 text-secondary transition-colors disabled:opacity-50"
-            >
-              {busy || ocrAvailable === null ? (
-                <Loader2 className="h-6 w-6 animate-spin text-accent" />
-              ) : (
-                <ImagePlus className="h-6 w-6 text-accent" />
-              )}
-              <span className="text-xs">
-                {progressLabel
-                  ?? (ocrAvailable === null ? '检查 OCR…' : '点击选择或拖拽截图（支持多选）')}
-              </span>
-            </button>
-
-            {previewUrls.length > 0 && (
-              <div className="flex gap-2 overflow-x-auto pb-1">
-                {previewUrls.map((url, i) => (
-                  <div
-                    key={url}
-                    className="shrink-0 w-20 h-20 rounded-btn overflow-hidden border border-border bg-black/40"
-                  >
-                    <img
-                      src={url}
-                      alt={`预览 ${i + 1}`}
-                      className="w-full h-full object-contain"
-                    />
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {candidates.length > 0 && (
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <span className="text-xs text-secondary">
-                    识别 {candidates.length} 个代码 · 匹配 {matched.length} · 已选 {selected.size}
-                  </span>
-                  {selectable.length > 0 && (
-                    <button
-                      type="button"
-                      onClick={toggleAll}
-                      className="text-[11px] text-accent hover:underline"
-                    >
-                      {allSelected ? '取消全选' : '全选可添加'}
-                    </button>
-                  )}
-                </div>
-                <ul className="divide-y divide-border/60 rounded-btn border border-border overflow-hidden">
-                  {candidates.map(c => {
-                    const key = c.symbol || c.code
-                    const disabled = !c.matched || !c.symbol || c.already_in_watchlist
-                    const checked = !!(c.symbol && selected.has(c.symbol))
-                    return (
-                      <li key={key}>
-                        <label
-                          className={`flex items-center gap-3 px-3 py-2.5 text-sm ${
-                            disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:bg-elevated/50'
-                          }`}
-                        >
-                          <input
-                            type="checkbox"
-                            disabled={disabled}
-                            checked={checked}
-                            onChange={() => c.symbol && toggle(c.symbol)}
-                            className="rounded border-border"
-                          />
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-baseline gap-2">
-                              <span className="font-medium text-foreground truncate">
-                                {c.name || (c.matched ? c.symbol : '未匹配')}
-                              </span>
-                              <span className="text-[11px] text-muted tabular-nums shrink-0">
-                                {c.code}
-                                {c.symbol ? ` · ${c.symbol}` : ''}
-                              </span>
-                            </div>
-                            {c.already_in_watchlist && (
-                              <span className="text-[10px] text-muted">已在自选</span>
-                            )}
-                            {!c.matched && (
-                              <span className="text-[10px] text-warning/90">主数据未找到，已跳过</span>
-                            )}
-                          </div>
-                        </label>
-                      </li>
-                    )
-                  })}
-                </ul>
+            {csvFileName && (
+              <div className="flex items-center gap-2 rounded-btn border border-border bg-elevated/40 px-3 py-2 text-xs text-secondary">
+                <FileText className="h-3.5 w-3.5 shrink-0 text-accent" />
+                <span className="truncate flex-1">{csvFileName}</span>
               </div>
             )}
           </>
+        )}
+
+        {candidates.length > 0 && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-secondary">
+                {mode === 'csv' ? '解析' : '识别'} {candidates.length} 个代码 · 匹配 {matched.length} · 已选 {selected.size}
+              </span>
+              {selectable.length > 0 && (
+                <button
+                  type="button"
+                  onClick={toggleAll}
+                  className="text-[11px] text-accent hover:underline"
+                >
+                  {allSelected ? '取消全选' : '全选可添加'}
+                </button>
+              )}
+            </div>
+            <ul className="divide-y divide-border/60 rounded-btn border border-border overflow-hidden">
+              {candidates.map(c => {
+                const key = c.symbol || c.code
+                const disabled = !c.matched || !c.symbol || c.already_in_watchlist
+                const checked = !!(c.symbol && selected.has(c.symbol))
+                return (
+                  <li key={key}>
+                    <label
+                      className={`flex items-center gap-3 px-3 py-2.5 text-sm ${
+                        disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:bg-elevated/50'
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        disabled={disabled}
+                        checked={checked}
+                        onChange={() => c.symbol && toggle(c.symbol)}
+                        className="rounded border-border"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-baseline gap-2">
+                          <span className="font-medium text-foreground truncate">
+                            {c.name || (c.matched ? c.symbol : '未匹配')}
+                          </span>
+                          <span className="text-[11px] text-muted tabular-nums shrink-0">
+                            {c.code}
+                            {c.symbol ? ` · ${c.symbol}` : ''}
+                          </span>
+                        </div>
+                        {c.already_in_watchlist && (
+                          <span className="text-[10px] text-muted">已在自选</span>
+                        )}
+                        {!c.matched && (
+                          <span className="text-[10px] text-warning/90">主数据未找到，已跳过</span>
+                        )}
+                      </div>
+                    </label>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
         )}
       </div>
 
@@ -404,7 +536,7 @@ export function WatchlistImportDialog({ open, onClose }: Props) {
         </button>
         <button
           type="button"
-          disabled={ocrBlocked || selected.size === 0 || batchAdd.isPending || busy}
+          disabled={selected.size === 0 || batchAdd.isPending || busy}
           onClick={() => void confirmAdd()}
           className="h-8 px-3 rounded-btn text-xs inline-flex items-center gap-1.5 bg-accent text-white hover:bg-accent/90 disabled:opacity-40"
         >

--- a/frontend/src/components/screener/ScreenerTable.tsx
+++ b/frontend/src/components/screener/ScreenerTable.tsx
@@ -51,6 +51,8 @@ interface ScreenerTableProps {
   /** 表头排序（受控，由 Screener.tsx 传入） */
   sort?: SortState | null
   onSortToggle?: (colId: string) => void
+  /** 正在 K 线弹窗预览中的 symbol → 高亮该行 */
+  activeSymbol?: string | null
 }
 
 /** 渲染标签数组（含 maxTags 折叠/展开、横竖排列）。策略列与 ext 列共用。 */
@@ -151,7 +153,7 @@ export function ScreenerTable({
   dailyKChartVisible = true, onToggleDailyKChart,
   minuteData = {}, intradayChartVisible = true, onToggleIntradayChart,
   intradayAutoRefresh = false, onRefreshIntraday, intradayRefreshing = false,
-  sort, onSortToggle,
+  sort, onSortToggle, activeSymbol,
 }: ScreenerTableProps) {
   const [expandedCells, setExpandedCells] = useState<Set<string>>(new Set())
   const [dimensionTarget, setDimensionTarget] = useState<DimensionMembersTarget | null>(null)
@@ -361,7 +363,9 @@ export function ScreenerTable({
         rowKey={(r: any) => `${r.symbol}${r._expired ? '-expired' : ''}`}
         rowClassName={(r: any) => r._expired
           ? 'border-border/50 opacity-40'
-          : 'border-border hover:bg-elevated/50'
+          : r.symbol === activeSymbol
+            ? 'border-border bg-accent/10 hover:bg-accent/15'
+            : 'border-border hover:bg-elevated/50'
         }
         // 日k / 分时列表头：标签 + 显示/隐藏的眼睛按钮（与自选页一致）
         renderHeaderContent={(col) => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1281,6 +1281,11 @@ export const api = {
       method: 'PUT',
       body: JSON.stringify({ url }),
     }),
+  sendTestWebhook: (channel: 'feishu' | 'wecom') =>
+    request<{ ok: boolean; detail: string }>('/api/settings/preferences/webhook-test', {
+      method: 'POST',
+      body: JSON.stringify({ channel }),
+    }),
   updateWecomBot: (botId: string, secret: string, enabled: boolean = true) =>
     request<{
       wecom_bot_id: string

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1071,6 +1071,13 @@ export interface StrategyAlertEvent {
 }
 
 // ===== API surface =====
+/** 上传单文件到 /api/watchlist/* 导入端点，返回候选结果。 */
+function uploadWatchlistFile(path: string, file: File, signal?: AbortSignal, quiet = false) {
+  const fd = new FormData()
+  fd.append('file', file)
+  return request<WatchlistImportResult>(path, { method: 'POST', body: fd, signal, quiet })
+}
+
 export const api = {
   health: () => request<{ status: string; version: string; mode: string }>('/health'),
 
@@ -1519,16 +1526,10 @@ export const api = {
     }),
   watchlistOcrStatus: () =>
     request<{ provider: string; available: boolean }>('/api/watchlist/ocr-status'),
-  watchlistImportImage: (file: File, signal?: AbortSignal, quiet = false) => {
-    const fd = new FormData()
-    fd.append('file', file)
-    return request<WatchlistImportResult>('/api/watchlist/import-image', {
-      method: 'POST',
-      body: fd,
-      signal,
-      quiet,
-    })
-  },
+  watchlistImportImage: (file: File, signal?: AbortSignal, quiet = false) =>
+    uploadWatchlistFile('/api/watchlist/import-image', file, signal, quiet),
+  watchlistImportCsv: (file: File, signal?: AbortSignal, quiet = false) =>
+    uploadWatchlistFile('/api/watchlist/import-csv', file, signal, quiet),
   watchlistRemove: (symbol: string) =>
     request<{ symbols: WatchlistEntry[] }>(
       `/api/watchlist/${encodeURIComponent(symbol)}`,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -233,6 +233,7 @@ export interface WatchlistEntry {
   added_at: string
   note?: string
   name?: string | null
+  tags?: string
 }
 
 export interface WatchlistImportCandidate {
@@ -1528,6 +1529,11 @@ export const api = {
     request<{ symbols: WatchlistEntry[]; added: number }>('/api/watchlist/batch', {
       method: 'POST',
       body: JSON.stringify({ symbols, note }),
+    }),
+  watchlistSetTags: (symbol: string, tags: string[]) =>
+    request<{ symbols: WatchlistEntry[] }>(`/api/watchlist/${symbol}/tags`, {
+      method: 'POST',
+      body: JSON.stringify({ tags }),
     }),
   watchlistOcrStatus: () =>
     request<{ provider: string; available: boolean }>('/api/watchlist/ocr-status'),

--- a/frontend/src/lib/kline.ts
+++ b/frontend/src/lib/kline.ts
@@ -1,0 +1,27 @@
+/**
+ * 日K查询配置 — klineDaily 的唯一权威 options。
+ *
+ * StockDailyKChart(图表) 与 StockPanel(信息条) 各自 useQuery 共享同一 cache key,
+ * React Query 按 key 去重只发一次请求; 邻近预取 prefetchQuery 也复用本配置, 三处不会漂移。
+ *
+ * placeholderData 内置"仅同 symbol 占位"守卫: 改日期范围/扩展字段时旧数据可暂显(不闪),
+ * 切股时不透传上一只股票的数据(不误显示)。
+ */
+import { api } from '@/lib/api'
+import { QK } from '@/lib/queryKeys'
+
+export function klineDailyQueryOptions(
+  symbol: string,
+  dateRange: { start: string; end: string },
+  extColumns?: string,
+) {
+  return {
+    queryKey: QK.kline(symbol, dateRange.start, dateRange.end, extColumns),
+    queryFn: () => api.klineDaily(symbol, undefined, dateRange, extColumns),
+    // 工厂无 TData 泛型, 参数用 any 以便 useQuery/prefetchQuery 共用
+    placeholderData: (prev: any, prevQuery: any) => {
+      const prevKey = prevQuery?.queryKey as readonly unknown[] | undefined
+      return prevKey?.[1] === symbol ? prev : undefined
+    },
+  }
+}

--- a/frontend/src/lib/stock-external-link.ts
+++ b/frontend/src/lib/stock-external-link.ts
@@ -1,0 +1,34 @@
+/**
+ * 个股详情外链 — 可配置 URL 模板 + 证券代码。
+ *
+ * 占位符保持独立, 用户自行排列 (市场前缀/后缀因站而异):
+ *   {code}   纯 6 位代码, 如 000001
+ *   {market} 市场前缀小写, 如 sz / sh / bj
+ *   {symbol} 完整 symbol (含交易所后缀), 如 000001.SZ
+ * 模板留空 = 关闭外链。
+ */
+import { storage } from '@/lib/storage'
+
+/** 形状守卫: 只放行 6位数字 + 沪深北后缀 的 symbol (信息条场景下即股票) */
+const STOCK_SYMBOL_RE = /^(\d{6})\.(SH|SZ|BJ)$/
+
+/** 未设置或留空 → 返回 '' 即关闭外链 */
+export function loadStockExternalTemplate(): string {
+  return storage.stockExternalTemplate.get('')
+}
+
+export function saveStockExternalTemplate(tpl: string): void {
+  storage.stockExternalTemplate.set(tpl.trim())
+}
+
+export function buildStockExternalUrl(template: string, symbol: string): string | null {
+  if (!template) return null
+  const m = symbol.match(STOCK_SYMBOL_RE)
+  if (!m) return null
+  const code = m[1]
+  const market = m[2].toLowerCase()
+  return template
+    .replaceAll('{code}', code)
+    .replaceAll('{market}', market)
+    .replaceAll('{symbol}', symbol)
+}

--- a/frontend/src/lib/stock-table.ts
+++ b/frontend/src/lib/stock-table.ts
@@ -48,7 +48,7 @@ export function signalCls(type: SignalType): string {
 // ===== 排序 =====
 
 /** 不可参与数值/文本排序的内置列 key（渲染为标签/图表，无单一标量值） */
-export const UNSORTABLE_KEYS = new Set(['signals', 'candle', 'intraday', 'strategies'])
+export const UNSORTABLE_KEYS = new Set(['signals', 'candle', 'intraday', 'strategies', 'tags'])
 
 /**
  * 取一列在某行上的排序标量值。builtin 列按 key 映射到行字段；ext 列走

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -122,6 +122,9 @@ export const storage = {
   /** 行业分析页面字段配置 */
   industryAnalysisConfig: kv<Record<string, any>>('industry-analysis-config'),
 
+  /** 个股详情外链 URL 模板 (语义见 stock-external-link) */
+  stockExternalTemplate: kv<string>('stock_external_template'),
+
   /** 数据页画像卡片显隐 (卡片key → 是否显示) */
   dataCardVisible: kv<Record<string, boolean>>('data-card-visible'),
   /** 数据页画像卡片顺序 (卡片key 数组, 长度=卡片总数) */

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -57,6 +57,9 @@ export const storage = {
   /** 自选列表板块筛选 */
   watchlistBoardFilter: kv<string[]>('watchlist_boardFilter'),
 
+  /** 自选列表标签筛选 */
+  watchlistTagFilter: kv<string[]>('watchlist_tagFilter'),
+
   /** Screener 卡片尺寸 */
   screenerCardSize:     kv<string>('screener-card-size'),
 

--- a/frontend/src/lib/useFinancials.ts
+++ b/frontend/src/lib/useFinancials.ts
@@ -20,13 +20,17 @@ export function useFinancialStatus() {
   })
 }
 
-export function useFinancialMetrics(symbol?: string) {
-  return useQuery({
+/** financialMetrics 查询配置 (hook 与邻近预取共用, 防止 key/fn/staleTime 漂移) */
+export function financialMetricsQueryOptions(symbol?: string) {
+  return {
     queryKey: FINANCIAL_QK.metrics(symbol),
     queryFn: () => api.financialMetrics(symbol),
-    enabled: !!symbol,
     staleTime: 300_000,
-  })
+  }
+}
+
+export function useFinancialMetrics(symbol?: string) {
+  return useQuery({ ...financialMetricsQueryOptions(symbol), enabled: !!symbol })
 }
 
 export function useFinancialIncome(symbol?: string) {

--- a/frontend/src/lib/watchlist-columns.ts
+++ b/frontend/src/lib/watchlist-columns.ts
@@ -25,6 +25,7 @@ export type { ColumnConfig, ColumnGroup, ColumnSource, ExtColumnDisplayConfig, C
 export const BUILTIN_COLUMNS: ColumnConfig[] = [
   // 固定列
   { id: 'builtin:symbol', source: { type: 'builtin', key: 'symbol' }, label: '代码/名称', visible: true, pinned: true, align: 'left' },
+  { id: 'builtin:tags', source: { type: 'builtin', key: 'tags' }, label: '标签', visible: true, align: 'left' },
   // 价格
   { id: 'builtin:price', source: { type: 'builtin', key: 'price' }, label: '现价', visible: true, align: 'center' },
   { id: 'builtin:pct', source: { type: 'builtin', key: 'pct' }, label: '涨跌幅', visible: true, align: 'center' },
@@ -94,6 +95,7 @@ export const COLUMN_GROUPS: ColumnGroup[] = [
   { id: 'momentum', label: '动量', icon: '🚀', keys: ['momentum_5d', 'momentum_10d', 'momentum_20d', 'momentum_30d', 'momentum_60d'] },
   { id: 'limit', label: '连板', icon: '🔥', keys: ['limit_ups', 'limit_downs'] },
   { id: 'signal', label: '信号', icon: '📡', keys: ['signals', 'candle', 'intraday'] },
+  { id: 'tags', label: '标签', icon: '🏷️', keys: ['tags'] },
   { id: 'finance', label: '财务', icon: '📋', keys: ['eps', 'bps', 'roe', 'pe_ttm', 'pb', 'gross_margin', 'net_margin', 'revenue_yoy', 'net_income_yoy', 'debt_ratio'] },
 ]
 

--- a/frontend/src/pages/ConceptAnalysis.tsx
+++ b/frontend/src/pages/ConceptAnalysis.tsx
@@ -15,7 +15,7 @@ import {
 import { PageHeader } from '@/components/PageHeader'
 import { EmptyState } from '@/components/EmptyState'
 import { AnalysisConfigDialog, PresetFetchState, type AnalysisFieldConfig } from '@/components/analysis-shared'
-import { StockPreviewDialog } from '@/components/StockPreviewDialog'
+import { StockPreviewDialog, toNavItems, type NavItem } from '@/components/StockPreviewDialog'
 import { RpsRotationDialog } from '@/components/RpsRotationDialog'
 import { api, type MarketSnapshotRow } from '@/lib/api'
 import { QK } from '@/lib/queryKeys'
@@ -241,6 +241,7 @@ export function ConceptAnalysis() {
   const [sortMode, setSortMode] = useState<SortMode>('heat')
   const [previewSymbol, setPreviewSymbol] = useState<string | null>(null)
   const [previewName, setPreviewName] = useState<string>('')
+  const [previewNavList, setPreviewNavList] = useState<NavItem[]>([])
   const [showRps, setShowRps] = useState(false)
 
   const configsQuery = useQuery({ queryKey: QK.extData, queryFn: api.extDataList })
@@ -298,6 +299,7 @@ export function ConceptAnalysis() {
   }, [stats, search, sortMode])
 
   const selected = filteredStats.find(s => s.key === selectedKey) ?? filteredStats[0] ?? null
+
   const leading = useMemo(() => [...stats].sort(statSort('heat')).slice(0, 10), [stats])
   const falling = useMemo(() => [...stats].sort(statSort('down')).slice(0, 10), [stats])
   const activeConcept = useMemo(() => [...stats].sort(statSort('amount'))[0] ?? null, [stats])
@@ -393,7 +395,8 @@ export function ConceptAnalysis() {
             falling={falling}
             selectedKey={selected?.key ?? null}
             onSelect={setSelectedKey}
-            onStockClick={(sym, name) => { setPreviewSymbol(sym); setPreviewName(name ?? '') }}
+            activeSymbol={previewSymbol}
+            onStockClick={(sym, name, navList) => { setPreviewSymbol(sym); setPreviewName(name ?? ''); setPreviewNavList(navList ?? []) }}
           />
 
           {stats.length > 0 ? (
@@ -407,7 +410,7 @@ export function ConceptAnalysis() {
                 onSort={setSortMode}
                 onSelect={setSelectedKey}
               />
-              <ConceptFocus stat={selected} onStockClick={(sym, name) => { setPreviewSymbol(sym); setPreviewName(name ?? '') }} />
+              <ConceptFocus stat={selected} activeSymbol={previewSymbol} onStockClick={(sym, name, navList) => { setPreviewSymbol(sym); setPreviewName(name ?? ''); setPreviewNavList(navList ?? []) }} />
             </div>
           ) : rowsQuery.isLoading ? (
             <div className="rounded-2xl border border-border bg-surface px-6 py-16 text-center text-sm text-muted">正在计算概念强度...</div>
@@ -433,7 +436,9 @@ export function ConceptAnalysis() {
         <StockPreviewDialog
           symbol={previewSymbol}
           name={previewName}
-          onClose={() => { setPreviewSymbol(null); setPreviewName('') }}
+          onClose={() => { setPreviewSymbol(null); setPreviewName(''); setPreviewNavList([]) }}
+          navList={previewNavList}
+          onNavigate={(sym, n) => { setPreviewSymbol(sym); setPreviewName(n ?? '') }}
         />
       )}
 
@@ -509,17 +514,19 @@ function MarketPulse({
   selectedKey,
   onSelect,
   onStockClick,
+  activeSymbol,
 }: {
   leading: ConceptStat[]
   falling: ConceptStat[]
   selectedKey: string | null
   onSelect: (key: string) => void
-  onStockClick: (symbol: string, name?: string) => void
+  onStockClick: (symbol: string, name?: string, navList?: NavItem[]) => void
+  activeSymbol: string | null
 }) {
   return (
     <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
-      <PulseList title="领涨主线" items={leading} mode="up" selectedKey={selectedKey} onSelect={onSelect} onStockClick={onStockClick} />
-      <PulseList title="领跌方向" items={falling} mode="down" selectedKey={selectedKey} onSelect={onSelect} onStockClick={onStockClick} />
+      <PulseList title="领涨主线" items={leading} mode="up" selectedKey={selectedKey} onSelect={onSelect} onStockClick={onStockClick} activeSymbol={activeSymbol} />
+      <PulseList title="领跌方向" items={falling} mode="down" selectedKey={selectedKey} onSelect={onSelect} onStockClick={onStockClick} activeSymbol={activeSymbol} />
     </div>
   )
 }
@@ -531,13 +538,15 @@ function PulseList({
   selectedKey,
   onSelect,
   onStockClick,
+  activeSymbol,
 }: {
   title: string
   items: ConceptStat[]
   mode: 'up' | 'down'
   selectedKey: string | null
   onSelect: (key: string) => void
-  onStockClick: (symbol: string, name?: string) => void
+  onStockClick: (symbol: string, name?: string, navList?: NavItem[]) => void
+  activeSymbol: string | null
 }) {
   const toneText = mode === 'up' ? 'text-bull' : 'text-bear'
   const toneBorder = mode === 'up' ? 'border-bull/20' : 'border-bear/20'
@@ -556,7 +565,8 @@ function PulseList({
       <div className="space-y-1">
         {items.map((item, idx) => {
           const active = selectedKey === item.key
-          const leaders = [...item.stocks].sort((a, b) => b.leaderScore - a.leaderScore).slice(0, 3)
+          const sortedStocks = [...item.stocks].sort((a, b) => b.leaderScore - a.leaderScore)
+          const leaders = sortedStocks.slice(0, 3)
           const upPct = item.count > 0 ? (item.upCount / item.count) * 100 : 0
           const downPct = item.count > 0 ? (item.downCount / item.count) * 100 : 0
           const flatPct = Math.max(0, 100 - upPct - downPct)
@@ -597,7 +607,7 @@ function PulseList({
                   {Array.from({ length: 3 }).map((_, i) => {
                     const stock = leaders[i]
                     return stock ? (
-                      <span key={stock.symbol} title={stock.name || stock.symbol} onClick={e => { e.stopPropagation(); onStockClick(stock.symbol, stock.name || undefined) }} className={cn('flex min-w-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] cursor-pointer hover:brightness-125', i === 0 ? 'bg-amber-300/10 text-foreground' : 'bg-elevated/60 text-secondary')}>
+                      <span key={stock.symbol} title={stock.name || stock.symbol} onClick={e => { e.stopPropagation(); onStockClick(stock.symbol, stock.name || undefined, toNavItems(sortedStocks.slice(0, MAX_RENDERED_STOCKS))) }} className={cn('flex min-w-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] cursor-pointer hover:brightness-125', i === 0 ? 'bg-amber-300/10 text-foreground' : 'bg-elevated/60 text-secondary', stock.symbol === activeSymbol && 'ring-1 ring-accent/60')}>
                         <span className="flex min-w-0 items-center gap-1">
                           <span className="min-w-0 truncate font-medium">{stock.name || stock.symbol}</span>
                         </span>
@@ -674,10 +684,11 @@ function ConceptRail({
   )
 }
 
-function ConceptFocus({ stat, onStockClick }: { stat: ConceptStat | null; onStockClick: (symbol: string, name?: string) => void }) {
+function ConceptFocus({ stat, onStockClick, activeSymbol }: { stat: ConceptStat | null; onStockClick: (symbol: string, name?: string, navList?: NavItem[]) => void; activeSymbol: string | null }) {
   if (!stat) return null
   const stocks = [...stat.stocks].sort((a, b) => b.leaderScore - a.leaderScore).slice(0, MAX_RENDERED_STOCKS)
   const topLeaders = stocks.slice(0, 3)
+  const focusNav: NavItem[] = toNavItems(stocks)
   return (
     <section className="flex max-h-[720px] flex-col overflow-hidden rounded-2xl border border-border bg-surface">
       <div className="shrink-0 border-b border-border px-5 py-4">
@@ -706,7 +717,7 @@ function ConceptFocus({ stat, onStockClick }: { stat: ConceptStat | null; onStoc
       </div>
 
       <div className="grid shrink-0 gap-3 border-b border-border bg-base/25 p-4 lg:grid-cols-[1fr_1.15fr]">
-        <LeaderStage stocks={topLeaders} onStockClick={onStockClick} />
+        <LeaderStage stocks={topLeaders} activeSymbol={activeSymbol} onStockClick={(sym, name) => onStockClick(sym, name, focusNav)} />
         <ScoreExplain stock={topLeaders[0]} />
       </div>
 
@@ -726,7 +737,7 @@ function ConceptFocus({ stat, onStockClick }: { stat: ConceptStat | null; onStoc
           </thead>
           <tbody className="divide-y divide-border/70">
             {stocks.map((s, idx) => (
-              <tr key={`${s.symbol}-${idx}`} className="hover:bg-elevated/30 cursor-pointer" onClick={() => onStockClick(s.symbol, s.name || undefined)}>
+              <tr key={`${s.symbol}-${idx}`} className={cn('cursor-pointer', s.symbol === activeSymbol ? 'bg-accent/10 hover:bg-accent/15' : 'hover:bg-elevated/30')} onClick={() => onStockClick(s.symbol, s.name || undefined, focusNav)}>
                 <td className="px-4 py-2 font-mono text-muted">{idx + 1}</td>
                 <td className="px-4 py-2">
                   <div className="font-medium text-foreground">{s.name || '—'}</div>
@@ -757,7 +768,7 @@ function MiniStat({ label, value, cls }: { label: string; value: string; cls: st
   return <div className="rounded-lg border border-border/60 bg-base/35 px-2 py-1.5"><div className="text-[10px] text-muted">{label}</div><div className={cn('mt-0.5 truncate text-sm font-semibold', cls)}>{value}</div></div>
 }
 
-function LeaderStage({ stocks, onStockClick }: { stocks: EnrichedStock[]; onStockClick: (symbol: string, name?: string) => void }) {
+function LeaderStage({ stocks, onStockClick, activeSymbol }: { stocks: EnrichedStock[]; onStockClick: (symbol: string, name?: string) => void; activeSymbol: string | null }) {
   if (!stocks.length) return <div className="rounded-xl border border-border/60 bg-surface p-4 text-sm text-muted">暂无龙头候选</div>
   return (
     <div className="rounded-xl border border-border/60 bg-surface p-3">
@@ -767,7 +778,7 @@ function LeaderStage({ stocks, onStockClick }: { stocks: EnrichedStock[]; onStoc
       </div>
       <div className="grid gap-2 md:grid-cols-3">
         {stocks.map((stock, idx) => (
-          <div key={stock.symbol} onClick={() => onStockClick(stock.symbol, stock.name || undefined)} className={cn('rounded-lg border p-3 cursor-pointer hover:brightness-110 transition-all', idx === 0 ? 'border-amber-400/25 bg-amber-400/[0.06]' : 'border-border/60 bg-base/35')}>
+          <div key={stock.symbol} onClick={() => onStockClick(stock.symbol, stock.name || undefined)} className={cn('rounded-lg border p-3 cursor-pointer hover:brightness-110 transition-all', idx === 0 ? 'border-amber-400/25 bg-amber-400/[0.06]' : 'border-border/60 bg-base/35', stock.symbol === activeSymbol && 'ring-1 ring-accent/60')}>
             <div className="flex items-center justify-between gap-2">
               <span className={cn('text-[10px] font-medium', idx === 0 ? 'text-amber-300' : 'text-muted')}>{idx === 0 ? '主龙头' : `辅龙 ${idx}`}</span>
               <span className="font-mono text-[11px] text-amber-300">{stock.leaderScore.toFixed(0)}</span>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -9,7 +9,7 @@ import { QK } from '@/lib/queryKeys'
 import { fmtBigNum, fmtPct } from '@/lib/format'
 import { useDataStatus, useCapabilities, useSettings } from '@/lib/useSharedQueries'
 import { SealedBadge } from '@/components/SealedBadge'
-import { StockPreviewDialog } from '@/components/StockPreviewDialog'
+import { StockPreviewDialog, toNavItems, type NavItem } from '@/components/StockPreviewDialog'
 import { SettingsModal } from '@/components/data/SettingsModal'
 import { STAGE_LABELS } from '@/components/data/ActiveJobCard'
 import { cn } from '@/lib/cn'
@@ -96,7 +96,10 @@ const _SEVERITY_BAR: Record<string, string> = {
   info: 'bg-accent/40', warn: 'bg-warning', critical: 'bg-danger',
 }
 
-function MonitorWidget({ onStockClick }: { onStockClick: (event: AlertEvent) => void }) {
+function MonitorWidget({ onStockClick, activeSymbol }: {
+  onStockClick: (event: AlertEvent, navList?: NavItem[]) => void
+  activeSymbol?: string
+}) {
   const navigate = useNavigate()
   const alerts = useQuery({
     queryKey: ['alerts', ''],
@@ -105,6 +108,8 @@ function MonitorWidget({ onStockClick }: { onStockClick: (event: AlertEvent) => 
     refetchIntervalInBackground: true,
   })
   const events: AlertEvent[] = alerts.data?.alerts ?? []
+  // 切股导航列表: 有 symbol 的触发记录
+  const alertNav = toNavItems(events.filter((ev): ev is AlertEvent & { symbol: string } => !!ev.symbol))
 
   if (events.length === 0) {
     return (
@@ -128,13 +133,13 @@ function MonitorWidget({ onStockClick }: { onStockClick: (event: AlertEvent) => 
               initial={{ opacity: 0, y: -8, scale: 0.98 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
               transition={{ duration: 0.3, delay: Math.min(i * 0.03, 0.3) }}
-              className="relative overflow-hidden rounded-md border border-border/40 bg-surface/60 pl-2.5 pr-2 py-1.5 hover:border-border hover:bg-surface transition-colors"
+              className={`relative overflow-hidden rounded-md border pl-2.5 pr-2 py-1.5 transition-colors ${ev.symbol && ev.symbol === activeSymbol ? 'border-accent/40 bg-accent/5' : 'border-border/40 bg-surface/60 hover:border-border hover:bg-surface'}`}
             >
               <div className={cn('absolute left-0 top-0 h-full w-0.5', sev)} />
               {/* 第一行: 代码 + 名称 + 价格 + 涨跌幅 (点击代码/名称弹日K) */}
               <div className="flex items-center gap-1.5">
                 <button
-                  onClick={() => isSector ? navigate('/monitor') : ev.symbol && onStockClick(ev)}
+                  onClick={() => isSector ? navigate('/monitor') : ev.symbol && onStockClick(ev, alertNav)}
                   title={isSector ? '在监控中心查看板块告警' : ev.symbol ? `查看 ${ev.symbol} 日K` : undefined}
                   className={`inline-flex items-center gap-1 min-w-0 shrink-0 rounded hover:bg-elevated/60 transition-colors -mx-0.5 px-0.5 ${isSector || ev.symbol ? 'cursor-pointer' : 'cursor-default'}`}
                 >
@@ -408,9 +413,10 @@ function MiniMetric({ label, value, cls = 'text-foreground' }: { label: string; 
   )
 }
 
-function StockList({ title, rows, mode, onStockClick }: {
+function StockList({ title, rows, mode, onStockClick, activeSymbol }: {
   title: string; rows: MarketSnapshotRow[]; mode: 'gain' | 'loss' | 'amount' | 'active';
   onStockClick?: (symbol: string, name?: string) => void;
+  activeSymbol?: string;
 }) {
   return (
     <div className="rounded-card border border-border bg-surface/80 p-1.5 shadow-[0_1px_2px_hsl(var(--border)/0.4)] backdrop-blur-sm transition-shadow hover:shadow-[0_2px_8px_hsl(var(--border)/0.5)]">
@@ -422,7 +428,7 @@ function StockList({ title, rows, mode, onStockClick }: {
         {rows.slice(0, 8).map((r, idx) => (
           <div
             key={`${r.symbol}-${idx}`}
-            className="grid grid-cols-[18px_1fr_auto] items-center gap-1.5 rounded-md bg-elevated/40 px-1.5 py-1 cursor-pointer hover:bg-elevated hover:brightness-110 transition-colors border border-transparent hover:border-border/60"
+            className={`grid grid-cols-[18px_1fr_auto] items-center gap-1.5 rounded-md px-1.5 py-1 cursor-pointer transition-colors border ${r.symbol === activeSymbol ? 'bg-accent/10 border-accent/30' : 'bg-elevated/40 border-transparent hover:bg-elevated hover:brightness-110 hover:border-border/60'}`}
             onClick={() => onStockClick?.(r.symbol, r.name ?? undefined)}
           >
             <span className="text-center font-mono text-[10px] text-muted">{idx + 1}</span>
@@ -466,15 +472,16 @@ function StockList({ title, rows, mode, onStockClick }: {
   )
 }
 
-function RankColumn({ title, rows, tone, onStockClick }: {
+function RankColumn({ title, rows, tone, onStockClick, activeSymbol }: {
   title: string; rows: OverviewDimensionRankItem[]; tone: 'bull' | 'bear';
   onStockClick?: (symbol: string, name?: string) => void;
+  activeSymbol?: string;
 }) {
   return (
     <div className="min-w-0 space-y-1">
       <div className={`text-[10px] font-medium ${tone === 'bull' ? 'text-bull' : 'text-bear'}`}>{title}</div>
       {rows.slice(0, 5).map((r, idx) => (
-        <div key={`${title}-${r.name}-${idx}`} className="grid grid-cols-[14px_1fr_auto] items-center gap-1 rounded-md bg-elevated/40 px-1.5 py-1 border border-transparent hover:border-border/60 transition-colors">
+        <div key={`${title}-${r.name}-${idx}`} className={`grid grid-cols-[14px_1fr_auto] items-center gap-1 rounded-md px-1.5 py-1 border transition-colors ${r.leader?.symbol && r.leader.symbol === activeSymbol ? 'bg-accent/10 border-accent/30' : 'bg-elevated/40 border-transparent hover:border-border/60'}`}>
           <span className="text-center font-mono text-[9px] text-muted">{idx + 1}</span>
           <div className="min-w-0">
             <div className="truncate text-[11px] text-foreground" title={r.name}>{r.name}</div>
@@ -508,9 +515,10 @@ function RankColumn({ title, rows, tone, onStockClick }: {
   )
 }
 
-function HotRankCard({ title, rank, configUrl, onStockClick }: {
+function HotRankCard({ title, rank, configUrl, onStockClick, activeSymbol }: {
   title: string; rank?: OverviewMarket['concept_rank']; configUrl: string;
   onStockClick?: (symbol: string, name?: string) => void;
+  activeSymbol?: string;
 }) {
   const hasData = (rank?.leading?.length ?? 0) > 0 || (rank?.lagging?.length ?? 0) > 0
   return (
@@ -518,8 +526,8 @@ function HotRankCard({ title, rank, configUrl, onStockClick }: {
       <SectionTitle icon={Flame} title={title} hint="领涨/领跌" />
       {hasData ? (
         <div className="grid grid-cols-2 gap-2">
-          <RankColumn title="领涨" rows={rank?.leading ?? []} tone="bull" onStockClick={onStockClick} />
-          <RankColumn title="领跌" rows={rank?.lagging ?? []} tone="bear" onStockClick={onStockClick} />
+          <RankColumn title="领涨" rows={rank?.leading ?? []} tone="bull" onStockClick={onStockClick} activeSymbol={activeSymbol} />
+          <RankColumn title="领跌" rows={rank?.lagging ?? []} tone="bear" onStockClick={onStockClick} activeSymbol={activeSymbol} />
         </div>
       ) : (
         <div className="py-4 text-center">
@@ -536,11 +544,29 @@ function HotRankCard({ title, rank, configUrl, onStockClick }: {
   )
 }
 
+// 切股导航列表构建 (与列表展示行一致: StockList 只显示前 8)
+function stockListNav(rows: MarketSnapshotRow[]): NavItem[] {
+  return toNavItems(rows.slice(0, 8))
+}
+function rankNav(rank?: OverviewMarket['concept_rank']): NavItem[] {
+  return [...(rank?.leading ?? []), ...(rank?.lagging ?? [])]
+    .filter(r => r.leader?.symbol)
+    .map(r => ({ symbol: r.leader!.symbol!, name: r.leader!.name ?? undefined }))
+}
+
 export function Dashboard() {
   const qc = useQueryClient()
   const [selectedDate, setSelectedDate] = useState<string | undefined>()
   const [manualFetching, setManualFetching] = useState(false)
-  const [previewStock, setPreviewStock] = useState<{symbol: string; name?: string; alert?: AlertEvent} | null>(null)
+  const [previewStock, setPreviewStock] = useState<{
+    symbol: string
+    name?: string
+    alert?: AlertEvent
+    /** 打开来源榜: 仅高亮来源榜的行 */
+    source?: 'gain' | 'loss' | 'amount' | 'active' | 'concept' | 'industry' | 'alert'
+    /** 切股导航列表 (来自来源榜) */
+    navList?: NavItem[]
+  } | null>(null)
   // 首次使用(无数据 + 未完成引导)自动弹窗: 同一会话只弹一次
   const [showWelcomeModal, setShowWelcomeModal] = useState(false)
   const dataStatus = useDataStatus({ staleTime: 60_000 })
@@ -805,15 +831,15 @@ export function Dashboard() {
           </div>
 
           <div className="grid grid-cols-1 gap-1.5 md:grid-cols-2">
-            <HotRankCard title="概念热度" rank={data.concept_rank} configUrl="/concept-analysis" onStockClick={(symbol, name) => setPreviewStock({symbol, name})} />
-            <HotRankCard title="行业热度" rank={data.industry_rank} configUrl="/industry-analysis" onStockClick={(symbol, name) => setPreviewStock({symbol, name})} />
+            <HotRankCard title="概念热度" rank={data.concept_rank} configUrl="/concept-analysis" activeSymbol={previewStock?.source === 'concept' ? previewStock.symbol : undefined} onStockClick={(symbol, name) => setPreviewStock({ symbol, name, source: 'concept', navList: rankNav(data.concept_rank) })} />
+            <HotRankCard title="行业热度" rank={data.industry_rank} configUrl="/industry-analysis" activeSymbol={previewStock?.source === 'industry' ? previewStock.symbol : undefined} onStockClick={(symbol, name) => setPreviewStock({ symbol, name, source: 'industry', navList: rankNav(data.industry_rank) })} />
           </div>
 
           <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-2 xl:grid-cols-4">
-            <StockList title="涨幅榜" rows={data.top_gainers} mode="gain" onStockClick={(symbol, name) => setPreviewStock({symbol, name})} />
-            <StockList title="跌幅榜" rows={data.top_losers} mode="loss" onStockClick={(symbol, name) => setPreviewStock({symbol, name})} />
-            <StockList title="成交额榜" rows={data.turnover_leaders} mode="amount" onStockClick={(symbol, name) => setPreviewStock({symbol, name})} />
-            <StockList title="活跃换手" rows={data.active_leaders} mode="active" onStockClick={(symbol, name) => setPreviewStock({symbol, name})} />
+            <StockList title="涨幅榜" rows={data.top_gainers} mode="gain" activeSymbol={previewStock?.source === 'gain' ? previewStock.symbol : undefined} onStockClick={(symbol, name) => setPreviewStock({ symbol, name, source: 'gain', navList: stockListNav(data.top_gainers) })} />
+            <StockList title="跌幅榜" rows={data.top_losers} mode="loss" activeSymbol={previewStock?.source === 'loss' ? previewStock.symbol : undefined} onStockClick={(symbol, name) => setPreviewStock({ symbol, name, source: 'loss', navList: stockListNav(data.top_losers) })} />
+            <StockList title="成交额榜" rows={data.turnover_leaders} mode="amount" activeSymbol={previewStock?.source === 'amount' ? previewStock.symbol : undefined} onStockClick={(symbol, name) => setPreviewStock({ symbol, name, source: 'amount', navList: stockListNav(data.turnover_leaders) })} />
+            <StockList title="活跃换手" rows={data.active_leaders} mode="active" activeSymbol={previewStock?.source === 'active' ? previewStock.symbol : undefined} onStockClick={(symbol, name) => setPreviewStock({ symbol, name, source: 'active', navList: stockListNav(data.active_leaders) })} />
           </div>
         </main>
 
@@ -833,9 +859,12 @@ export function Dashboard() {
                 <ArrowUpRight className="h-3.5 w-3.5" />
               </Link>
             </div>
-            <MonitorWidget onStockClick={(event) => {
-              if (event.symbol) setPreviewStock({ symbol: event.symbol, name: event.name ?? undefined, alert: event })
-            }} />
+            <MonitorWidget
+              activeSymbol={previewStock?.source === 'alert' ? previewStock.symbol : undefined}
+              onStockClick={(event, navList) => {
+                if (event.symbol) setPreviewStock({ symbol: event.symbol, name: event.name ?? undefined, alert: event, source: 'alert', navList })
+              }}
+            />
           </section>
         </aside>
       </div>
@@ -850,6 +879,8 @@ export function Dashboard() {
           signals: previewStock.alert.signals,
           message: previewStock.alert.message,
         } : null}
+        navList={previewStock?.navList}
+        onNavigate={(sym, n) => setPreviewStock(prev => prev ? { ...prev, symbol: sym, name: n, alert: prev.source === 'alert' ? undefined : prev.alert } : prev)}
         onClose={() => setPreviewStock(null)}
       />
     </div>

--- a/frontend/src/pages/IndustryAnalysis.tsx
+++ b/frontend/src/pages/IndustryAnalysis.tsx
@@ -15,7 +15,7 @@ import {
 import { PageHeader } from '@/components/PageHeader'
 import { EmptyState } from '@/components/EmptyState'
 import { AnalysisConfigDialog, DimensionHeatmap, PresetFetchState, type AnalysisFieldConfig } from '@/components/analysis-shared'
-import { StockPreviewDialog } from '@/components/StockPreviewDialog'
+import { StockPreviewDialog, toNavItems, type NavItem } from '@/components/StockPreviewDialog'
 import { RpsRotationDialog } from '@/components/RpsRotationDialog'
 import { api, type MarketSnapshotRow } from '@/lib/api'
 import { QK } from '@/lib/queryKeys'
@@ -276,6 +276,7 @@ export function IndustryAnalysis() {
   const [sortMode, setSortMode] = useState<SortMode>('heat')
   const [previewSymbol, setPreviewSymbol] = useState<string | null>(null)
   const [previewName, setPreviewName] = useState<string>('')
+  const [previewNavList, setPreviewNavList] = useState<NavItem[]>([])
   const [showRps, setShowRps] = useState(false)
 
   const configsQuery = useQuery({ queryKey: QK.extData, queryFn: api.extDataList })
@@ -336,6 +337,7 @@ export function IndustryAnalysis() {
   }, [stats, search, sortMode])
 
   const selected = filteredStats.find(s => s.key === selectedKey) ?? filteredStats[0] ?? null
+
   const leading = useMemo(() => [...stats].sort(statSort('heat')).slice(0, 10), [stats])
   const falling = useMemo(() => [...stats].sort(statSort('down')).slice(0, 10), [stats])
   const activeIndustry = useMemo(() => [...stats].sort(statSort('amount'))[0] ?? null, [stats])
@@ -446,7 +448,8 @@ export function IndustryAnalysis() {
             falling={falling}
             selectedKey={selected?.key ?? null}
             onSelect={setSelectedKey}
-            onStockClick={(sym, name) => { setPreviewSymbol(sym); setPreviewName(name ?? '') }}
+            activeSymbol={previewSymbol}
+            onStockClick={(sym, name, navList) => { setPreviewSymbol(sym); setPreviewName(name ?? ''); setPreviewNavList(navList ?? []) }}
           />
 
           {/* 热力图 */}
@@ -471,7 +474,7 @@ export function IndustryAnalysis() {
                 onSort={setSortMode}
                 onSelect={setSelectedKey}
               />
-              <IndustryFocus stat={selected} onStockClick={(sym, name) => { setPreviewSymbol(sym); setPreviewName(name ?? '') }} />
+              <IndustryFocus stat={selected} activeSymbol={previewSymbol} onStockClick={(sym, name, navList) => { setPreviewSymbol(sym); setPreviewName(name ?? ''); setPreviewNavList(navList ?? []) }} />
             </div>
           ) : rowsQuery.isLoading ? (
             <div className="rounded-2xl border border-border bg-surface px-6 py-16 text-center text-sm text-muted">正在计算行业强度...</div>
@@ -497,7 +500,9 @@ export function IndustryAnalysis() {
         <StockPreviewDialog
           symbol={previewSymbol}
           name={previewName}
-          onClose={() => { setPreviewSymbol(null); setPreviewName('') }}
+          onClose={() => { setPreviewSymbol(null); setPreviewName(''); setPreviewNavList([]) }}
+          navList={previewNavList}
+          onNavigate={(sym, n) => { setPreviewSymbol(sym); setPreviewName(n ?? '') }}
         />
       )}
       {showRps && <RpsRotationDialog onClose={() => setShowRps(false)} kind="industry" />}
@@ -574,17 +579,19 @@ function MarketPulse({
   selectedKey,
   onSelect,
   onStockClick,
+  activeSymbol,
 }: {
   leading: IndustryStat[]
   falling: IndustryStat[]
   selectedKey: string | null
   onSelect: (key: string) => void
-  onStockClick: (symbol: string, name?: string) => void
+  onStockClick: (symbol: string, name?: string, navList?: NavItem[]) => void
+  activeSymbol: string | null
 }) {
   return (
     <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
-      <PulseList title="领涨主线" items={leading} mode="up" selectedKey={selectedKey} onSelect={onSelect} onStockClick={onStockClick} />
-      <PulseList title="领跌方向" items={falling} mode="down" selectedKey={selectedKey} onSelect={onSelect} onStockClick={onStockClick} />
+      <PulseList title="领涨主线" items={leading} mode="up" selectedKey={selectedKey} onSelect={onSelect} onStockClick={onStockClick} activeSymbol={activeSymbol} />
+      <PulseList title="领跌方向" items={falling} mode="down" selectedKey={selectedKey} onSelect={onSelect} onStockClick={onStockClick} activeSymbol={activeSymbol} />
     </div>
   )
 }
@@ -596,13 +603,15 @@ function PulseList({
   selectedKey,
   onSelect,
   onStockClick,
+  activeSymbol,
 }: {
   title: string
   items: IndustryStat[]
   mode: 'up' | 'down'
   selectedKey: string | null
   onSelect: (key: string) => void
-  onStockClick: (symbol: string, name?: string) => void
+  onStockClick: (symbol: string, name?: string, navList?: NavItem[]) => void
+  activeSymbol: string | null
 }) {
   const toneText = mode === 'up' ? 'text-bull' : 'text-bear'
   const toneBorder = mode === 'up' ? 'border-bull/20' : 'border-bear/20'
@@ -621,7 +630,8 @@ function PulseList({
       <div className="space-y-1">
         {items.map((item, idx) => {
           const active = selectedKey === item.key
-          const leaders = [...item.stocks].sort((a, b) => b.leaderScore - a.leaderScore).slice(0, 3)
+          const sortedStocks = [...item.stocks].sort((a, b) => b.leaderScore - a.leaderScore)
+          const leaders = sortedStocks.slice(0, 3)
           const upPct = item.count > 0 ? (item.upCount / item.count) * 100 : 0
           const downPct = item.count > 0 ? (item.downCount / item.count) * 100 : 0
           const flatPct = Math.max(0, 100 - upPct - downPct)
@@ -662,7 +672,7 @@ function PulseList({
                   {Array.from({ length: 3 }).map((_, i) => {
                     const stock = leaders[i]
                     return stock ? (
-                      <span key={stock.symbol} title={stock.name || stock.symbol} onClick={e => { e.stopPropagation(); onStockClick(stock.symbol, stock.name || undefined) }} className={cn('flex min-w-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] cursor-pointer hover:brightness-125', i === 0 ? 'bg-amber-300/10 text-foreground' : 'bg-elevated/60 text-secondary')}>
+                      <span key={stock.symbol} title={stock.name || stock.symbol} onClick={e => { e.stopPropagation(); onStockClick(stock.symbol, stock.name || undefined, toNavItems(sortedStocks.slice(0, MAX_RENDERED_STOCKS))) }} className={cn('flex min-w-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] cursor-pointer hover:brightness-125', i === 0 ? 'bg-amber-300/10 text-foreground' : 'bg-elevated/60 text-secondary', stock.symbol === activeSymbol && 'ring-1 ring-accent/60')}>
                         <span className="flex min-w-0 items-center gap-1">
                           <span className="min-w-0 truncate font-medium">{stock.name || stock.symbol}</span>
                         </span>
@@ -743,10 +753,11 @@ function IndustryRail({
 
 // ===== IndustryFocus（右侧聚焦面板） =====
 
-function IndustryFocus({ stat, onStockClick }: { stat: IndustryStat | null; onStockClick: (symbol: string, name?: string) => void }) {
+function IndustryFocus({ stat, onStockClick, activeSymbol }: { stat: IndustryStat | null; onStockClick: (symbol: string, name?: string, navList?: NavItem[]) => void; activeSymbol: string | null }) {
   if (!stat) return null
   const stocks = [...stat.stocks].sort((a, b) => b.leaderScore - a.leaderScore).slice(0, MAX_RENDERED_STOCKS)
   const topLeaders = stocks.slice(0, 3)
+  const focusNav: NavItem[] = toNavItems(stocks)
   return (
     <section className="flex max-h-[720px] flex-col overflow-hidden rounded-2xl border border-border bg-surface">
       <div className="shrink-0 border-b border-border px-5 py-4">
@@ -775,7 +786,7 @@ function IndustryFocus({ stat, onStockClick }: { stat: IndustryStat | null; onSt
       </div>
 
       <div className="grid shrink-0 gap-3 border-b border-border bg-base/25 p-4 lg:grid-cols-[1fr_1.15fr]">
-        <LeaderStage stocks={topLeaders} onStockClick={onStockClick} />
+        <LeaderStage stocks={topLeaders} activeSymbol={activeSymbol} onStockClick={(sym, name) => onStockClick(sym, name, focusNav)} />
         <ScoreExplain stock={topLeaders[0]} />
       </div>
 
@@ -795,7 +806,7 @@ function IndustryFocus({ stat, onStockClick }: { stat: IndustryStat | null; onSt
           </thead>
           <tbody className="divide-y divide-border/70">
             {stocks.map((s, idx) => (
-              <tr key={`${s.symbol}-${idx}`} className="hover:bg-elevated/30 cursor-pointer" onClick={() => onStockClick(s.symbol, s.name || undefined)}>
+              <tr key={`${s.symbol}-${idx}`} className={cn('cursor-pointer', s.symbol === activeSymbol ? 'bg-accent/10 hover:bg-accent/15' : 'hover:bg-elevated/30')} onClick={() => onStockClick(s.symbol, s.name || undefined, focusNav)}>
                 <td className="px-4 py-2 font-mono text-muted">{idx + 1}</td>
                 <td className="px-4 py-2">
                   <div className="font-medium text-foreground">{s.name || '—'}</div>
@@ -826,7 +837,7 @@ function MiniStat({ label, value, cls }: { label: string; value: string; cls: st
   return <div className="rounded-lg border border-border/60 bg-base/35 px-2 py-1.5"><div className="text-[10px] text-muted">{label}</div><div className={cn('mt-0.5 truncate text-sm font-semibold', cls)}>{value}</div></div>
 }
 
-function LeaderStage({ stocks, onStockClick }: { stocks: EnrichedStock[]; onStockClick: (symbol: string, name?: string) => void }) {
+function LeaderStage({ stocks, onStockClick, activeSymbol }: { stocks: EnrichedStock[]; onStockClick: (symbol: string, name?: string) => void; activeSymbol: string | null }) {
   if (!stocks.length) return <div className="rounded-xl border border-border/60 bg-surface p-4 text-sm text-muted">暂无龙头候选</div>
   return (
     <div className="rounded-xl border border-border/60 bg-surface p-3">
@@ -836,7 +847,7 @@ function LeaderStage({ stocks, onStockClick }: { stocks: EnrichedStock[]; onStoc
       </div>
       <div className="grid gap-2 md:grid-cols-3">
         {stocks.map((stock, idx) => (
-          <div key={stock.symbol} onClick={() => onStockClick(stock.symbol, stock.name || undefined)} className={cn('rounded-lg border p-3 cursor-pointer hover:brightness-110 transition-all', idx === 0 ? 'border-amber-400/25 bg-amber-400/[0.06]' : 'border-border/60 bg-base/35')}>
+          <div key={stock.symbol} onClick={() => onStockClick(stock.symbol, stock.name || undefined)} className={cn('rounded-lg border p-3 cursor-pointer hover:brightness-110 transition-all', idx === 0 ? 'border-amber-400/25 bg-amber-400/[0.06]' : 'border-border/60 bg-base/35', stock.symbol === activeSymbol && 'ring-1 ring-accent/60')}>
             <div className="flex items-center justify-between gap-2">
               <span className={cn('text-[10px] font-medium', idx === 0 ? 'text-amber-300' : 'text-muted')}>{idx === 0 ? '主龙头' : `辅龙 ${idx}`}</span>
               <span className="font-mono text-[11px] text-amber-300">{stock.leaderScore.toFixed(0)}</span>

--- a/frontend/src/pages/LimitUpLadder.tsx
+++ b/frontend/src/pages/LimitUpLadder.tsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { RefreshCw, ChevronDown, Flame, Settings2, X, Bell, BellOff, AlertCircle } from 'lucide-react'
 import { DatePicker } from '@/components/DatePicker'
 import { api, type LimitLadderTier, type LimitLadderStock, type MonitorRule } from '@/lib/api'
-import { StockPreviewDialog } from '@/components/StockPreviewDialog'
+import { StockPreviewDialog, toNavItems, type NavItem } from '@/components/StockPreviewDialog'
 import { DimensionMembersDialog, type DimensionKind, type DimensionMembersTarget } from '@/components/DimensionMembersDialog'
 import { QK } from '@/lib/queryKeys'
 import { storage } from '@/lib/storage'
@@ -220,7 +220,7 @@ function useSealedDegrade(asOf: string, latestDate: string | undefined, sealedRe
 
 // ===== 单只股票卡片 =====
 
-const StockCard = React.memo(function StockCard({ stock, extFields, direction, sealMode, monitored, monitorRule, onMonitorChange, hasDepth, onClick, onDimensionClick }: {
+const StockCard = React.memo(function StockCard({ stock, extFields, direction, sealMode, monitored, monitorRule, onMonitorChange, hasDepth, onClick, onDimensionClick, active }: {
   stock: LimitLadderStock
   extFields: ExtFieldConfig
   direction: Direction
@@ -231,6 +231,8 @@ const StockCard = React.memo(function StockCard({ stock, extFields, direction, s
   hasDepth: boolean
   onClick: (symbol: string, name?: string) => void
   onDimensionClick: (kind: DimensionKind, value: string, sourceField?: string) => void
+  /** 正在 K 线弹窗预览中 → 高亮卡片 */
+  active?: boolean
 }) {
   const [showMonitorMenu, setShowMonitorMenu] = useState(false)
   const [menuAnchor, setMenuAnchor] = useState<DOMRect | null>(null)
@@ -298,7 +300,7 @@ const StockCard = React.memo(function StockCard({ stock, extFields, direction, s
         event.preventDefault()
         onClick(stock.symbol, stock.name ?? undefined)
       }}
-      className={`w-full flex flex-col items-start gap-1 px-2.5 py-2 rounded-md transition-all duration-200 cursor-pointer hover:opacity-100 ${style.bg} ${style.bar} ${monitored ? 'ring-1 ring-amber-400/50 ring-inset' : ''}`}
+      className={`w-full flex flex-col items-start gap-1 px-2.5 py-2 rounded-md transition-all duration-200 cursor-pointer hover:opacity-100 ${style.bg} ${style.bar} ${monitored ? 'ring-1 ring-amber-400/50 ring-inset' : ''} ${active ? 'ring-1 ring-accent/60 ring-inset' : ''}`}
       style={style.cardStyle ? { ...style.cardStyle } : undefined}
       onMouseEnter={e => {
         if (!style.cardStyle || !style.hoverShadow) return
@@ -924,7 +926,53 @@ function TagStats({ title, tiers, extFields, fieldKey, color, selectedTag, onSel
 
 // ===== 梯队分组 =====
 
-function TierGroup({ tier, defaultOpen, extFields, filterKeys, bf, onStockClick, selectedTag, onSelectTag, onDimensionClick, direction, sealMode, monitoredSymbols, ladderRules, onMonitorChange, hasDepth }: {
+/** 与 TierGroup 卡片展示一致的过滤+排序 (监控优先 → 状态 → 封单量), 供切股导航列表复用 */
+function sortLadderStocks(
+  stocks: LimitLadderStock[],
+  opts: {
+    monitoredSymbols: Set<string>
+    sealMode: 'vol' | 'amount'
+    selectedTag: { fieldKey: 'concept' | 'industry'; tag: string } | null
+    extFields: ExtFieldConfig
+  },
+): LimitLadderStock[] {
+  return [...stocks]
+    .filter(s => {
+      if (!opts.selectedTag) return true
+      const item = opts.extFields[opts.selectedTag.fieldKey]
+      if (!item) return true
+      const tags = getExtTags(s, item)
+      return tags.includes(opts.selectedTag.tag)
+    })
+    .sort((a, b) => {
+      // 开启监控的卡片排到分组最前
+      const ma = opts.monitoredSymbols.has(a.symbol) ? 0 : 1
+      const mb = opts.monitoredSymbols.has(b.symbol) ? 0 : 1
+      if (ma !== mb) return ma - mb
+      const ord = (s: string) => {
+        if (s === 'limit_up' || s === 'limit_down' || !s) return 0
+        if (s === 'broken' || s === 'recovery') return 1
+        return 2
+      }
+      const oa = ord(a.status ?? '')
+      const ob = ord(b.status ?? '')
+      if (oa !== ob) return oa - ob
+      // 同状态(主状态=涨停/跌停)内: 按封单从高到低排, 无封单排末尾。
+      // 封单额 = sealed_vol(手) × 100 × close, 与展示口径一致。
+      if (oa === 0) {
+        const sealVal = (s: LimitLadderStock) => {
+          if (s.sealed_vol == null) return -1
+          return opts.sealMode === 'amount' && s.close
+            ? s.sealed_vol * 100 * s.close
+            : s.sealed_vol
+        }
+        return sealVal(b) - sealVal(a)
+      }
+      return 0
+    })
+}
+
+function TierGroup({ tier, defaultOpen, extFields, filterKeys, bf, onStockClick, selectedTag, onSelectTag, onDimensionClick, direction, sealMode, monitoredSymbols, ladderRules, onMonitorChange, hasDepth, activeSymbol }: {
   tier: LimitLadderTier
   defaultOpen: boolean
   extFields: ExtFieldConfig
@@ -940,6 +988,7 @@ function TierGroup({ tier, defaultOpen, extFields, filterKeys, bf, onStockClick,
   ladderRules: Map<string, MonitorRule>
   onMonitorChange: () => void
   hasDepth: boolean
+  activeSymbol: string | null
 }) {
   const isDarkTheme = useTheme() === 'dark'
   const [open, setOpen] = useState(defaultOpen)
@@ -1083,40 +1132,7 @@ function TierGroup({ tier, defaultOpen, extFields, filterKeys, bf, onStockClick,
               </div>
             )}
             <div className="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-3 px-3 pb-3">
-              {[...tier.stocks]
-                .filter(s => {
-                  if (!selectedTag) return true
-                  const item = extFields[selectedTag.fieldKey]
-                  if (!item) return true
-                  const tags = getExtTags(s, item)
-                  return tags.includes(selectedTag.tag)
-                })
-                .sort((a, b) => {
-                  // 开启监控的卡片排到分组最前
-                  const ma = monitoredSymbols.has(a.symbol) ? 0 : 1
-                  const mb = monitoredSymbols.has(b.symbol) ? 0 : 1
-                  if (ma !== mb) return ma - mb
-                  const ord = (s: string) => {
-                    if (s === 'limit_up' || s === 'limit_down' || !s) return 0
-                    if (s === 'broken' || s === 'recovery') return 1
-                    return 2
-                  }
-                  const oa = ord(a.status ?? '')
-                  const ob = ord(b.status ?? '')
-                  if (oa !== ob) return oa - ob
-                  // 同状态(主状态=涨停/跌停)内: 按封单从高到低排, 无封单排末尾。
-                  // 封单额 = sealed_vol(手) × 100 × close, 与展示口径一致。
-                  if (oa === 0) {
-                    const sealVal = (s: typeof a) => {
-                      if (s.sealed_vol == null) return -1
-                      return sealMode === 'amount' && s.close
-                        ? s.sealed_vol * 100 * s.close
-                        : s.sealed_vol
-                    }
-                    return sealVal(b) - sealVal(a)
-                  }
-                  return 0
-                }).map(s => (
+              {sortLadderStocks(tier.stocks, { monitoredSymbols, sealMode, selectedTag, extFields }).map(s => (
                 <StockCard
                   key={`${s.symbol}-${s.status}`}
                   stock={s}
@@ -1129,6 +1145,7 @@ function TierGroup({ tier, defaultOpen, extFields, filterKeys, bf, onStockClick,
                   hasDepth={hasDepth}
                   onClick={onStockClick}
                   onDimensionClick={onDimensionClick}
+                  active={activeSymbol === s.symbol}
                 />
               ))}
             </div>
@@ -1488,6 +1505,7 @@ export function LimitUpLadder() {
   }, [showConcept])
   const [previewSymbol, setPreviewSymbol] = useState<string | null>(null)
   const [previewName, setPreviewName] = useState('')
+  const [previewNavList, setPreviewNavList] = useState<NavItem[]>([])
   const [selectedTag, setSelectedTag] = useState<{ fieldKey: 'concept' | 'industry'; tag: string } | null>(null)
   const [dimensionTarget, setDimensionTarget] = useState<DimensionMembersTarget | null>(null)
   const handleSelectTag = useCallback((sel: { fieldKey: 'concept' | 'industry'; tag: string } | null) => {
@@ -1509,11 +1527,6 @@ export function LimitUpLadder() {
     storage.limitLadderExtFields.set(f)
   }, [])
 
-  const handleStockClick = useCallback((symbol: string, name?: string) => {
-    setPreviewSymbol(symbol)
-    setPreviewName(name ?? '')
-  }, [])
-
   const extColumnsParam = useMemo(() => buildExtColumnsParam(extFields), [extFields])
 
   const { data, isLoading, refetch, isFetching } = useQuery({
@@ -1527,8 +1540,26 @@ export function LimitUpLadder() {
   }, [asOf, data?.as_of])
 
   const rawTiers = data?.tiers ?? []
-  const tiers = filterTiers(rawTiers, filterKeys, extFields.bf)
+  // filterTiers 每次返回新数组, 不 memo 会破坏 React.memo(StockCard) 且全梯队二次排序
+  const tiers = useMemo(() => filterTiers(rawTiers, filterKeys, extFields.bf), [rawTiers, filterKeys, extFields.bf])
   const displayDate = data?.as_of ?? asOf
+
+  // 切股导航列表: 各梯队按展示同款排序展平 (监控优先 → 状态 → 封单量)
+  const ladderNavItems = useMemo(
+    () => toNavItems(tiers.flatMap(t => sortLadderStocks(t.stocks, {
+      monitoredSymbols,
+      sealMode,
+      selectedTag,
+      extFields: resolveExtFields(extFields, showConcept, showIndustry),
+    }))),
+    [tiers, monitoredSymbols, sealMode, selectedTag, extFields, showConcept, showIndustry],
+  )
+
+  const handleStockClick = useCallback((symbol: string, name?: string, navList?: NavItem[]) => {
+    setPreviewSymbol(symbol)
+    setPreviewName(name ?? '')
+    setPreviewNavList(navList ?? ladderNavItems)
+  }, [ladderNavItems])
 
   // sealed 降级判定
   const sealedDegrade = useSealedDegrade(asOf, data?.as_of, data?.sealed_ready, data?.sealed_counts)
@@ -1749,6 +1780,7 @@ export function LimitUpLadder() {
             ladderRules={ladderRules}
             onMonitorChange={refetchMonitorRules}
             hasDepth={sealedDegrade.hasDepth}
+            activeSymbol={previewSymbol}
           />
         ))}
       </div>
@@ -1756,9 +1788,9 @@ export function LimitUpLadder() {
       <DimensionMembersDialog
         target={dimensionTarget}
         onClose={() => setDimensionTarget(null)}
-        onStockClick={(symbol, name) => {
+        onStockClick={(symbol, name, navList) => {
           setDimensionTarget(null)
-          handleStockClick(symbol, name)
+          handleStockClick(symbol, name, navList)
         }}
       />
 
@@ -1766,7 +1798,9 @@ export function LimitUpLadder() {
       <StockPreviewDialog
         symbol={previewSymbol}
         name={previewName}
-        onClose={() => setPreviewSymbol(null)}
+        onClose={() => { setPreviewSymbol(null); setPreviewNavList([]) }}
+        navList={previewNavList}
+        onNavigate={(sym, n) => { setPreviewSymbol(sym); setPreviewName(n ?? '') }}
       />
 
       {/* 字段配置弹窗 */}

--- a/frontend/src/pages/Monitor.tsx
+++ b/frontend/src/pages/Monitor.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo } from 'react'
+import { useCallback, useState, useRef, useEffect, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { motion, AnimatePresence } from 'framer-motion'
@@ -16,7 +16,7 @@ import { LEGACY_STRATEGY_NOTIFY_EVENTS, STRATEGY_NOTIFY_EVENT_OPTIONS, strategyE
 import { boardTag } from '@/components/stock-table/primitives'
 import { markSeen, resetBadge, leaveMonitorPage } from '@/lib/monitorBadge'
 import { RuleEditor } from '@/components/monitor/RuleEditor'
-import { StockPreviewDialog } from '@/components/StockPreviewDialog'
+import { StockPreviewDialog, toNavItems, type NavItem } from '@/components/StockPreviewDialog'
 import { DimensionMembersDialog, type DimensionKind, type DimensionMembersTarget } from '@/components/DimensionMembersDialog'
 import { usePreferences } from '@/lib/useSharedQueries'
 
@@ -301,6 +301,7 @@ function AlertsList({ alertsQuery, confirmClear, setConfirmClear, total, enterTs
   const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [previewEv, setPreviewEv] = useState<AlertEvent | null>(null)
   const [memberPreview, setMemberPreview] = useState<{ symbol: string; name?: string } | null>(null)
+  const [previewNavList, setPreviewNavList] = useState<NavItem[]>([])
   const [dimensionTarget, setDimensionTarget] = useState<DimensionMembersTarget | null>(null)
 
   const clearMut = useMutation({
@@ -328,6 +329,22 @@ function AlertsList({ alertsQuery, confirmClear, setConfirmClear, total, enterTs
   }
 
   const events = (alertsQuery.data as any)?.alerts ?? []
+
+  // 切股导航列表: 有 symbol 的触发记录 (按展示顺序)
+  const alertsNavItems = useMemo(
+    () => toNavItems(events.filter((ev: AlertEvent) => ev.symbol)),
+    [events],
+  )
+  const handlePreviewEvent = useCallback((ev: AlertEvent) => {
+    setPreviewEv(ev)
+    setPreviewNavList(alertsNavItems)
+  }, [alertsNavItems])
+  // 弹窗内切股: 来自成分弹窗则更新 memberPreview, 否则按 symbol 找到对应事件 (保住 triggerInfo)
+  const handleNavigate = useCallback((sym: string, name?: string) => {
+    if (memberPreview) { setMemberPreview({ symbol: sym, name }); return }
+    const ev = events.find((e: AlertEvent) => e.symbol === sym)
+    if (ev) setPreviewEv(ev)
+  }, [memberPreview, events])
 
   return (
     <div className="space-y-3">
@@ -362,6 +379,7 @@ function AlertsList({ alertsQuery, confirmClear, setConfirmClear, total, enterTs
                 className={cn(
                   'group relative flex items-start gap-3 overflow-hidden rounded-lg border bg-surface pl-3.5 pr-3 py-2.5 shadow-sm transition-all duration-200 hover:border-border hover:shadow-md hover:shadow-black/10 hover:-translate-y-px',
                   isNew ? 'border-accent/60 ring-1 ring-accent/30' : 'border-border/50',
+                  previewEv && ev.symbol && ev.symbol === previewEv.symbol ? 'ring-1 ring-accent/60 border-accent/40' : '',
                 )}
               >
                 <div className={cn('absolute left-0 top-0 h-full w-0.5', sev.bar)} />
@@ -380,7 +398,7 @@ function AlertsList({ alertsQuery, confirmClear, setConfirmClear, total, enterTs
                             const board = boardTag(ev.symbol)
                             return (
                               <button
-                                onClick={() => setPreviewEv(ev)}
+                                onClick={() => handlePreviewEvent(ev)}
                                 className="inline-flex items-center gap-1.5 rounded hover:bg-elevated/50 px-1 -mx-1 transition-colors cursor-pointer"
                                 title="点击查看日K"
                               >
@@ -459,7 +477,7 @@ function AlertsList({ alertsQuery, confirmClear, setConfirmClear, total, enterTs
                           const board = boardTag(ev.symbol)
                           return (
                             <button
-                              onClick={() => setPreviewEv(ev)}
+                              onClick={() => handlePreviewEvent(ev)}
                               className="inline-flex items-center gap-1.5 rounded hover:bg-elevated/50 px-1 -mx-1 transition-colors cursor-pointer"
                               title="点击查看日K"
                             >
@@ -589,15 +607,18 @@ function AlertsList({ alertsQuery, confirmClear, setConfirmClear, total, enterTs
           signals: previewEv.signals,
           message: previewEv.message,
         } : null}
-        onClose={() => { setPreviewEv(null); setMemberPreview(null) }}
+        navList={previewNavList}
+        onNavigate={handleNavigate}
+        onClose={() => { setPreviewEv(null); setMemberPreview(null); setPreviewNavList([]) }}
       />
 
       <DimensionMembersDialog
         target={dimensionTarget}
         onClose={() => setDimensionTarget(null)}
-        onStockClick={(symbol, name) => {
+        onStockClick={(symbol, name, navList) => {
           setDimensionTarget(null)
           setMemberPreview({ symbol, name })
+          setPreviewNavList(navList ?? alertsNavItems)
         }}
       />
     </div>
@@ -631,6 +652,17 @@ function RulesList({ rulesQuery, onEdit }: {
     staleTime: 300000,
   })
   const symbolNames = namesQuery.data?.names ?? {}
+
+  // 切股导航列表: 个股规则 (取第一个 symbol, 按展示顺序)
+  const rulesNavItems = useMemo(
+    () => rules
+      .filter(r => r.scope === 'symbols' && r.symbols.length > 0)
+      .map(r => ({ symbol: r.symbols[0], name: symbolNames[r.symbols[0]] ?? undefined }) as NavItem),
+    [rules, symbolNames],
+  )
+  const handlePreviewSymbol = useCallback((sym: string) => {
+    setPreviewSymbol(sym)
+  }, [])
 
   const del = useMutation({
     mutationFn: api.monitorRuleDelete,
@@ -686,6 +718,7 @@ function RulesList({ rulesQuery, onEdit }: {
                 r.enabled
                   ? 'border-border/50 bg-surface hover:border-accent/30'
                   : 'border-border/30 bg-surface/40 opacity-70 hover:opacity-100',
+                r.scope === 'symbols' && r.symbols[0] === previewSymbol ? 'ring-1 ring-accent/60 border-accent/40' : '',
               )}
             >
               {/* 左侧状态条 */}
@@ -703,7 +736,7 @@ function RulesList({ rulesQuery, onEdit }: {
                   {/* 个股类型: 直接显示可点击的代码+名称; 其他类型显示规则名 */}
                   {r.scope === 'symbols' && r.symbols.length > 0 ? (
                     <button
-                      onClick={() => setPreviewSymbol(r.symbols[0])}
+                      onClick={() => handlePreviewSymbol(r.symbols[0])}
                       className="inline-flex items-center gap-1 min-w-0 hover:bg-elevated/50 rounded px-0.5 transition-colors cursor-pointer"
                       title={`查看 ${r.symbols[0]} 日K`}
                     >
@@ -815,6 +848,8 @@ function RulesList({ rulesQuery, onEdit }: {
       <StockPreviewDialog
         symbol={previewSymbol}
         name={previewSymbol ? symbolNames[previewSymbol] : undefined}
+        navList={rulesNavItems}
+        onNavigate={(sym) => setPreviewSymbol(sym)}
         onClose={() => setPreviewSymbol(null)}
       />
     </div>

--- a/frontend/src/pages/Screener.tsx
+++ b/frontend/src/pages/Screener.tsx
@@ -13,7 +13,7 @@ import { storage } from '@/lib/storage'
 import { PageHeader } from '@/components/PageHeader'
 import { EmptyState } from '@/components/EmptyState'
 import { DatePicker } from '@/components/DatePicker'
-import { StockPreviewDialog } from '@/components/StockPreviewDialog'
+import { StockPreviewDialog, toNavItems } from '@/components/StockPreviewDialog'
 import { useStrategyPool } from '@/lib/useStrategyPool'
 import { StrategyCard, CardSize, loadCardSize, cardWrapCls } from '@/components/screener/StrategyCard'
 import { ScreenerTable } from '@/components/screener/ScreenerTable'
@@ -372,6 +372,12 @@ export function Screener() {
   const candleDays = useMemo(() => resolveCandleConfig(candleColumn?.candleConfig).days, [candleColumn])
   // 真正请求/渲染蜡烛图：列可见 且 眼睛开关开启
   const dailyKVisible = candleColumnEnabled && dailyKChartVisible
+
+  // 切股导航列表: 按当前展示顺序 (含灰色失效行)
+  const previewNavItems = useMemo(
+    () => toNavItems(displayRows),
+    [displayRows],
+  )
 
   // 批量日k数据 (仅当蜡烛图可见时加载，省请求)
   const dailyKSymbols = useMemo(
@@ -894,6 +900,7 @@ export function Screener() {
                     symbolStrategyMap={symbolStrategyMap}
                     activeStrategy={activeStrategy}
                     watchlistSet={watchlistSet}
+                    activeSymbol={previewSymbol}
                     onPreview={(symbol, name) => { setPreviewSymbol(symbol); setPreviewName(name) }}
                     onToggleWatchlist={(symbol, inList) => toggleWatchlist.mutate({ symbol, inList })}
                     watchlistPending={toggleWatchlist.isPending}
@@ -943,6 +950,8 @@ export function Screener() {
         symbol={previewSymbol}
         name={previewName}
         onClose={closePreview}
+        navList={previewNavItems}
+        onNavigate={(sym, n) => { setPreviewSymbol(sym); setPreviewName(n ?? '') }}
       />
 
       <StrategySettingsDialog

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Trash2, RefreshCw, Star, X, Search, LayoutGrid, List, Settings2, Plus, Check, Filter, Eye, EyeOff, Minus, ChevronsUp, Clock, RotateCcw, ImagePlus } from 'lucide-react'
+import { Trash2, RefreshCw, Star, X, Search, LayoutGrid, List, Settings2, Plus, Check, Filter, Eye, EyeOff, Minus, ChevronsUp, Clock, RotateCcw, Import } from 'lucide-react'
 import { api, type KlineRow, type MinuteKlineRow } from '@/lib/api'
 import { QK } from '@/lib/queryKeys'
 import { storage } from '@/lib/storage'
@@ -16,7 +16,6 @@ import {
   type DimensionMembersTarget,
 } from '@/components/DimensionMembersDialog'
 import { WatchlistImportDialog } from '@/components/WatchlistImportDialog'
-import { getOcrInstallHint } from '@/lib/ocrInstallHint'
 import { ColumnCustomizer } from '@/components/ColumnCustomizer'
 import { StockDataTable } from '@/components/stock-table/StockDataTable'
 import { VIRTUAL_LIST_THRESHOLD, useParentScroll } from '@/components/virtual-list/useParentScroll'
@@ -584,33 +583,12 @@ export function Watchlist() {
   const [columns, setColumns] = useState<ColumnConfig[]>([...BUILTIN_COLUMNS])
   const [customizerOpen, setCustomizerOpen] = useState(false)
   const [importOpen, setImportOpen] = useState(false)
-  const [ocrAvailable, setOcrAvailable] = useState<boolean | null>(null)
-  const [ocrInstallHint, setOcrInstallHint] = useState('')
   const columnsLoaded = useRef(false)
 
   useEffect(() => {
     if (columnsLoaded.current) return
     columnsLoaded.current = true
     loadColumnConfig().then(setColumns)
-  }, [])
-
-  useEffect(() => {
-    let cancelled = false
-    void api.watchlistOcrStatus().then(
-      res => {
-        if (cancelled) return
-        setOcrAvailable(res.available)
-        if (!res.available) setOcrInstallHint(getOcrInstallHint())
-      },
-      () => {
-        if (cancelled) return
-        setOcrAvailable(false)
-        setOcrInstallHint(getOcrInstallHint())
-      },
-    )
-    return () => {
-      cancelled = true
-    }
   }, [])
 
   const handleColumnsChange = useCallback((next: ColumnConfig[]) => {
@@ -1048,19 +1026,11 @@ export function Watchlist() {
               onAdd={(sym) => addMutation.mutate(sym)}
             />
             <button
-              onClick={() => {
-                if (ocrAvailable === false) return
-                setImportOpen(true)
-              }}
-              disabled={ocrAvailable === false}
-              className="inline-flex items-center justify-center h-8 w-8 rounded-btn bg-elevated hover:bg-elevated/80 text-secondary hover:text-foreground transition-colors duration-150 ease-smooth disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-elevated disabled:hover:text-secondary"
-              title={
-                ocrAvailable === false
-                  ? ocrInstallHint || 'OCR 不可用，请先安装 Tesseract'
-                  : '从截图导入自选'
-              }
+              onClick={() => setImportOpen(true)}
+              className="inline-flex items-center justify-center h-8 w-8 rounded-btn bg-elevated hover:bg-elevated/80 text-secondary hover:text-foreground transition-colors duration-150 ease-smooth"
+              title="导入自选（截图识别 / CSV 文件）"
             >
-              <ImagePlus className="h-4 w-4" />
+              <Import className="h-4 w-4" />
             </button>
             <div className="w-px h-5 bg-border" />
             {/* 视图 */}

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Trash2, RefreshCw, Star, X, Search, LayoutGrid, List, Settings2, Plus, Check, Filter, Eye, EyeOff, Minus, ChevronsUp, Clock, RotateCcw, Import } from 'lucide-react'
+import { Trash2, RefreshCw, Star, X, Search, LayoutGrid, List, Settings2, Tag, Plus, Check, Filter, Eye, EyeOff, Minus, ChevronsUp, Clock, RotateCcw, Import } from 'lucide-react'
 import { api, type KlineRow, type MinuteKlineRow } from '@/lib/api'
 import { QK } from '@/lib/queryKeys'
 import { storage } from '@/lib/storage'
@@ -10,6 +10,7 @@ import { fmtPrice, fmtPct, fmtBigNum, priceColorClass, formatExtNumber } from '@
 import { PageHeader } from '@/components/PageHeader'
 import { EmptyState } from '@/components/EmptyState'
 import { StockPreviewDialog, type NavItem } from '@/components/StockPreviewDialog'
+import { Modal } from '@/components/Modal'
 import {
   DimensionMembersDialog,
   dimensionKindForSourceField,
@@ -59,6 +60,69 @@ function turnoverColor(rate: number | null | undefined): string {
   if (rate < 20)  return 'text-[#f97316]'
   if (rate < 35)  return 'text-[#d94a3d]'
   return 'text-[#b84a8a]'
+}
+
+// ===== 标签（多对多注解）=====
+
+function splitTags(s?: string | null): string[] {
+  return (s || '').split(',').map(t => t.trim()).filter(Boolean)
+}
+
+function TagChips({ tags, onEdit }: { tags: string[]; onEdit?: () => void }) {
+  return (
+    <div className="flex items-center gap-1 flex-wrap min-w-0">
+      {tags.slice(0, 3).map(t => (
+        <span key={t} className="inline-block px-1.5 py-px rounded text-[10px] font-medium leading-tight text-yellow-500 bg-yellow-500/10">
+          {t}
+        </span>
+      ))}
+      {tags.length > 3 && <span className="text-[10px] text-muted">+{tags.length - 3}</span>}
+      {onEdit && (
+        <button
+          type="button"
+          onClick={e => { e.stopPropagation(); onEdit() }}
+          className="p-0.5 text-muted hover:text-accent rounded transition-colors"
+          title="编辑标签"
+          aria-label="编辑标签"
+        >
+          <Tag className="h-3 w-3" />
+        </button>
+      )}
+    </div>
+  )
+}
+
+// 筛选栏单行标签筛选块 (板块/标签共用)
+function FilterChipRow({ label, chips, activeSet, onToggle }: {
+  label: string
+  chips: readonly string[]
+  activeSet: Set<string>
+  onToggle: (v: string) => void
+}) {
+  if (chips.length === 0) return null
+  return (
+    <div className="mb-2">
+      <div className="text-[10px] text-muted uppercase tracking-wider mb-0.5">{label}</div>
+      <div className="flex flex-wrap gap-1">
+        {chips.map(v => {
+          const active = activeSet.has(v)
+          return (
+            <button
+              key={v}
+              onClick={() => onToggle(v)}
+              className={`px-2 py-0.5 rounded text-[11px] transition-colors ${
+                active
+                  ? 'bg-accent/15 text-accent'
+                  : 'bg-elevated text-secondary hover:text-foreground hover:bg-elevated/80'
+              }`}
+            >
+              {v}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
 }
 
 // ===== 动态列渲染 =====
@@ -402,6 +466,7 @@ const StockCard = React.memo(function StockCard({
   onDimensionClick,
   isMonitored,
   active,
+  onEditTags,
 }: {
   r: any
   candleRows: KlineRow[]
@@ -418,11 +483,13 @@ const StockCard = React.memo(function StockCard({
   isMonitored?: boolean
   /** 正在 K 线弹窗预览中 → 高亮卡片 */
   active?: boolean
+  onEditTags: (symbol: string) => void
 }) {
   const board = boardTag(r.symbol)
   const price = r.rt_price ?? r.close
   const pct = r.rt_pct ?? r.change_pct
   const name = r.rt_name ?? r.name
+  const tags = splitTags(r.tags)
   const signals = getSignals(r)
   const isUp = (pct ?? 0) > 0
   const isDown = (pct ?? 0) < 0
@@ -542,6 +609,10 @@ const StockCard = React.memo(function StockCard({
         </div>
       </div>
 
+      <div className="pl-4 pr-2.5 pt-1.5 pb-0">
+        <TagChips tags={tags} onEdit={() => onEditTags(r.symbol)} />
+      </div>
+
       {/* 信号标签区 */}
       {signals.length > 0 && (
         <div className="pl-4 pr-2.5 pt-1.5 pb-2 flex flex-wrap gap-1">
@@ -567,6 +638,117 @@ const StockCard = React.memo(function StockCard({
     </div>
   )
 })
+
+// ===== 标签编辑弹窗 =====
+
+function TagEditorDialog({
+  symbol,
+  name,
+  tags,
+  allTags,
+  onClose,
+  onSave,
+}: {
+  symbol: string
+  name: string
+  tags: string[]
+  allTags: string[]
+  onClose: () => void
+  onSave: (symbol: string, tags: string[]) => void
+}) {
+  const titleId = 'tag-editor-title'
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [draft, setDraft] = useState<string[]>(tags)
+  const [input, setInput] = useState('')
+  const suggestions = allTags.filter(t => !draft.includes(t))
+
+  function addTag(raw?: string) {
+    const clean = (raw ?? input).trim().replace(/[,，]/g, '')
+    setInput('')
+    inputRef.current?.focus()
+    if (!clean || draft.includes(clean)) return
+    const next = [...draft, clean]
+    setDraft(next)
+    onSave(symbol, next)
+  }
+
+  function removeTag(t: string) {
+    const next = draft.filter(x => x !== t)
+    setDraft(next)
+    onSave(symbol, next)
+  }
+
+  return (
+    <Modal
+      onClose={onClose}
+      labelledBy={titleId}
+      panelClassName="relative w-[90vw] max-w-[360px] rounded-card border border-border bg-base shadow-2xl p-5"
+    >
+      <h3 id={titleId} className="text-sm font-medium text-foreground mb-0.5">
+        <span className="font-mono">{symbol}</span>
+        {name && <span className="text-secondary ml-2">{name}</span>}
+      </h3>
+
+      <div className="flex flex-wrap gap-1 mb-2 min-h-[24px]">
+        {draft.map(t => (
+          <span key={t} className="inline-flex items-center gap-1 px-1.5 py-px rounded text-[11px] font-medium leading-tight text-yellow-500 bg-yellow-500/10">
+            {t}
+            <button
+              onClick={() => removeTag(t)}
+              className="text-yellow-500/60 hover:text-yellow-500 transition-colors"
+              aria-label={`删除标签 ${t}`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+        {draft.length === 0 && <span className="text-[11px] text-muted self-center">暂无标签</span>}
+      </div>
+
+      <div className="flex items-center gap-1.5">
+        <input
+          ref={inputRef}
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') addTag() }}
+          placeholder="输入标签，回车添加"
+          maxLength={20}
+          autoFocus
+          className="flex-1 h-8 px-2 rounded-btn bg-elevated border border-border text-xs text-foreground placeholder:text-muted focus:outline-none focus:border-accent/50"
+        />
+        <button
+          onClick={() => addTag()}
+          className="px-2.5 h-8 rounded-btn bg-accent/15 text-accent hover:bg-accent/25 text-xs font-medium transition-colors"
+        >
+          添加
+        </button>
+      </div>
+
+      {suggestions.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {suggestions.map(s => (
+            <button
+              key={s}
+              onClick={() => addTag(s)}
+              className="px-1.5 py-px rounded text-[10px] text-muted bg-elevated hover:text-accent hover:bg-accent/10 transition-colors"
+            >
+              + {s}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-4 flex items-center justify-end">
+        <button
+          onClick={onClose}
+          className="px-3 py-1.5 rounded-btn bg-elevated text-secondary hover:bg-elevated/80 text-sm transition-colors"
+        >
+          完成
+        </button>
+      </div>
+    </Modal>
+  )
+}
 
 // ===== 主页面 =====
 
@@ -772,18 +954,47 @@ export function Watchlist() {
     },
   })
 
+  const setTags = useMutation({
+    mutationFn: ({ symbol, tags }: { symbol: string; tags: string[] }) => api.watchlistSetTags(symbol, tags),
+    onSuccess: (data, variables) => {
+      qc.setQueryData(QK.watchlist, data)
+      // 标签只改自选行的 tags 字段, 就地 patch 该行即可, 不必整表重拉行情
+      qc.setQueryData(['watchlist-enriched', extColumnsParam], (old: any) => {
+        if (!old?.rows) return old
+        const tags = data.symbols.find(s => s.symbol === variables.symbol)?.tags ?? ''
+        return {
+          ...old,
+          rows: old.rows.map((r: any) => r.symbol === variables.symbol ? { ...r, tags } : r),
+        }
+      })
+    },
+  })
+
   // 二次确认状态
   const [confirmClear, setConfirmClear] = useState(false)
   const [confirmRemove, setConfirmRemove] = useState<string | null>(null)
 
+  const [tagEditSymbol, setTagEditSymbol] = useState<string | null>(null)
+
   const allSymbols = list.data?.symbols?.map(s => s.symbol) ?? []
   const rows = enriched.data?.rows ?? []
+
+  // 每行标签只 split 一次, 筛选/列渲染/编辑弹窗共用
+  const tagsBySymbol = useMemo(() => {
+    const map = new Map<string, string[]>()
+    for (const r of rows) map.set(r.symbol, splitTags(r.tags))
+    return map
+  }, [rows])
+
   const handleCardConfirmRemove = useCallback((sym: string) => {
     remove.mutate(sym); setConfirmRemove(null)
   }, [remove])
   const handleCardCancelRemove = useCallback(() => setConfirmRemove(null), [])
   const handleCardRequestRemove = useCallback((sym: string) => setConfirmRemove(sym), [])
-
+  const handleEditTags = useCallback((sym: string) => setTagEditSymbol(sym), [])
+  const handleSaveTags = useCallback((sym: string, tags: string[]) => {
+    setTags.mutate({ symbol: sym, tags })
+  }, [setTags])
   // 实时监控圆点: 仅 Free/低档 "按自选股实时监控" 模式 (mode === 'watchlist') 下显示;
   // Starter+ 全市场模式 (mode === 'full_market') 全部标的都在监控, 标圆点无意义, 故不显示。
   // 后端 Free 档实际只监控自选页前 N 个 (N = watchlist_symbol_count), 顺序与 allSymbols 一致。
@@ -820,6 +1031,29 @@ export function Watchlist() {
     })
   }, [persistBoardFilter])
 
+  const [tagFilter, setTagFilter] = useState<Set<string>>(() => new Set(storage.watchlistTagFilter.get([])))
+  const persistTagFilter = useCallback((next: Set<string>) => {
+    setTagFilter(next)
+    storage.watchlistTagFilter.set([...next])
+  }, [])
+
+  const toggleTag = useCallback((tag: string) => {
+    setTagFilter(prev => {
+      const next = new Set(prev)
+      if (next.has(tag)) next.delete(tag)
+      else next.add(tag)
+      persistTagFilter(next)
+      return next
+    })
+  }, [persistTagFilter])
+
+  // 全部现有标签 ∪ 已激活筛选(含已从行里消失的), 供筛选栏与编辑弹窗建议
+  const tagFilterChips = useMemo(() => {
+    const set = new Set(tagFilter)
+    for (const ts of tagsBySymbol.values()) for (const t of ts) set.add(t)
+    return [...set].sort()
+  }, [tagsBySymbol, tagFilter])
+
   const updateFilter = useCallback((colId: string, patch: { min?: string; max?: string; text?: string }) => {
     setFilters(prev => {
       const next = { ...prev }
@@ -837,7 +1071,8 @@ export function Watchlist() {
   const resetAllFilters = useCallback(() => {
     setFilters({})
     persistBoardFilter(new Set(BOARDS))
-  }, [persistBoardFilter])
+    persistTagFilter(new Set())
+  }, [persistBoardFilter, persistTagFilter])
 
   // 可筛选的内置列
   const filterableBuiltinCols = useMemo(
@@ -870,6 +1105,9 @@ export function Watchlist() {
         return board != null && boardFilter.has(board)
       })
     }
+    if (tagFilter.size > 0) {
+      result = result.filter(r => (tagsBySymbol.get(r.symbol) ?? []).some(t => tagFilter.has(t)))
+    }
     // 数值/文本筛选
     const activeFilters = Object.entries(filters).filter(([, v]) => v.min || v.max || v.text)
     if (activeFilters.length > 0) {
@@ -890,9 +1128,9 @@ export function Watchlist() {
       })
     }
     return result
-  }, [rows, filters, columns, boardFilter])
+  }, [rows, filters, columns, boardFilter, tagFilter, tagsBySymbol])
 
-  const activeFilterCount = Object.values(filters).filter(v => v.min || v.max || v.text).length
+  const activeFilterCount = Object.values(filters).filter(v => v.min || v.max || v.text).length + tagFilter.size
   const hasBoardFilter = boardFilter.size > 0 && boardFilter.size < BOARDS.length
   const hasActiveFilters = activeFilterCount > 0 || hasBoardFilter
 
@@ -968,8 +1206,11 @@ export function Watchlist() {
       onDimensionClick={setDimensionTarget}
       isMonitored={monitoredSymbols.has(r.symbol)}
       active={previewSymbol === r.symbol}
+      onEditTags={handleEditTags}
     />
   )
+
+  const tagRow = tagEditSymbol ? rows.find(r => r.symbol === tagEditSymbol) : undefined
 
   return (
     <div className="flex flex-col h-full">
@@ -1087,28 +1328,8 @@ export function Watchlist() {
       {/* 筛选栏 */}
       {filterOpen && (
         <div className="px-5 py-2 border-b border-border bg-surface/50 max-h-[184px] overflow-y-auto">
-          {/* 板块筛选 */}
-          <div className="mb-2">
-            <div className="text-[10px] text-muted uppercase tracking-wider mb-0.5">板块</div>
-            <div className="flex flex-wrap gap-1">
-              {BOARDS.map(board => {
-                const active = boardFilter.has(board)
-                return (
-                  <button
-                    key={board}
-                    onClick={() => toggleBoard(board)}
-                    className={`px-2 py-0.5 rounded text-[11px] transition-colors ${
-                      active
-                        ? 'bg-accent/15 text-accent'
-                        : 'bg-elevated text-secondary hover:text-foreground hover:bg-elevated/80'
-                    }`}
-                  >
-                    {board}
-                  </button>
-                )
-              })}
-            </div>
-          </div>
+          <FilterChipRow label="板块" chips={BOARDS} activeSet={boardFilter} onToggle={toggleBoard} />
+          <FilterChipRow label="标签" chips={tagFilterChips} activeSet={tagFilter} onToggle={toggleTag} />
           {COLUMN_GROUPS.map(cat => {
             const items = colsByCategory[cat.label]?.filter(i => i.col)
             if (!items?.length) return null
@@ -1391,6 +1612,13 @@ export function Watchlist() {
                     </td>
                   )
                 }
+                if (key === 'tags') {
+                  return (
+                    <td className="px-2 py-1.5">
+                      <TagChips tags={tagsBySymbol.get(r.symbol) ?? []} onEdit={() => handleEditTags(r.symbol)} />
+                    </td>
+                  )
+                }
                 // 其余纯数据列 → 共享原语
                 return renderBuiltinDataCell(r, col)
               }}
@@ -1484,6 +1712,18 @@ export function Watchlist() {
         navList={previewNavItems}
         onNavigate={(sym, n) => { setPreviewSymbol(sym); setPreviewName(n ?? '') }}
       />
+
+      {tagEditSymbol && (
+        <TagEditorDialog
+          key={tagEditSymbol}
+          symbol={tagEditSymbol}
+          name={tagRow?.name ?? ''}
+          tags={tagsBySymbol.get(tagEditSymbol) ?? []}
+          allTags={tagFilterChips}
+          onClose={() => setTagEditSymbol(null)}
+          onSave={handleSaveTags}
+        />
+      )}
 
       <DimensionMembersDialog
         target={dimensionTarget}

--- a/frontend/src/pages/Watchlist.tsx
+++ b/frontend/src/pages/Watchlist.tsx
@@ -9,7 +9,7 @@ import { storage } from '@/lib/storage'
 import { fmtPrice, fmtPct, fmtBigNum, priceColorClass, formatExtNumber } from '@/lib/format'
 import { PageHeader } from '@/components/PageHeader'
 import { EmptyState } from '@/components/EmptyState'
-import { StockPreviewDialog } from '@/components/StockPreviewDialog'
+import { StockPreviewDialog, type NavItem } from '@/components/StockPreviewDialog'
 import {
   DimensionMembersDialog,
   dimensionKindForSourceField,
@@ -402,6 +402,7 @@ const StockCard = React.memo(function StockCard({
   onToggleExpand,
   onDimensionClick,
   isMonitored,
+  active,
 }: {
   r: any
   candleRows: KlineRow[]
@@ -416,6 +417,8 @@ const StockCard = React.memo(function StockCard({
   onToggleExpand: (key: string) => void
   onDimensionClick: (target: DimensionMembersTarget) => void
   isMonitored?: boolean
+  /** 正在 K 线弹窗预览中 → 高亮卡片 */
+  active?: boolean
 }) {
   const board = boardTag(r.symbol)
   const price = r.rt_price ?? r.close
@@ -438,7 +441,7 @@ const StockCard = React.memo(function StockCard({
 
   return (
     <div
-      className={`relative rounded-lg border border-border bg-surface hover:border-border/80 transition-all duration-200 group cursor-pointer overflow-hidden ${bgGlow}`}
+      className={`relative rounded-lg border border-border bg-surface hover:border-border/80 transition-all duration-200 group cursor-pointer overflow-hidden ${bgGlow} ${active ? 'ring-2 ring-accent/60' : ''}`}
       onClick={() => onPreview(r.symbol, name ?? '')}
     >
       {/* 左侧彩色指示条 */}
@@ -795,18 +798,13 @@ export function Watchlist() {
   const [confirmClear, setConfirmClear] = useState(false)
   const [confirmRemove, setConfirmRemove] = useState<string | null>(null)
 
-  // 稳定的 per-symbol 回调 (供 memo 化的 StockCard 使用, 避免每次渲染都传新引用)
-  const handleCardPreview = useCallback((sym: string, name: string) => {
-    setPreviewSymbol(sym); setPreviewName(name)
-  }, [])
+  const allSymbols = list.data?.symbols?.map(s => s.symbol) ?? []
+  const rows = enriched.data?.rows ?? []
   const handleCardConfirmRemove = useCallback((sym: string) => {
     remove.mutate(sym); setConfirmRemove(null)
   }, [remove])
   const handleCardCancelRemove = useCallback(() => setConfirmRemove(null), [])
   const handleCardRequestRemove = useCallback((sym: string) => setConfirmRemove(sym), [])
-
-  const allSymbols = list.data?.symbols?.map(s => s.symbol) ?? []
-  const rows = enriched.data?.rows ?? []
 
   // 实时监控圆点: 仅 Free/低档 "按自选股实时监控" 模式 (mode === 'watchlist') 下显示;
   // Starter+ 全市场模式 (mode === 'full_market') 全部标的都在监控, 标圆点无意义, 故不显示。
@@ -928,6 +926,17 @@ export function Watchlist() {
     [filteredRows, sortRows, columns],
   )
 
+  // 切股导航列表: 按列表当前展示顺序 (与 sortedRows 一致, 排序/筛选后行序随之变化)
+  const previewNavItems = useMemo(
+    () => sortedRows.map((r: any) => ({ symbol: r.symbol, name: r.rt_name ?? r.name }) as NavItem),
+    [sortedRows],
+  )
+
+  // 稳定的 per-symbol 回调 (供 memo 化的 StockCard 使用, 避免每次渲染都传新引用)
+  const handleCardPreview = useCallback((sym: string, name: string) => {
+    setPreviewSymbol(sym); setPreviewName(name)
+  }, [])
+
   const cardColumns = useCardColumnCount()
   const cardGridRef = useRef<HTMLDivElement>(null)
   const virtualizeCards = viewMode === 'card' && sortedRows.length > VIRTUAL_LIST_THRESHOLD
@@ -980,6 +989,7 @@ export function Watchlist() {
       onToggleExpand={handleToggleExpand}
       onDimensionClick={setDimensionTarget}
       isMonitored={monitoredSymbols.has(r.symbol)}
+      active={previewSymbol === r.symbol}
     />
   )
 
@@ -1197,7 +1207,7 @@ export function Watchlist() {
               sort={sort}
               onSortToggle={handleSortToggle}
               rowKey={(r: any) => r.symbol}
-              rowClassName={() => 'border-t border-border hover:bg-elevated/50 transition-colors duration-150 ease-smooth'}
+              rowClassName={(r: any) => `border-t border-border transition-colors duration-150 ease-smooth ${r.symbol === previewSymbol ? 'bg-accent/10 hover:bg-accent/15' : 'hover:bg-elevated/50'}`}
               // 日k列表头：标签 + 显示/隐藏眼睛按钮
               renderHeaderContent={(col) => {
                 if (col.source.type === 'builtin' && col.source.key === 'candle') {
@@ -1501,6 +1511,8 @@ export function Watchlist() {
         symbol={previewSymbol}
         name={previewName}
         onClose={closePreview}
+        navList={previewNavItems}
+        onNavigate={(sym, n) => { setPreviewSymbol(sym); setPreviewName(n ?? '') }}
       />
 
       <DimensionMembersDialog

--- a/frontend/src/pages/settings/Monitoring.tsx
+++ b/frontend/src/pages/settings/Monitoring.tsx
@@ -199,6 +199,13 @@ export function SettingsMonitoringPanel({ highlight }: { highlight?: string } = 
     saveWecomWebhook.mutate(url)
   }, [wecomDraft, saveWecomWebhook])
 
+  const testFeishu = useMutation({
+    mutationFn: () => api.sendTestWebhook('feishu'),
+  })
+  const testWecom = useMutation({
+    mutationFn: () => api.sendTestWebhook('wecom'),
+  })
+
   // 智能机器人 (BotID + Secret) 保存 → 后端立即重建连接
   const saveWecomBot = useMutation({
     mutationFn: ({ botId, secret }: { botId: string; secret: string }) =>
@@ -565,7 +572,7 @@ export function SettingsMonitoringPanel({ highlight }: { highlight?: string } = 
                     <span className="text-[11px] text-muted">Webhook 地址</span>
                     <input
                       value={feishuDraft}
-                      onChange={e => setFeishuDraft(e.target.value)}
+                      onChange={e => { setFeishuDraft(e.target.value); if (!testFeishu.isPending) testFeishu.reset() }}
                       placeholder={FEISHU_PREFIX + 'xxxxxxxx'}
                       className="h-9 w-full rounded-btn border border-border bg-base px-3 text-xs font-mono text-foreground focus:outline-none focus:border-accent/50"
                     />
@@ -576,7 +583,7 @@ export function SettingsMonitoringPanel({ highlight }: { highlight?: string } = 
                     <input
                       type="password"
                       value={feishuSecretDraft}
-                      onChange={e => setFeishuSecretDraft(e.target.value)}
+                      onChange={e => { setFeishuSecretDraft(e.target.value); if (!testFeishu.isPending) testFeishu.reset() }}
                       placeholder="机器人未启用签名校验则留空"
                       className="h-9 w-full rounded-btn border border-border bg-base px-3 text-xs font-mono text-foreground focus:outline-none focus:border-accent/50"
                     />
@@ -594,9 +601,11 @@ export function SettingsMonitoringPanel({ highlight }: { highlight?: string } = 
                     >
                       {saveFeishuWebhook.isPending ? '保存中…' : '保存'}
                     </button>
+                    <TestSendButton test={testFeishu} configured={!!feishuWebhookUrl} />
                     {feishuWebhookUrl && (
                       <span className="text-[10px] text-emerald-500">● 已配置</span>
                     )}
+                    <TestResult test={testFeishu} />
                   </div>
 
                   <details className="mt-3 text-[10px] text-muted">
@@ -650,7 +659,7 @@ export function SettingsMonitoringPanel({ highlight }: { highlight?: string } = 
                     <span className="text-[11px] text-muted">Webhook 地址 或 Key</span>
                     <input
                       value={wecomDraft}
-                      onChange={e => setWecomDraft(e.target.value)}
+                      onChange={e => { setWecomDraft(e.target.value); if (!testWecom.isPending) testWecom.reset() }}
                       placeholder={WECOM_PREFIX + '?key=xxxxxxxx' + ' 或直接填 key'}
                       className="h-9 w-full rounded-btn border border-border bg-base px-3 text-xs font-mono text-foreground focus:outline-none focus:border-accent/50"
                     />
@@ -668,9 +677,11 @@ export function SettingsMonitoringPanel({ highlight }: { highlight?: string } = 
                     >
                       {saveWecomWebhook.isPending ? '保存中…' : '保存'}
                     </button>
+                    <TestSendButton test={testWecom} configured={!!wecomWebhookUrl} />
                     {wecomWebhookUrl && (
                       <span className="text-[10px] text-emerald-500">● 已配置</span>
                     )}
+                    <TestResult test={testWecom} />
                   </div>
 
                   <details className="mt-3 text-[10px] text-muted">
@@ -794,6 +805,48 @@ export function SettingsMonitoringPanel({ highlight }: { highlight?: string } = 
   )
 }
 
+
+// ===== 推送测试按钮 + 内联结果 =====
+
+function TestSendButton({ test, configured }: {
+  test: { isPending: boolean; mutate: () => void }
+  configured: boolean
+}) {
+  return (
+    <button
+      onClick={() => test.mutate()}
+      disabled={test.isPending || !configured}
+      title={!configured ? '请先保存 Webhook 地址' : '向已保存的地址发送测试消息'}
+      className="inline-flex items-center gap-1 px-3 py-1.5 rounded-btn bg-elevated text-secondary hover:text-foreground text-xs disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+    >
+      {test.isPending ? '测试中…' : '测试'}
+    </button>
+  )
+}
+
+function TestResult({ test }: {
+  test: { data?: { ok: boolean; detail: string } | null; isError: boolean; error?: Error | null; reset: () => void }
+}) {
+  // 成功结果 2 秒后自动消失; 失败保留, 便于阅读
+  useEffect(() => {
+    if (test.data?.ok) {
+      const t = window.setTimeout(test.reset, 2000)
+      return () => window.clearTimeout(t)
+    }
+  }, [test.data, test.reset])
+
+  let text: string | null = null
+  let tone = ''
+  if (test.isError) {
+    text = String(test.error?.message ?? '发送失败')
+    tone = 'text-danger'
+  } else if (test.data) {
+    text = (test.data.ok ? '✓ ' : '✗ ') + test.data.detail
+    tone = test.data.ok ? 'text-emerald-500' : 'text-danger'
+  }
+  if (!text) return null
+  return <span className={`min-w-0 text-[11px] leading-snug ${tone}`}>{text}</span>
+}
 
 // ===== ToggleRow =====
 

--- a/frontend/src/pages/settings/System.tsx
+++ b/frontend/src/pages/settings/System.tsx
@@ -5,7 +5,7 @@
  */
 import { useState, useCallback, useEffect } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { Settings2, Trash2, RefreshCw, Bell, Volume2, Info } from 'lucide-react'
+import { Settings2, Trash2, RefreshCw, Bell, Volume2, Info, ExternalLink } from 'lucide-react'
 import { usePreferences, useVersion } from '@/lib/useSharedQueries'
 import { api } from '@/lib/api'
 import { QK } from '@/lib/queryKeys'
@@ -15,6 +15,7 @@ import { SOUND_OPTIONS, previewSound } from '@/lib/notificationSound'
 import {
   listZhVoices, previewVoice, activateVoice, getCurrentVoiceURI,
 } from '@/lib/voiceBroadcast'
+import { loadStockExternalTemplate, saveStockExternalTemplate } from '@/lib/stock-external-link'
 
 export function SettingsSystemPanel() {
   const qc = useQueryClient()
@@ -23,6 +24,7 @@ export function SettingsSystemPanel() {
   const [saving, setSaving] = useState(false)
 
   const screenerAutoRun = prefs?.screener_auto_run ?? true
+  const [extTpl, setExtTpl] = useState(() => loadStockExternalTemplate())
   const [clearing, setClearing] = useState(false)
   const [toastEnabled, setToastEnabled] = useState(() => {
     try { return localStorage.getItem('alert_toast_enabled') !== '0' } catch { return true }
@@ -285,6 +287,30 @@ export function SettingsSystemPanel() {
             />
             <span className="text-xs text-muted w-8 text-right">{voiceRate.toFixed(1)}</span>
           </div>
+        </div>
+      </section>
+
+      <section className="rounded-card border border-border bg-surface p-5 mt-6">
+        <div className="flex items-center gap-2 mb-4">
+          <ExternalLink className="h-4 w-4 text-accent" />
+          <h3 className="text-sm font-medium text-foreground">个股详情外链</h3>
+        </div>
+
+        <div className="flex items-center justify-between gap-4 py-2">
+          <div className="min-w-0">
+            <div className="text-sm text-foreground">详情页 URL 模板</div>
+            <div className="text-[11px] text-muted truncate">{"支持 {code} {market} {symbol} · 留空关闭外链"}</div>
+          </div>
+          <input
+            value={extTpl}
+            onChange={(e) => {
+              setExtTpl(e.target.value)
+              saveStockExternalTemplate(e.target.value)
+            }}
+            placeholder="https://..."
+            spellCheck={false}
+            className="w-[26rem] max-w-[60%] h-8 px-2.5 rounded-btn border border-border bg-base text-xs font-mono text-foreground focus:border-accent/50 focus:outline-none"
+          />
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

Adds many-to-many tags to the watchlist. Each symbol can carry multiple tags (e.g. "困境反转", "连板") and the watchlist can be filtered by tag from the filter bar.

## What changed

**Backend**
- `watchlist.py`: unified `_read`/`_write` with a stable 4-column schema; legacy files missing the `tags` column are backfilled with an empty string. New `set_tags` normalizes input (trim / dedupe / strip half- and full-width commas / cap at 20 chars) and atomically replaces a symbol's tags under a module lock (read-modify-write protection against concurrent requests).
- `watchlist.py` API: new `POST /api/watchlist/{symbol}/tags` returning the full watchlist; the `enriched` response now joins a `tags` column.
- Tests: `test_watchlist_tags.py` covers round-trip + normalization, re-add preserving tags, legacy-file migration, and clear/remove.

**Frontend**
- New "标签" (tags) builtin column plus a tags row on cards, editable through a modal dialog (immediate save, suggestions drawn from existing tags).
- New persisted tag filter in the filter bar (localStorage), AND-composed with board and column filters.
- Re-adding a symbol keeps its tags.

## Notes

- The tags column is registered in `COLUMN_GROUPS`, so it can be re-enabled from the column customizer.
- `tags` is in `UNSORTABLE_KEYS`, keeping it out of the numeric sort/filter machinery.

## Test plan

- Backend: full `pytest` suite passes (595 tests).
- Frontend: `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
