### PR TITLE
feat(ai): add OrcaRouter as a first-class AI provider preset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 TICKFLOW_API_KEY=
 
 # ===== AI(可选,留空跳过 AI 功能) =====
-AI_PROVIDER=openai_compat          # openai_compat | ollama
+AI_PROVIDER=openai_compat          # openai_compat | ollama | orcarouter
 AI_BASE_URL=https://api.deepseek.com/v1
 AI_API_KEY=
 AI_MODEL=deepseek-chat

--- a/backend/app/services/ai_provider.py
+++ b/backend/app/services/ai_provider.py
@@ -21,6 +21,7 @@ from app.config import settings
 
 OPENAI_COMPAT_PROVIDER = "openai_compat"
 OPENAI_PROVIDER = "openai"
+ORCAROUTER_PROVIDER = "orcarouter"
 CODEX_CLI_PROVIDER = "codex_cli"
 CODEX_DEFAULT_COMMAND = "codex"
 CODEX_SUPPORTED_REASONING_EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh"}

--- a/backend/tests/test_ai_provider.py
+++ b/backend/tests/test_ai_provider.py
@@ -208,6 +208,27 @@ def test_openai_kwargs_none_max_tokens_omits_limit():
     assert ai_provider._openai_kwargs(temperature=None, max_tokens=8) == {"max_tokens": 8}
 
 
+def test_orcarouter_provider_uses_openai_compat_path(monkeypatch):
+    """OrcaRouter is an OpenAI-compatible gateway (namespaced models); it goes through the
+    generic channel and must not attach OpenAI-specific reasoning params."""
+    assert ai_provider.ORCAROUTER_PROVIDER == "orcarouter"
+    stored = {
+        "ai_provider": "orcarouter",
+        "ai_reasoning_effort": "high",  # leftover, must not be sent
+        "ai_base_url": "https://api.orcarouter.ai/v1",
+        "ai_model": "orcarouter/auto",
+    }
+    monkeypatch.setattr(secrets_store, "load", lambda: stored)
+    monkeypatch.setattr(secrets_store, "get_ai_config", lambda key, default=None: stored.get(key, default))
+
+    kwargs = ai_provider._openai_kwargs(temperature=0.3, max_tokens=1000)
+    assert kwargs == {"max_tokens": 1000, "temperature": 0.3}
+    assert "reasoning_effort" not in kwargs
+
+    # like openai_compat, orcarouter is configured by an API key (not a Codex CLI login)
+    assert ai_provider.is_codex_cli_provider("orcarouter") is False
+
+
 def test_codex_prompt_none_max_tokens_skips_length_hint():
     prompt = ai_provider._codex_prompt([{"role": "user", "content": "hi"}], max_tokens=None)
     assert "Keep the final answer" not in prompt

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ TickFlow 是内置默认数据源;同时支持插件化接入第三方数据源(
 用于自然语言生成策略。**所有配置留空即跳过**,不影响核心功能。支持任意 OpenAI 兼容接口。
 
 ```ini
-AI_PROVIDER=openai_compat              # openai_compat | ollama
+AI_PROVIDER=openai_compat              # openai_compat | ollama | orcarouter
 AI_BASE_URL=https://api.deepseek.com/v1
 AI_API_KEY=                            # 留空 = 关闭 AI
 AI_MODEL=deepseek-chat
@@ -47,10 +47,10 @@ AI_DAILY_TOKEN_BUDGET=500000           # 每日 token 预算上限
 
 | 配置项 | 说明 |
 | :--- | :--- |
-| `AI_PROVIDER` | `openai_compat`(OpenAI 兼容,支持 DeepSeek / 通义 / OpenAI 等)或 `ollama`(本地模型) |
-| `AI_BASE_URL` | 接口地址,如 DeepSeek `https://api.deepseek.com/v1` |
+| `AI_PROVIDER` | `openai_compat`(OpenAI 兼容,支持 DeepSeek / 通义 / OpenAI 等)、`ollama`(本地模型)或 `orcarouter`(AI 网关,统一路由 100+ 模型,自适应路由/故障转移/零加成计费/护栏) |
+| `AI_BASE_URL` | 接口地址,如 DeepSeek `https://api.deepseek.com/v1`;OrcaRouter 用 `https://api.orcarouter.ai/v1` |
 | `AI_API_KEY` | 留空则关闭 AI 功能 |
-| `AI_MODEL` | 模型名,如 `deepseek-chat` |
+| `AI_MODEL` | 模型名,如 `deepseek-chat`;OrcaRouter 用命名空间模型名,如 `orcarouter/auto`(自动路由)或 `openai/gpt-5` |
 | `AI_DAILY_TOKEN_BUDGET` | 每日 token 预算,超限后当日不再调用 |
 
 接入示例见 [strategy.md](./strategy.md) 的「AI 生成策略」章节。

--- a/frontend/src/pages/settings/AI.tsx
+++ b/frontend/src/pages/settings/AI.tsx
@@ -21,6 +21,7 @@ const toPositiveInt = (v: string) => {
 
 const CODEX_PROVIDER = 'codex_cli'
 const OPENAI_PROVIDER = 'openai'
+const ORCAROUTER_PROVIDER = 'orcarouter'
 const OPENAI_COMPAT_PROVIDER = 'openai_compat'
 const CODEX_COMMAND = 'codex'
 const DEFAULT_CODEX_MODEL = 'gpt-5.6-sol'
@@ -62,6 +63,7 @@ const PRESETS: AiPreset[] = [
   { label: 'Kimi', url: 'https://api.moonshot.cn/v1', model: 'kimi-k2.7-code', website: 'https://platform.moonshot.cn/', websiteLabel: 'platform.moonshot.cn', description: '月之暗面 Moonshot 官方 OpenAI 兼容接口，支持超长上下文。' },
   { label: 'Codex CLI', provider: CODEX_PROVIDER, url: '', model: DEFAULT_CODEX_MODEL, codexCommand: CODEX_COMMAND, website: 'https://developers.openai.com/codex/noninteractive', websiteLabel: 'codex exec', description: '调用本机 Codex CLI 的 codex exec, 适合已登录 ChatGPT/Codex 的本地环境。' },
   { label: '炸鸡中转站', url: 'https://api.zhaji.dev/v1', model: 'gpt-5.5', website: 'https://api.zhaji.dev', websiteLabel: 'api.zhaji.dev', description: 'OpenAI 兼容中转服务，适合直接使用国际模型。' },
+  { label: 'OrcaRouter', provider: ORCAROUTER_PROVIDER, url: 'https://api.orcarouter.ai/v1', model: 'orcarouter/auto', website: 'https://www.orcarouter.ai', websiteLabel: 'orcarouter.ai', description: 'AI 网关，统一路由 100+ 模型，支持自适应路由、故障转移、零加成计费、可观测、护栏与智能体工具治理。' },
 ]
 
 const findPreset = (provider: string, baseUrl: string, codexCommand: string) => PRESETS.find(p => {


### PR DESCRIPTION
This PR adds **OrcaRouter** as a named provider preset in the AI settings panel of this self-hosted A-share quant workbench, alongside the existing OpenAI, DeepSeek, Tongyi, GLM, Kimi and Codex CLI presets. The project already models every OpenAI-compatible endpoint (DeepSeek / Tongyi / OpenAI etc.) as a preset in the settings UI; OrcaRouter is the same shape, so it slots into the existing preset registry without touching the provider abstraction.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

What changed:

- **backend**: added an `ORCAROUTER_PROVIDER = "orcarouter"` constant in `ai_provider.py`. OrcaRouter is OpenAI-compatible with namespaced models (`orcarouter/auto`, `deepseek/deepseek-chat`, …), so it reuses the existing generic chat-completions channel — deliberately *without* the OpenAI-only `reasoning_effort` parameter, mirroring how the DeepSeek / GLM / Kimi presets behave.
- **frontend**: added an OrcaRouter quick preset in `AI.tsx` (`https://api.orcarouter.ai/v1`, default model `orcarouter/auto`), exactly like the other OpenAI-compatible presets.
- **docs**: documented `orcarouter` in `.env.example` and `docs/configuration.md` (`AI_PROVIDER`, `AI_BASE_URL`, `AI_MODEL`).
- **test**: added `test_orcarouter_provider_uses_openai_compat_path` asserting OrcaRouter goes through the generic channel and never attaches OpenAI-specific reasoning params.

Verification:

- `cd backend && uv run pytest tests/test_ai_provider.py -q` → **36 passed** (incl. the new OrcaRouter test).
- `cd frontend && pnpm build` → **build OK** (tsc + vite, exit 0).
- `git diff --check` → clean.
- Live L3 test against `https://api.orcarouter.ai/v1` through the real `ai_provider` code path (`generate_ai_text` and `stream_ai_text` with model `orcarouter/auto`) → **HTTP 200**, both non-streaming and streaming responses returned the expected text.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.