### PR TITLE
perf(kline): 个股详情仅增量更新最后一根日 K

### DIFF
--- a/backend/app/api/kline.py
+++ b/backend/app/api/kline.py
@@ -459,51 +459,54 @@ def _attach_ext(resp: dict, repo, symbol: str, ext_columns: Optional[str]) -> di
     return resp
 
 
-def _maybe_inject_live_candle(request: Request, symbol: str, rows: list[dict], asset_type: str = "stock") -> list[dict]:
-    """如果有当日实时 enriched 数据, 用实时数据生成今日蜡烛并追加/覆盖。
+def _latest_live_candle(
+    request: Request,
+    symbol: str,
+    asset_type: str = "stock",
+    *,
+    refresh_asset: bool = True,
+) -> dict | None:
+    """从内存缓存读取单只标的的当日实时 enriched 行。"""
 
-    stock 走 QuoteService 的股票实时缓存; etf 走 ETF enriched 缓存 (开启实时 ETF
-    拉取时为盘中数据, 否则为磁盘最新日, 由下方"非今日不注入"守卫自然跳过)。
-    """
     if asset_type == "stock":
         qs = getattr(request.app.state, "quote_service", None)
         if not qs:
-            return rows
+            return None
         df_today, enriched_date = qs.get_enriched_today()
     elif asset_type == "etf":
-        df_today, enriched_date = request.app.state.repo.get_enriched_latest_asset("etf")
+        df_today, enriched_date = request.app.state.repo.get_enriched_latest_asset(
+            "etf", refresh=refresh_asset,
+        )
     else:
-        return rows
+        return None
     if df_today.is_empty():
-        return rows
+        return None
 
-    # 非交易日（周末/假日）缓存的行情日期 != 今天，跳过注入避免产生重复蜡烛
+    # 非交易日(周末/假日)缓存日期 != 今天, 跳过注入避免产生重复蜡烛
     if not enriched_date or enriched_date != date.today():
-        return rows
+        return None
 
     # 查找该 symbol 的实时 enriched 行
     import polars as pl
     try:
         q = df_today.filter(pl.col("symbol") == symbol).to_dicts()
         if not q:
-            return rows
+            return None
         q = q[0]
-    except Exception:  # noqa: BLE001
-        return rows
+    except Exception:
+        return None
 
     close_price = q.get("close")
     if not close_price or close_price <= 0:
-        return rows
+        return None
 
-    today_str = str(enriched_date)
-
-    # enriched 行已包含 OHLCV + 全套指标, 直接用它
-    # 修复: API 在非交易时段可能返回 open/high/low=0, 用 close 填充避免异常蜡烛
+    # 沿用完整日K接口原有的实时行投影, 避免增量接口形成第二套字段契约。
+    # API 在非交易时段可能返回 open/high/low=0, 用 close 填充避免异常蜡烛。
     raw_open = q.get("open")
     raw_high = q.get("high")
     raw_low = q.get("low")
-    live_row: dict = {
-        "date": today_str,
+    live_row = {
+        "date": str(enriched_date),
         "symbol": symbol,
         "open": raw_open if raw_open and raw_open > 0 else close_price,
         "high": raw_high if raw_high and raw_high > 0 else close_price,
@@ -514,7 +517,6 @@ def _maybe_inject_live_candle(request: Request, symbol: str, rows: list[dict], a
         "change_pct": q.get("change_pct"),
         "is_live": True,
     }
-    # 补上 enriched 的技术指标字段
     for key in ("ma5", "ma10", "ma20", "ma30", "ma60",
                 "macd_dif", "macd_dea", "macd_hist",
                 "kdj_k", "kdj_d", "kdj_j",
@@ -523,11 +525,19 @@ def _maybe_inject_live_candle(request: Request, symbol: str, rows: list[dict], a
                 "atr_14", "vol_ratio_5d"):
         if key in q and q[key] is not None:
             live_row[key] = q[key]
+    return live_row
+
+
+def _maybe_inject_live_candle(request: Request, symbol: str, rows: list[dict], asset_type: str = "stock") -> list[dict]:
+    """如果有当日实时 enriched 数据, 用实时数据生成今日蜡烛并追加/覆盖。"""
+    live_row = _latest_live_candle(request, symbol, asset_type)
+    if live_row is None:
+        return rows
 
     # 如果已有今天的 enriched 行, 覆盖; 否则追加
     found = False
-    for i, r in enumerate(rows):
-        if str(r.get("date")) == today_str:
+    for r in rows:
+        if str(r.get("date")) == live_row["date"]:
             r.update(live_row)
             found = True
             break
@@ -536,6 +546,22 @@ def _maybe_inject_live_candle(request: Request, symbol: str, rows: list[dict], a
         rows.append(live_row)
 
     return rows
+
+
+@router.get("/daily/latest")
+def get_daily_latest(
+    request: Request,
+    symbol: str = Query(..., description="标的代码,如 000001.SZ"),
+):
+    """返回内存中的当日单行 K 线, 供详情页实时增量更新。"""
+    repo = request.app.state.repo
+    asset_type = repo.resolve_asset_type(symbol)
+    row = _latest_live_candle(request, symbol, asset_type, refresh_asset=False)
+    return {
+        "symbol": symbol,
+        "row": row,
+        "source": "live" if row is not None else "none",
+    }
 
 
 class DailyBatchRequest:

--- a/backend/tests/test_kline_daily_latest.py
+++ b/backend/tests/test_kline_daily_latest.py
@@ -1,0 +1,140 @@
+"""个股详情日 K 最新行接口测试。"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import polars as pl
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.kline import router
+
+
+class _FakeQuoteService:
+    def __init__(self, frame: pl.DataFrame, trade_date: date | None) -> None:
+        self._frame = frame
+        self._trade_date = trade_date
+
+    def get_enriched_today(self):
+        return self._frame, self._trade_date
+
+
+class _FakeRepo:
+    def __init__(
+        self,
+        asset_type: str = "stock",
+        latest_asset: tuple[pl.DataFrame, date | None] | None = None,
+    ) -> None:
+        self.asset_type = asset_type
+        self.latest_asset = latest_asset
+        self.latest_asset_calls = 0
+        self.latest_asset_refresh: bool | None = None
+
+    def resolve_asset_type(self, symbol: str) -> str:
+        return self.asset_type
+
+    def get_enriched_latest_asset(self, asset_type: str, refresh: bool = True):
+        self.latest_asset_calls += 1
+        self.latest_asset_refresh = refresh
+        if self.latest_asset is not None:
+            return self.latest_asset
+        raise AssertionError("stock latest row must use QuoteService's memory cache")
+
+
+def _client(
+    frame: pl.DataFrame,
+    trade_date: date | None,
+    *,
+    asset_type: str = "stock",
+    latest_asset: tuple[pl.DataFrame, date | None] | None = None,
+) -> tuple[TestClient, _FakeRepo]:
+    repo = _FakeRepo(asset_type, latest_asset)
+    app = FastAPI()
+    app.include_router(router)
+    app.state.repo = repo
+    app.state.quote_service = _FakeQuoteService(frame, trade_date)
+    return TestClient(app), repo
+
+
+def _live_frame() -> pl.DataFrame:
+    return pl.DataFrame({
+        "symbol": ["600000.SH"],
+        "date": [date.today()],
+        "open": [10.0],
+        "high": [10.8],
+        "low": [9.9],
+        "close": [10.6],
+        "volume": [123_456.0],
+        "amount": [1_234_560.0],
+        "ma5": [10.2],
+        "signal_limit_up": [False],
+    })
+
+
+def test_daily_latest_returns_only_current_memory_row() -> None:
+    client, repo = _client(_live_frame(), date.today())
+
+    response = client.get("/api/kline/daily/latest", params={"symbol": "600000.SH"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["symbol"] == "600000.SH"
+    assert body["source"] == "live"
+    assert body["row"] == {
+        "symbol": "600000.SH",
+        "date": date.today().isoformat(),
+        "open": 10.0,
+        "high": 10.8,
+        "low": 9.9,
+        "close": 10.6,
+        "volume": 123_456.0,
+        "amount": 1_234_560.0,
+        "change_pct": None,
+        "ma5": 10.2,
+        "is_live": True,
+    }
+    assert repo.latest_asset_calls == 0
+
+
+def test_daily_latest_returns_none_for_stale_cache() -> None:
+    client, _ = _client(_live_frame(), date.today() - timedelta(days=1))
+
+    response = client.get("/api/kline/daily/latest", params={"symbol": "600000.SH"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "symbol": "600000.SH",
+        "row": None,
+        "source": "none",
+    }
+
+
+def test_daily_latest_returns_none_when_symbol_is_missing() -> None:
+    client, _ = _client(_live_frame(), date.today())
+
+    response = client.get("/api/kline/daily/latest", params={"symbol": "600001.SH"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "symbol": "600001.SH",
+        "row": None,
+        "source": "none",
+    }
+
+
+def test_daily_latest_uses_etf_enriched_cache() -> None:
+    etf = _live_frame().with_columns(pl.lit("510300.SH").alias("symbol"))
+    client, repo = _client(
+        pl.DataFrame(),
+        None,
+        asset_type="etf",
+        latest_asset=(etf, date.today()),
+    )
+
+    response = client.get("/api/kline/daily/latest", params={"symbol": "510300.SH"})
+
+    assert response.status_code == 200
+    assert response.json()["row"]["close"] == 10.6
+    assert response.json()["source"] == "live"
+    assert repo.latest_asset_calls == 1
+    assert repo.latest_asset_refresh is False

--- a/frontend/src/components/StockDailyKChart.tsx
+++ b/frontend/src/components/StockDailyKChart.tsx
@@ -44,8 +44,6 @@ interface Props {
   onPriceDoubleClick?: (price: number, currentPrice: number) => void
   /** 扩展数据列参数（逗号分隔 config_id.field_name），透传给 klineDaily 接口 */
   extColumns?: string
-  /** 日K自动刷新间隔(ms)。undefined = 不轮询(默认)。个股对话框实时刷新时传入, 盘中今日蜡烛随之更新 */
-  refetchIntervalMs?: number
 }
 
 function isValidRow(r: any): boolean {
@@ -121,7 +119,6 @@ export function StockDailyKChart({
   onDateClick,
   onPriceDoubleClick,
   extColumns,
-  refetchIntervalMs,
 }: Props) {
   const [activeIndicators, setActiveIndicators] = useState<string[]>(['vol'])
   const [showMarkers, setShowMarkers] = useState(true)
@@ -131,7 +128,7 @@ export function StockDailyKChart({
   const dateRange = externalDateRange ?? getDefaultRange()
 
   // 查询配置统一来自 klineDailyQueryOptions, 与 StockPanel 信息条/邻近预取共享同一 cache key (只发一次请求)
-  const kline = useQuery({ ...klineDailyQueryOptions(symbol, dateRange, extColumns), enabled: !!symbol, refetchInterval: refetchIntervalMs })
+  const kline = useQuery({ ...klineDailyQueryOptions(symbol, dateRange, extColumns), enabled: !!symbol })
 
   const rows = useMemo(() => toOHLC(kline.data?.rows ?? []), [kline.data?.rows])
   const stockInfo = kline.data?.stock_info

--- a/frontend/src/components/StockIntradayChart.tsx
+++ b/frontend/src/components/StockIntradayChart.tsx
@@ -40,7 +40,7 @@ export function StockIntradayChart({
     // 避免读到分钟增量落盘的上一轮本地分区; 历史日期后端自行忽略 live。
     ...klineMinuteQueryOptions(symbol, date ?? undefined, refetchIntervalMs != null),
     enabled: !!symbol && !!date,
-    refetchInterval: refetchIntervalMs,
+    refetchInterval: query => query.state.data?.source === 'none' ? false : refetchIntervalMs,
   })
 
   const fetchMinute = useMutation({

--- a/frontend/src/components/StockPanel.tsx
+++ b/frontend/src/components/StockPanel.tsx
@@ -215,7 +215,6 @@ export function StockPanel({
           onPriceDoubleClick={onPriceDoubleClick}
           visibleBars={showIntraday ? 40 : 60}
           extColumns={extColumns}
-          refetchIntervalMs={refetchIntervalMs}
         />
 
         {showIntraday && selectedDate && !intradayDismissed && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -234,6 +234,20 @@ export interface KlineRow {
   [key: string]: any
 }
 
+export interface KlineDailyResponse {
+  symbol: string
+  name?: string
+  stock_info?: { name?: string; total_shares?: number; float_shares?: number; ext?: Record<string, unknown> }
+  rows: KlineRow[]
+  source?: string
+}
+
+export interface KlineDailyLatestResponse {
+  symbol: string
+  row: KlineRow | null
+  source: 'live' | 'none'
+}
+
 // ===== Watchlist =====
 export interface WatchlistEntry {
   symbol: string
@@ -2082,17 +2096,15 @@ export const api = {
     request<CapabilitiesResponse>('/api/capabilities/redetect', { method: 'POST' }),
 
   klineDaily: (symbol: string, days = 120, dateRange?: { start: string; end: string }, extColumns?: string) =>
-    request<{
-      symbol: string
-      name?: string
-      stock_info?: { name?: string; total_shares?: number; float_shares?: number; ext?: Record<string, unknown> }
-      rows: KlineRow[]
-      source?: string
-    }>(
+    request<KlineDailyResponse>(
       (dateRange
         ? `/api/kline/daily?symbol=${encodeURIComponent(symbol)}&start_date=${dateRange.start}&end_date=${dateRange.end}`
         : `/api/kline/daily?symbol=${encodeURIComponent(symbol)}&days=${days}`)
       + (extColumns ? `&ext_columns=${encodeURIComponent(extColumns)}` : ''),
+    ),
+  klineDailyLatest: (symbol: string) =>
+    request<KlineDailyLatestResponse>(
+      `/api/kline/daily/latest?symbol=${encodeURIComponent(symbol)}`,
     ),
   klineDailyBatch: (symbols: string[], days = 12) =>
     request<{ data: Record<string, KlineRow[]> }>('/api/kline/daily-batch', {

--- a/frontend/src/lib/kline.ts
+++ b/frontend/src/lib/kline.ts
@@ -7,7 +7,7 @@
  * placeholderData 内置"仅同 symbol 占位"守卫: 改日期范围/扩展字段时旧数据可暂显(不闪),
  * 切股时不透传上一只股票的数据(不误显示)。
  */
-import { api } from '@/lib/api'
+import { api, type KlineDailyLatestResponse, type KlineDailyResponse } from '@/lib/api'
 import { QK } from '@/lib/queryKeys'
 
 /** 分时 tab 多日分时默认周期 (StockPanel 预取与弹窗存储回退共用, 避免魔数两处漂移) */
@@ -27,6 +27,34 @@ export function klineDailyQueryOptions(
       return prevKey?.[1] === symbol ? prev : undefined
     },
   }
+}
+
+export function klineDailyLatestQueryOptions(symbol: string) {
+  return {
+    queryKey: QK.klineLatest(symbol),
+    queryFn: () => api.klineDailyLatest(symbol),
+  }
+}
+
+export function mergeLatestKlineRow(
+  current: KlineDailyResponse | undefined,
+  latest: KlineDailyLatestResponse,
+): KlineDailyResponse | undefined {
+  if (!current || !latest.row || current.symbol !== latest.symbol) return current
+
+  const latestDate = String(latest.row.date).slice(0, 10)
+  const last = current.rows.at(-1)
+  if (!last) return { ...current, rows: [{ ...latest.row, date: latestDate }] }
+
+  const lastDate = String(last.date).slice(0, 10)
+  if (latestDate < lastDate) return current
+  if (latestDate === lastDate) {
+    return {
+      ...current,
+      rows: [...current.rows.slice(0, -1), { ...last, ...latest.row, date: latestDate }],
+    }
+  }
+  return { ...current, rows: [...current.rows, { ...latest.row, date: latestDate }] }
 }
 
 /**

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -79,6 +79,7 @@ export const QK = {
   // Kline
   kline:                (symbol: string, start: string, end: string, extColumns?: string) =>
                            ['kline', symbol, start, end, extColumns ?? ''] as const,
+  klineLatest:          (symbol: string) => ['kline-latest', symbol] as const,
   stockLevels:          (symbol: string, days?: number) => ['stock-levels', symbol, days ?? 120] as const,
   klineMinute:          (symbol: string, date: string) =>
                              ['kline-minute', symbol, date] as const,

--- a/frontend/src/lib/useQuoteStream.ts
+++ b/frontend/src/lib/useQuoteStream.ts
@@ -1,11 +1,12 @@
 import { useEffect, useRef, useCallback, useSyncExternalStore } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { SSE_INVALIDATE_PREFIXES, QK } from './queryKeys'
+import { klineDailyLatestQueryOptions, mergeLatestKlineRow } from './kline'
 import { getQueryConfig } from './useQueryConfig'
 import { toast } from '@/components/Toast'
 import { pushAlertToasts } from '@/components/AlertToast'
 import { feedReviewEvent } from './reviewStore'
-import type { StrategyAlertEvent } from './api'
+import type { KlineDailyResponse, StrategyAlertEvent } from './api'
 
 // ===== 全局 SSE 连接状态 (模块级 store, 仿 AlertToast.tsx 模式) =====
 // 实时行情 SSE 断开时 UI 无感知 → 会漏掉策略告警。这里暴露连接状态,
@@ -47,8 +48,8 @@ export function useQuoteStreamStatus(): QuoteStreamStatus {
 }
 
 // ===== 焦点股票注册表 (个股对话框用) =====
-// 个股对话框打开时注册当前 symbol, SSE quotes_updated 推送时精准 invalidate
-// 该 symbol 的日K查询 (['kline', symbol]), 让日K最后一根蜡烛随实时价变化。
+// 个股对话框打开时注册当前 symbol, SSE quotes_updated 推送时只取当日最新行，
+// 再原位更新该 symbol 的日K查询缓存，避免重复下载整段历史。
 // 不加进 SSE_INVALIDATE_PREFIXES 全局列表 —— 避免回测弹窗等也每秒重拉。
 let _focusSymbol: string | null = null
 
@@ -161,10 +162,25 @@ export function useQuoteStream(
               ),
           })
         }
-        // 焦点股票日K精准刷新: 个股对话框打开时, 日K最后一根蜡烛随实时价变化。
-        // 后端 _maybe_inject_live_candle 只读内存缓存, 不调 TickFlow, 秒级重拉零额外成本。
+        // 焦点股票日K增量刷新: 只取内存中的当日行并合并缓存尾部。
         if (_focusSymbol) {
-          qc.invalidateQueries({ queryKey: ['kline', _focusSymbol] })
+          const symbol = _focusSymbol
+          void qc.fetchQuery({ ...klineDailyLatestQueryOptions(symbol), staleTime: 0 })
+            .then((latest) => {
+              if (_focusSymbol !== symbol || !latest.row) return
+              const latestDate = String(latest.row.date).slice(0, 10)
+              const queries = qc.getQueryCache().findAll({ queryKey: ['kline', symbol] })
+              for (const query of queries) {
+                const start = String(query.queryKey[2] ?? '')
+                const end = String(query.queryKey[3] ?? '')
+                if (latestDate < start || latestDate > end) continue
+                qc.setQueryData<KlineDailyResponse>(
+                  query.queryKey,
+                  current => mergeLatestKlineRow(current, latest),
+                )
+              }
+            })
+            .catch(() => {})
         }
       })
 


### PR DESCRIPTION
## 问题与复现

个股详情默认日 K 视图把分时刷新间隔（默认 6 秒）同时传给 `StockDailyKChart` 和 `StockIntradayChart`。左侧为了更新当天最后一根蜡烛，会持续重新请求完整日期范围：

```text
GET /api/kline/daily?symbol=...&start_date=...&end_date=...
```

生产样本 `920006.BJ` 的半年日 K 为 128 行，完整响应 265,776 字节且未压缩；服务端生成约 32 ms，但完整响应返回到浏览器并进入后续请求约 10.95 s。详情保持打开时还会继续重复这份历史响应。

Closes #234

## 根因

`d9ff91f` 为保证盘中实时蜡烛更新，把同一个 `refetchIntervalMs` 透传给日 K 和分时查询。实时变化只涉及当天最后一行，但 TanStack Query 失效和固定轮询都作用于完整 `['kline', symbol, start, end, ext]` 查询，因此热路径成本随历史范围和字段数线性增长。

项目已有焦点股票注册和 `quotes_updated` SSE，但原实现仍通过 invalidate 完整日 K 查询响应事件。

## 解决方案

- 新增只读内存的 `GET /api/kline/daily/latest?symbol=...`：仅返回当天实时 enriched 行，不扫描历史、不调用外部 provider；ETF 路径显式 `refresh=False`，避免冷缓存同步重算。
- 完整日 K 仍在首次打开、切股、切日期范围或手动刷新时加载，移除 `StockDailyKChart` 的固定轮询。
- `quotes_updated` 到达时只 fetch latest-row，并按 query key 的日期范围对现有日 K 缓存执行：
  - 同日：保留旧行扩展字段并替换最新字段；
  - 跨日：append 新行；
  - 旧日期或范围外：忽略。
- 快速切股时校验当前焦点 symbol，避免旧请求回写新股票。
- 分时接口返回 `source=none` 后停止该查询的定时轮询，避免持续请求已确认不提供分钟数据的源。

## 缓存与状态变化

```text
首次/切股/切区间/手动刷新
  -> 完整 kline query

quotes_updated + 当前焦点股票
  -> kline-latest query（单行）
  -> setQueryData 更新匹配日期范围的 kline cache 尾行
```

不新增独立业务状态；`StockPanel` 信息条和 `StockDailyKChart` 继续共享既有日 K query key。

## 兼容性

- API 为向后兼容的新增端点，现有 `/api/kline/daily` 响应不变。
- 不修改 Parquet、数据库、配置、指标口径或数据源协议。
- 股票 latest-row 复用 QuoteService 内存缓存；ETF 复用现有独立 enriched 缓存且禁止热路径冷刷新；指数保持原行为。
- latest-row 获取失败或没有当日数据时保留上一份有效日 K，用户仍可手动完整刷新。

## 性能

修改前：详情打开期间每约 6 秒重新请求完整历史日 K。

修改后：完整历史只在明确的全量加载事件中请求；行情 SSE 只请求并合并 1 行。实时热路径不再随半年/一年历史长度线性增长。

## 验证结果

- `uv run --frozen --extra dev pytest tests/test_kline_daily_latest.py tests/test_kline_hot_path_memory.py tests/test_kline_minute_live.py tests/test_kline_sync_timezone.py tests/test_minute_range_api.py tests/test_get_daily_cache_reuse.py -q`
  - 34 passed
- `uv run --frozen --extra dev ruff check tests/test_kline_daily_latest.py`
  - passed
- `./node_modules/.bin/tsc -b`
  - passed
- `./node_modules/.bin/vite build`
  - passed
- Vite SSR 直接执行 `mergeLatestKlineRow`
  - 同日 replace 并保留旧字段、跨日 append、旧日期忽略，3 项通过
- `git diff --check`
  - passed

`backend/app/api/kline.py` 全文件仍有上游既存 Ruff 告警；本 PR 修改行范围未新增 Ruff 诊断，未夹带无关清理。

## 界面证据

无视觉布局或文案变化。行为变化只体现在 Network：行情更新时从完整 `/api/kline/daily` 变为单行 `/api/kline/daily/latest`。

## 风险与回滚

- 风险：latest-row API 或 SSE 暂时失败时，最后一根蜡烛会停留在上一份有效值；不会清空或污染历史数据，手动刷新可恢复。
- 回滚：回退本 PR 即恢复原完整日 K invalidate + 定时轮询行为；无数据迁移或配置回滚要求。
