### PR TITLE
feat(kline): add configurable external stock link

### DIFF
--- a/frontend/src/components/StockInfoBar.tsx
+++ b/frontend/src/components/StockInfoBar.tsx
@@ -1,9 +1,10 @@
 import { useState, type ReactNode } from 'react'
-import { Settings2, RadioTower, Star } from 'lucide-react'
+import { Settings2, RadioTower, Star, ExternalLink } from 'lucide-react'
 import type { KlineRow, FinancialMetricRecord } from '@/lib/api'
 import { fmtPrice, fmtBigNum, fmtVolume } from '@/lib/format'
 import { ListColumnCustomizer } from '@/components/ListColumnCustomizer'
 import { INFO_GROUPS, type ColumnConfig } from '@/lib/stock-info-fields'
+import { buildStockExternalUrl, loadStockExternalTemplate } from '@/lib/stock-external-link'
 
 const BULL = '#C74040'
 const BEAR = '#2D9B65'
@@ -199,6 +200,8 @@ export function StockInfoBar({ symbol, name, stockInfo, rows, fields, onFieldsCh
     )
   }
 
+  const extUrl = buildStockExternalUrl(loadStockExternalTemplate(), symbol)
+
   return (
     <div className="px-2 pb-3 font-mono text-[12px] select-none space-y-1">
       {/* Row 1: code, name, price, change, change% */}
@@ -214,8 +217,18 @@ export function StockInfoBar({ symbol, name, stockInfo, rows, fields, onFieldsCh
         <span style={{ color: clr }} className="tabular-nums">
           {isUp ? '+' : ''}{fmtPrice(chgPct)}%
         </span>
-        {/* 右侧操作按钮：加自选 + 加监控 + 信息条配置 */}
         <div className="ml-auto self-center flex items-center gap-1">
+          {extUrl && (
+            <a
+              href={extUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={extUrl}
+              className="p-1 rounded-btn text-muted hover:text-foreground hover:bg-elevated transition-colors"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          )}
           {onToggleWatchlist && (
             <button
               onClick={onToggleWatchlist}

--- a/frontend/src/lib/stock-external-link.ts
+++ b/frontend/src/lib/stock-external-link.ts
@@ -1,0 +1,34 @@
+/**
+ * 个股详情外链 — 可配置 URL 模板 + 证券代码。
+ *
+ * 占位符保持独立, 用户自行排列 (市场前缀/后缀因站而异):
+ *   {code}   纯 6 位代码, 如 000001
+ *   {market} 市场前缀小写, 如 sz / sh / bj
+ *   {symbol} 完整 symbol (含交易所后缀), 如 000001.SZ
+ * 模板留空 = 关闭外链。
+ */
+import { storage } from '@/lib/storage'
+
+/** 形状守卫: 只放行 6位数字 + 沪深北后缀 的 symbol (信息条场景下即股票) */
+const STOCK_SYMBOL_RE = /^(\d{6})\.(SH|SZ|BJ)$/
+
+/** 未设置或留空 → 返回 '' 即关闭外链 */
+export function loadStockExternalTemplate(): string {
+  return storage.stockExternalTemplate.get('')
+}
+
+export function saveStockExternalTemplate(tpl: string): void {
+  storage.stockExternalTemplate.set(tpl.trim())
+}
+
+export function buildStockExternalUrl(template: string, symbol: string): string | null {
+  if (!template) return null
+  const m = symbol.match(STOCK_SYMBOL_RE)
+  if (!m) return null
+  const code = m[1]
+  const market = m[2].toLowerCase()
+  return template
+    .replaceAll('{code}', code)
+    .replaceAll('{market}', market)
+    .replaceAll('{symbol}', symbol)
+}

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -122,6 +122,9 @@ export const storage = {
   /** 行业分析页面字段配置 */
   industryAnalysisConfig: kv<Record<string, any>>('industry-analysis-config'),
 
+  /** 个股详情外链 URL 模板 (语义见 stock-external-link) */
+  stockExternalTemplate: kv<string>('stock_external_template'),
+
   /** 数据页画像卡片显隐 (卡片key → 是否显示) */
   dataCardVisible: kv<Record<string, boolean>>('data-card-visible'),
   /** 数据页画像卡片顺序 (卡片key 数组, 长度=卡片总数) */

--- a/frontend/src/pages/settings/System.tsx
+++ b/frontend/src/pages/settings/System.tsx
@@ -5,7 +5,7 @@
  */
 import { useState, useCallback, useEffect } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { Settings2, Trash2, RefreshCw, Bell, Volume2, Info } from 'lucide-react'
+import { Settings2, Trash2, RefreshCw, Bell, Volume2, Info, ExternalLink } from 'lucide-react'
 import { usePreferences, useVersion } from '@/lib/useSharedQueries'
 import { api } from '@/lib/api'
 import { QK } from '@/lib/queryKeys'
@@ -15,6 +15,7 @@ import { SOUND_OPTIONS, previewSound } from '@/lib/notificationSound'
 import {
   listZhVoices, previewVoice, activateVoice, getCurrentVoiceURI,
 } from '@/lib/voiceBroadcast'
+import { loadStockExternalTemplate, saveStockExternalTemplate } from '@/lib/stock-external-link'
 
 export function SettingsSystemPanel() {
   const qc = useQueryClient()
@@ -23,6 +24,7 @@ export function SettingsSystemPanel() {
   const [saving, setSaving] = useState(false)
 
   const screenerAutoRun = prefs?.screener_auto_run ?? true
+  const [extTpl, setExtTpl] = useState(() => loadStockExternalTemplate())
   const [clearing, setClearing] = useState(false)
   const [toastEnabled, setToastEnabled] = useState(() => {
     try { return localStorage.getItem('alert_toast_enabled') !== '0' } catch { return true }
@@ -285,6 +287,30 @@ export function SettingsSystemPanel() {
             />
             <span className="text-xs text-muted w-8 text-right">{voiceRate.toFixed(1)}</span>
           </div>
+        </div>
+      </section>
+
+      <section className="rounded-card border border-border bg-surface p-5 mt-6">
+        <div className="flex items-center gap-2 mb-4">
+          <ExternalLink className="h-4 w-4 text-accent" />
+          <h3 className="text-sm font-medium text-foreground">个股详情外链</h3>
+        </div>
+
+        <div className="flex items-center justify-between gap-4 py-2">
+          <div className="min-w-0">
+            <div className="text-sm text-foreground">详情页 URL 模板</div>
+            <div className="text-[11px] text-muted truncate">{"支持 {code} {market} {symbol} · 留空关闭外链"}</div>
+          </div>
+          <input
+            value={extTpl}
+            onChange={(e) => {
+              setExtTpl(e.target.value)
+              saveStockExternalTemplate(e.target.value)
+            }}
+            placeholder="https://..."
+            spellCheck={false}
+            className="w-[26rem] max-w-[60%] h-8 px-2.5 rounded-btn border border-border bg-base text-xs font-mono text-foreground focus:border-accent/50 focus:outline-none"
+          />
         </div>
       </section>
 


### PR DESCRIPTION
Add a configurable URL template for stock detail pages, rendered as an
external-link icon in the stock info bar (Row 1 action cluster). The
template supports `{code}`, `{market}` and `{symbol}` placeholders so it
works with any site that builds a fixed URL from the security code
(10jqka, eastmoney, sina, tencent, ...).

### Changes
- **New** `frontend/src/lib/stock-external-link.ts` — placeholder
  substitution and template persistence. `{code}` = 6-digit code,
  `{market}` = lowercase exchange prefix (`sz`/`sh`/`bj`), `{symbol}` =
  full symbol with suffix. Shape guard only passes `\d{6}.(SH|SZ|BJ)`.
- **`frontend/src/components/StockInfoBar.tsx`** — icon in the per-stock
  action cluster (watchlist / monitor / info-bar config), opens in a new
  tab. StockInfoBar is shared by the K-line preview dialog and the
  backtest trade modal, so both get the link.
- **`frontend/src/pages/settings/System.tsx`** — single template input
  under System settings with a placeholder hint.
- **`frontend/src/lib/storage.ts`** — typed localStorage key.

### Semantics
- No default site — the link is hidden until a template is configured
- Explicitly emptied (or never set) → link hidden
- Market prefix is position-flexible (`{market}{code}` or `{code}{market}`)

### Verification
- `tsc -b` and `vite build` pass
- Manually confirmed the icon links to 10jqka for `600519.SH` / `000001.SZ`
  / `920176.BJ` once a template is set, switches to eastmoney format with
  a custom template, and disappears while the template is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)
