### PR TITLE
fix(pipeline): A 股盘后拉取开关生效 (#216)

### DIFF
--- a/backend/app/services/preferences.py
+++ b/backend/app/services/preferences.py
@@ -284,8 +284,8 @@ def get_financial_provider() -> str:
 # ===== 盘后管道拉取内容开关 (A股 / ETF / 指数 独立控制) =====
 
 def get_pipeline_pull_a_share() -> bool:
-    """A 股日K固定拉取。"""
-    return True
+    """是否拉取 A 股日K。默认 True。"""
+    return load().get("pipeline_pull_a_share", True)
 
 
 def get_pipeline_pull_etf() -> bool:
@@ -429,7 +429,7 @@ def set_mainline_filter_config(cfg: dict) -> dict:
     return get_mainline_filter_config()
 
 
-_PIPELINE_PULL_KEYS = ("pipeline_pull_etf", "pipeline_pull_index")
+_PIPELINE_PULL_KEYS = ("pipeline_pull_a_share", "pipeline_pull_etf", "pipeline_pull_index")
 
 
 def get_pipeline_pull_types() -> dict:

--- a/backend/tests/test_pipeline_pull_types.py
+++ b/backend/tests/test_pipeline_pull_types.py
@@ -1,0 +1,60 @@
+"""盘后管道「A股 / ETF / 指数」拉取开关回归测试。
+
+覆盖 issue #216: `get_pipeline_pull_a_share()` 硬编码 True 且 A股键不在
+`set_pipeline_pull_types()` 白名单内, 导致取消勾选 A 股完全不生效。
+
+纯逻辑, 不触网, 不依赖真实数据源。
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services import preferences
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    path = tmp_path / "preferences.json"
+    monkeypatch.setattr(preferences, "_path", lambda: path)
+    preferences._invalidate_cache()
+    yield path
+    preferences._invalidate_cache()
+
+
+def test_a_share_defaults_to_true_when_unset():
+    """未设置时三个开关的默认值: A股/指数 默认开, ETF 默认关。"""
+    assert preferences.get_pipeline_pull_a_share() is True
+    assert preferences.get_pipeline_pull_index() is True
+    assert preferences.get_pipeline_pull_etf() is False
+
+
+def test_a_share_toggle_off_is_honored():
+    """写入 False 后 getter 必须返回 False(修复前硬编码 True)。"""
+    preferences.save({"pipeline_pull_a_share": False})
+    assert preferences.get_pipeline_pull_a_share() is False
+
+
+def test_set_pipeline_pull_types_persists_a_share():
+    """setter 必须接受并落盘 A 股开关(修复前白名单遗漏该键, 被静默丢弃)。"""
+    result = preferences.set_pipeline_pull_types({"pipeline_pull_a_share": False})
+    assert result["pipeline_pull_a_share"] is False
+    # 落盘后重新读取仍为 False
+    preferences._invalidate_cache()
+    assert preferences.get_pipeline_pull_a_share() is False
+    assert preferences.get_pipeline_pull_types()["pipeline_pull_a_share"] is False
+
+
+def test_set_pipeline_pull_types_independent_switches():
+    """三个开关互相独立: 关 A 股不影响 ETF / 指数。"""
+    result = preferences.set_pipeline_pull_types(
+        {
+            "pipeline_pull_a_share": False,
+            "pipeline_pull_etf": True,
+            "pipeline_pull_index": False,
+        }
+    )
+    assert result == {
+        "pipeline_pull_a_share": False,
+        "pipeline_pull_etf": True,
+        "pipeline_pull_index": False,
+    }


### PR DESCRIPTION
## 问题与复现

在设置里取消勾选「A 股」拉取内容(或 `PUT /api/settings/preferences/pipeline-pull-types` 写入 `pipeline_pull_a_share=false`)后**完全不生效** —— 每次盘后同步仍拉取全市场 A 股日K(约 5522 只)。对只做 ETF / 指数的用户尤其浪费网络与接口配额。

修复 #216。

复现:
1. `PUT /api/settings/preferences/pipeline-pull-types` body `{"pipeline_pull_a_share": false}`
2. 触发同步 `POST /api/pipeline/run`
3. 观察日志:仍执行 A 股日K同步,`sync_daily: skipped` 分支从不出现。

## 根因

`backend/app/services/preferences.py` 两处联合导致开关不可用:

1. `get_pipeline_pull_a_share()` **硬编码 `return True`**,从不读取偏好。`get_pipeline_pull_etf()` / `get_pipeline_pull_index()` 都正常走 `load().get(...)`,唯独 A 股例外。这使 `jobs/daily_pipeline.py:182` 的 `if not pull_a_share and not override_start_date:` 跳过分支**永不可达**(该分支的日志 `sync_daily: skipped (pipeline_pull_a_share=False)` 和进度提示都是为这个开关准备的)。
2. `set_pipeline_pull_types()` 的白名单 `_PIPELINE_PULL_KEYS = ("pipeline_pull_etf", "pipeline_pull_index")` **遗漏 `pipeline_pull_a_share`**。尽管 API 模型 `PipelinePullTypesIn` 接受该字段,值也会在 setter 里被静默过滤掉、无法落盘。

即:开关的 API 模型、`get_pipeline_pull_types()` 汇总、`daily_pipeline` 消费分支都已按「可开关」设计,只有 getter 与 setter 白名单两处未接通。

## 解决方案

- `get_pipeline_pull_a_share()` 改为 `load().get("pipeline_pull_a_share", True)`,与 ETF / 指数口径一致。
- `_PIPELINE_PULL_KEYS` 补入 `"pipeline_pull_a_share"`,使 PUT 能正确落盘。

改动仅 2 行源码,不触碰数据源插件化、缓存或成交口径。

## 兼容性

默认值保持 `True`:历史 `preferences.json` 无此键时,`get_pipeline_pull_a_share()` 仍返回 `True`,行为与修复前完全一致。仅当用户显式写入 `false` 时才生效。数据修正(`override_start_date`)路径不受影响,仍强制拉取。

## 性能

不进入实时 / 列表热路径。开关关闭时反而减少一次全市场 A 股日K拉取。

## 验证结果

新增 `backend/tests/test_pipeline_pull_types.py`(纯逻辑,不触网):

```
cd backend
uv run pytest tests/test_pipeline_pull_types.py -q
# 修复前: 3 failed, 1 passed  (关闭开关不生效 / setter 丢弃 A 股键)
# 修复后: 4 passed

uv run pytest tests/test_preferences_cache.py tests/test_pipeline_and_monitor_fixes.py -q
# 20 passed  (相邻 preferences / pipeline 回归)

uv run ruff check app/services/preferences.py tests/test_pipeline_pull_types.py
# 改动行与新增文件无新增告警(仓库既有 RUF002/003 中文标点告警未触碰)
```

(本地无 `uv`,实际以仓库同版本依赖的 venv 执行 `python -m pytest`,命令等价。)

## 风险与回滚

风险极低:两行改动、默认值不变、有回归测试。回滚即还原这两行。