### PR TITLE
fix(backtest): 因子回测默认区间改用 180 天而非 3 年 (#202)

### DIFF
--- a/backend/app/api/backtest.py
+++ b/backend/app/api/backtest.py
@@ -158,7 +158,7 @@ def factor_run(req: FactorBacktestRequest, request: Request):
     svc = FactorBacktestService(engine)
 
     end = req.end or date.today()
-    start = _resolve_start(req, end, STRATEGY_DEFAULT_DAYS)
+    start = _resolve_start(req, end, FACTOR_DEFAULT_DAYS)
     _guard_server_backtest_range(start, end)
     symbols = req.symbols if req.symbols else None
     if symbols is not None and len(symbols) > FACTOR_MAX_SYMBOLS:
@@ -212,7 +212,7 @@ def factor_batch(req: FactorBatchRequest, request: Request):
         raise HTTPException(status_code=400, detail=f"不支持的因子: {', '.join(invalid)}")
 
     end = req.end or date.today()
-    start = _resolve_start(req, end, STRATEGY_DEFAULT_DAYS)
+    start = _resolve_start(req, end, FACTOR_DEFAULT_DAYS)
     _guard_server_backtest_range(start, end)
     symbols = req.symbols if req.symbols else None
     if symbols is not None and len(symbols) > FACTOR_MAX_SYMBOLS:

--- a/backend/tests/backtest/test_factor_default_range.py
+++ b/backend/tests/backtest/test_factor_default_range.py
@@ -1,0 +1,89 @@
+"""因子回测默认区间回归测试。
+
+覆盖 issue #202: `/api/backtest/factor/run` 与 `/api/backtest/factor/batch`
+在省略 `start` 时错误使用了策略默认区间(3 年)而非因子默认区间(180 天)。
+
+只关注「起始日解析」这一关注点, 用替身 Service 捕获传入配置, 不做真实数据加载。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import ClassVar
+
+import pytest
+
+from app.api import backtest as bt
+
+
+@dataclass
+class _DummyResult:
+    ok: bool = True
+
+
+class _CapturingService:
+    """替身 FactorBacktestService: 捕获配置, 不触真实引擎。"""
+
+    captured: ClassVar[list] = []
+
+    def __init__(self, engine):
+        pass
+
+    def run(self, cfg):
+        _CapturingService.captured.append(cfg)
+        return _DummyResult()
+
+    def run_batch(self, cfg):
+        _CapturingService.captured.append(cfg)
+        return _DummyResult()
+
+
+class _Req:
+    """占位 request; _get_engine 已被 patch, 不会真正访问其属性。"""
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    _CapturingService.captured = []
+    monkeypatch.setattr(bt, "_get_engine", lambda request: object())
+    # factor_run / factor_batch 内部 `from app.backtest.factor import FactorBacktestService`
+    # 读取的是模块属性, patch 源模块即可命中。
+    import app.backtest.factor as factor_mod
+    monkeypatch.setattr(factor_mod, "FactorBacktestService", _CapturingService)
+    # 隔离守卫, 单测「起始日解析」。
+    monkeypatch.setattr(bt, "_guard_server_backtest_range", lambda start, end: None)
+    return _CapturingService
+
+
+def test_factor_run_omitted_start_uses_factor_default(patched):
+    end = date(2026, 8, 24)
+    bt.factor_run(bt.FactorBacktestRequest(factor_name="momentum_5d", end=end), _Req())
+    cfg = patched.captured[-1]
+    assert cfg.start == end - timedelta(days=bt.FACTOR_DEFAULT_DAYS)
+    # 回归保护: 不得再退回策略默认的 3 年。
+    assert cfg.start != end - timedelta(days=bt.STRATEGY_DEFAULT_DAYS)
+
+
+def test_factor_batch_omitted_start_uses_factor_default(patched):
+    end = date(2026, 8, 24)
+    bt.factor_batch(bt.FactorBatchRequest(factor_names=["momentum_5d"], end=end), _Req())
+    cfg = patched.captured[-1]
+    assert cfg.start == end - timedelta(days=bt.FACTOR_DEFAULT_DAYS)
+    assert cfg.start != end - timedelta(days=bt.STRATEGY_DEFAULT_DAYS)
+
+
+def test_factor_run_explicit_null_start_means_all_history(patched):
+    """显式传 start=null 语义不变: 代表全部历史。"""
+    end = date(2026, 8, 24)
+    bt.factor_run(bt.FactorBacktestRequest(factor_name="momentum_5d", start=None, end=end), _Req())
+    assert patched.captured[-1].start == date(1900, 1, 1)
+
+
+def test_factor_run_explicit_start_passthrough(patched):
+    """显式日期原样透传。"""
+    end = date(2026, 8, 24)
+    bt.factor_run(
+        bt.FactorBacktestRequest(factor_name="momentum_5d", start=date(2026, 1, 1), end=end),
+        _Req(),
+    )
+    assert patched.captured[-1].start == date(2026, 1, 1)


### PR DESCRIPTION
## 问题与复现

因子回测接口 `/api/backtest/factor/run` 在未提供 `start` 时,使用了策略回测的默认区间 **3 年**,而不是代码中为因子回测定义的 **180 天**。以基线 `0eb3e54`、`end=2026-08-24` 为例,省略 `start` 会解析为 `2023-08-25`(应为 `2026-02-25`)。

修复 #202。批量因子接口 `/api/backtest/factor/batch` 存在同一处错误,一并修复。

## 根因

`backend/app/api/backtest.py`:

```python
FACTOR_DEFAULT_DAYS = 180
STRATEGY_DEFAULT_DAYS = 365 * 3
...
# factor_run / factor_batch
start = _resolve_start(req, end, STRATEGY_DEFAULT_DAYS)   # ← 误用策略默认
```

同文件的 `strategy_run` 已正确使用 `FACTOR_DEFAULT_DAYS`,只有两个因子入口把默认常量写反了。

## 影响

- 用户只选因子直接运行时,服务端会加载约 3 年数据,增加内存和计算耗时。
- 与前端 `FactorBacktest.tsx` 的提示「默认最近 3 个月」不一致。
- 服务器区间守卫 `BACKTEST_MAX_SERVER_DAYS = 186`;开启守卫(`backtest_range_guard`)时,3 年的默认区间会被 `_guard_server_backtest_range` 直接拒绝(400),即该默认区间本身不可用。

## 解决方案

`factor_run`(第 161 行)与 `factor_batch`(第 215 行)的 `_resolve_start` 默认参数改为 `FACTOR_DEFAULT_DAYS`。

`_resolve_start` 本身未改:显式传 `start: null` 仍表示全部历史(`date(1900,1,1)`),显式日期原样透传。`strategy_run` 与 `walkforward` 的默认区间不在本次范围内,保持不变。

## 兼容性

仅改变「省略 start 时的默认区间」。API 契约、请求/响应字段、资产类型口径均不变。

## 性能

减少因子回测默认加载的数据量(3 年 → 180 天),降低内存与耗时;不进入实时热路径。

## 验证结果

新增 `backend/tests/backtest/test_factor_default_range.py`,用替身 Service 捕获传入的 `FactorConfig`/`FactorBatchConfig`,只针对「起始日解析」这一关注点断言(不做真实数据加载):

```
cd backend
uv run pytest tests/backtest/test_factor_default_range.py -q
# 修复前: 2 failed(factor_run / factor_batch 省略 start 解析为 2023-08-25), 2 passed
# 修复后: 4 passed(覆盖省略 start / 显式 null / 显式日期)

uv run pytest tests/backtest/test_factor_batch.py tests/backtest/test_factor_metrics.py tests/backtest/test_optimizer_api.py -q
# 28 passed(相邻因子 / 优化器回归)

uv run ruff check app/api/backtest.py tests/backtest/test_factor_default_range.py
# All checks passed
```

(本地无 `uv`,实际以仓库同版本依赖的 venv 执行 `python -m pytest`,命令等价。)

## 风险与回滚

风险低:两行默认参数改动 + 新增测试。显式区间行为不变。回滚即还原这两行。