### PR TITLE
fix: make extension-loader isolation test version-agnostic

### DIFF
--- a/backend/tests/test_extensions.py
+++ b/backend/tests/test_extensions.py
@@ -4,6 +4,7 @@ import types
 
 import pytest
 from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
 
 from app.extensions.contracts import (
     BACKEND_EXTENSION_API_VERSION,
@@ -151,4 +152,6 @@ def test_loader_isolates_failed_setup_and_registers_valid_route(
     assert registry.extension_ids() == frozenset({"company.valid"})
     assert len(errors) == 1
     assert errors[0].module == broken.__name__
-    assert any(getattr(route, "path", None) == "/api/custom/valid/status" for route in app.routes)
+    client = TestClient(app)
+    response = client.get("/api/custom/valid/status")
+    assert response.status_code == 200


### PR DESCRIPTION
## 问题
`tests/test_extensions.py::test_loader_isolates_failed_setup_and_registers_valid_route` 在 fastapi 0.141 / starlette 1.6 下失败（项目 pyproject 允许 `fastapi>=0.115`，非依赖漂移）。

## 根因
Starlette >=1.x 把 `include_router` 引入的路由包进 `_IncludedRouter`（不再急切展开成顶层 `APIRoute`）。原断言扫描 `app.routes` 顶层 `APIRoute.path`，在新版下找不到路由，产生 false negative。

## 修复
将断言改为用 `TestClient(app).get("/api/custom/valid/status")` 验证路由真实返回 200，与 Starlette 内部路由包装方式解耦，未来升级 fastapi 亦不会误伤。

## 验证
- 该测试 PASS
- `test_extensions.py` 6/6 全绿
- 完整后端套件 1087 passed / 0 failed