### PR TITLE
fix(ext-data): 扩展数据上传增加体积上限并分块落盘 (#204)

### DIFF
--- a/backend/app/api/ext_data.py
+++ b/backend/app/api/ext_data.py
@@ -489,6 +489,30 @@ def dimension_members(
 # 文件上传
 # ---------------------------------------------------------------------------
 
+# 扩展数据 CSV/Excel 上传上限(与自选截图 OCR 的 12MB 上限属同类保护, 见 watchlist.py)。
+# 通过分块写入临时文件, 超限即拒绝, 避免 `await file.read()` 把整个文件读入内存。
+_MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+_UPLOAD_CHUNK_BYTES = 1024 * 1024
+
+
+async def _write_upload_capped(file: UploadFile, dest: Path, max_bytes: int) -> None:
+    """分块把上传文件写入 dest, 累计超过 max_bytes 立即拒绝(413)。
+
+    避免一次性 `await file.read()` 把整个文件读入内存(大文件可能触发高内存占用、
+    进程 OOM 或服务不可用); 超限时停止继续读取与落盘。
+    """
+    total = 0
+    with dest.open("wb") as f:
+        while True:
+            chunk = await file.read(_UPLOAD_CHUNK_BYTES)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > max_bytes:
+                raise HTTPException(413, f"文件过大(上限 {max_bytes // (1024 * 1024)}MB)")
+            f.write(chunk)
+
+
 @router.post("/{config_id}/upload")
 async def upload_data(
     request: Request,
@@ -511,9 +535,7 @@ async def upload_data(
     tmp_dir = Path(tempfile.mkdtemp())
     tmp_path = tmp_dir / f"upload{suffix}"
     try:
-        with tmp_path.open("wb") as f:
-            content = await file.read()
-            f.write(content)
+        await _write_upload_capped(file, tmp_path, _MAX_UPLOAD_BYTES)
 
         # 直接读取文件，不做列重命名
         if suffix == ".csv":
@@ -746,9 +768,7 @@ async def detect_fields(
     tmp_dir = Path(tempfile.mkdtemp())
     tmp_path = tmp_dir / f"upload{suffix}"
     try:
-        with tmp_path.open("wb") as f:
-            content = await file.read()
-            f.write(content)
+        await _write_upload_capped(file, tmp_path, _MAX_UPLOAD_BYTES)
 
         # 直接读取，不要求 symbol 列
         if suffix == ".csv":

--- a/backend/tests/test_ext_upload_size_limit.py
+++ b/backend/tests/test_ext_upload_size_limit.py
@@ -1,0 +1,41 @@
+"""扩展数据上传体积上限回归测试(issue #204)。
+
+_write_upload_capped 分块把上传写入临时文件, 累计超过上限即拒绝(413),
+避免 `await file.read()` 把整个文件读入内存。纯逻辑, 不需真实数据源。
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+from fastapi import HTTPException
+from starlette.datastructures import UploadFile
+
+from app.api.ext_data import _write_upload_capped
+
+
+def _upload(data: bytes) -> UploadFile:
+    return UploadFile(io.BytesIO(data), filename="x.csv")
+
+
+async def test_under_limit_writes_full_content(tmp_path):
+    data = b"code,close\n000001.SZ,10.5\n600000.SH,8.2\n"
+    dest = tmp_path / "upload.csv"
+    await _write_upload_capped(_upload(data), dest, max_bytes=1024)
+    assert dest.read_bytes() == data
+
+
+async def test_at_limit_is_allowed(tmp_path):
+    data = b"x" * 64
+    dest = tmp_path / "upload.csv"
+    await _write_upload_capped(_upload(data), dest, max_bytes=64)
+    assert dest.read_bytes() == data
+
+
+async def test_over_limit_raises_413(tmp_path):
+    data = b"x" * 200
+    dest = tmp_path / "upload.csv"
+    with pytest.raises(HTTPException) as exc:
+        await _write_upload_capped(_upload(data), dest, max_bytes=64)
+    assert exc.value.status_code == 413
+    assert "过大" in str(exc.value.detail)


### PR DESCRIPTION
## 问题与复现

扩展数据的上传 `POST /api/ext-data/{config_id}/upload` 与字段检测 `POST /api/ext-data/detect-fields` 都直接 `content = await file.read()`,没有任何字节数、行数或解析资源限制。上传很大的 CSV/XLSX 时,服务会先把整个文件读入内存,再交给 Polars/Excel 解析,可能造成高内存占用、进程 OOM 或服务不可用。

现有自选截图 OCR 上传已有 12MB 上限(`watchlist.py`),但扩展上传没有统一上限。

修复 #204。

## 根因

`backend/app/api/ext_data.py` 两处上传入口:

```python
with tmp_path.open("wb") as f:
    content = await file.read()   # ← 整文件读入内存, 无上限
    f.write(content)
```

## 解决方案

抽出统一的分块写入助手:

```python
async def _write_upload_capped(file, dest, max_bytes):
    total = 0
    with dest.open("wb") as f:
        while chunk := await file.read(_UPLOAD_CHUNK_BYTES):  # 1MB/块
            total += len(chunk)
            if total > max_bytes:
                raise HTTPException(413, f"文件过大(上限 {max_bytes // (1024*1024)}MB)")
            f.write(chunk)
```

- 分块(1MB)写入临时文件,**不再一次性把整个文件读入内存**。
- 累计字节超过上限**立即拒绝并停止读取/落盘**,返回 `413 Payload Too Large`。
- 两个上传入口统一改用它;后缀白名单、解析与映射逻辑保持不变。

上限常量 `_MAX_UPLOAD_BYTES = 50MB`:对扩展快照数据足够宽裕,同时挡住恶意/异常的超大文件。数值集中在一处常量,便于按部署环境调整。

## 兼容性

- 仅新增体积上限,不改数据契约、字段映射、`symbol/code` 生成逻辑。
- `detect_fields` 的 `except HTTPException: raise` 会原样透传 413;`upload_data` 的 413 不属于其 `except ValueError`,正常向上传播,且 `finally` 仍会清理临时目录。

## 性能

上传路径改为流式分块,峰值内存不再随文件大小线性增长(此前需同时持有「整文件 bytes + 落盘副本」)。不进入实时/列表热路径。

## 验证结果

```
cd backend
uv run pytest tests/test_ext_upload_size_limit.py -q
# 3 passed —— 覆盖: 未超限完整写入 / 恰好等于上限放行 / 超限抛 413

uv run ruff check app/api/ext_data.py tests/test_ext_upload_size_limit.py
# 无新增告警(B008 与 origin/main 同为 2, 均为既有 FastAPI `File(...)` 默认值写法)
```

(本地无 `uv`,实际以仓库同版本依赖的 venv 执行 `python -m pytest`,命令等价。)

## 风险与回滚

风险低:新增一个助手函数 + 两处调用替换,行为对合法上传不变。若 50MB 上限对某些部署偏小,只需调整一个常量。回滚即还原两处调用与该助手。

> 说明:issue 另提及「解析行数/列数边界」。本 PR 先堵住最直接的「整文件读入内存 + 无上限」这一 DoS/OOM 面;更细的解析期资源限制(如 Polars 行列上限)可作为后续增量,避免单 PR 混入多个关注点。