### PR TITLE
fix(watchlist): 自选导入上传分块读取, 越限即拒绝而非读完再拒

### DIFF
--- a/backend/app/api/watchlist.py
+++ b/backend/app/api/watchlist.py
@@ -40,6 +40,28 @@ _IMPORT_CSV_TYPES = {
     "text/plain",
     "application/csv",
 }
+# 上传分块读取粒度 (与 ext_data 上传一致)
+_UPLOAD_CHUNK_BYTES = 1024 * 1024
+
+
+async def _read_upload_capped(file: UploadFile, max_bytes: int, too_large: str) -> bytes:
+    """分块读取上传内容, 累计超过 max_bytes 立即拒绝(400), 返回完整字节。
+
+    与 ext_data._write_upload_capped 同类保护: 一次性 `await file.read()` 会先把整个
+    文件读入内存再比较长度, 上限在那之后才生效, 一个远超上限的上传照样把进程内存
+    顶满; 分块读取在越过上限的那一块就停止, 内存占用不超过上限 + 一块。
+    """
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = await file.read(_UPLOAD_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise HTTPException(400, too_large)
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 class AddRequest(BaseModel):
@@ -186,11 +208,9 @@ async def import_from_image(request: Request, file: UploadFile = File(...)):
     if not ok_type and not ok_ext:
         raise HTTPException(400, "仅支持 JPG / PNG / WebP / BMP / GIF 图片")
 
-    data = await file.read()
+    data = await _read_upload_capped(file, _MAX_IMPORT_IMAGE_BYTES, "图片过大（上限 12MB）")
     if not data:
         raise HTTPException(400, "空文件")
-    if len(data) > _MAX_IMPORT_IMAGE_BYTES:
-        raise HTTPException(400, "图片过大（上限 12MB）")
 
     existing = {r["symbol"] for r in watchlist.list_symbols()}
     data_dir = request.app.state.repo.store.data_dir
@@ -242,11 +262,9 @@ async def import_from_csv(request: Request, file: UploadFile = File(...)):
     if not ok_type and not ok_ext:
         raise HTTPException(400, "仅支持 CSV / TXT 文件")
 
-    data = await file.read()
+    data = await _read_upload_capped(file, _MAX_IMPORT_CSV_BYTES, "文件过大（上限 5MB）")
     if not data:
         raise HTTPException(400, "空文件")
-    if len(data) > _MAX_IMPORT_CSV_BYTES:
-        raise HTTPException(400, "文件过大（上限 5MB）")
 
     data_dir = request.app.state.repo.store.data_dir
     # 解码与自选/instruments parquet 读取为同步 CPU/IO，挪线程池避免卡事件循环

--- a/backend/tests/test_watchlist_csv.py
+++ b/backend/tests/test_watchlist_csv.py
@@ -40,7 +40,9 @@ def _mock_upload(*, content: bytes, content_type: str = "text/csv", filename: st
     file = MagicMock()
     file.content_type = content_type
     file.filename = filename
-    file.read = AsyncMock(return_value=content)
+    # 像真实 UploadFile 一样: 第一次 read 返回全部内容, 之后返回 b"" 表示读尽
+    # (端点已改为分块读取, 一直返回同一段内容的 mock 会被当成无限大的文件)
+    file.read = AsyncMock(side_effect=[content, b""])
     return file
 
 

--- a/backend/tests/test_watchlist_ocr.py
+++ b/backend/tests/test_watchlist_ocr.py
@@ -54,7 +54,9 @@ def _mock_upload(
     file = MagicMock()
     file.content_type = content_type
     file.filename = filename
-    file.read = AsyncMock(return_value=content)
+    # 像真实 UploadFile 一样: 第一次 read 返回全部内容, 之后返回 b"" 表示读尽
+    # (端点已改为分块读取, 一直返回同一段内容的 mock 会被当成无限大的文件)
+    file.read = AsyncMock(side_effect=[content, b""])
     return file
 
 

--- a/backend/tests/test_watchlist_upload_size_limit.py
+++ b/backend/tests/test_watchlist_upload_size_limit.py
@@ -1,0 +1,67 @@
+"""自选导入上传体积上限回归测试 (import-csv / import-image)。
+
+两个端点原先 `data = await file.read()` 之后才比较长度: 上限只在整个文件已经进入
+内存之后生效, 与 ext_data 上传修复 (issue #204) 前的问题同类。_read_upload_capped
+分块读取, 越过上限即拒绝(400), 内存占用不超过上限 + 一块。纯逻辑, 不需真实数据源。
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+from fastapi import HTTPException
+from starlette.datastructures import UploadFile
+
+from app.api import watchlist as watchlist_api
+from app.api.watchlist import _read_upload_capped
+
+
+class _CountingStream(io.BytesIO):
+    """记录被读取的字节数, 用来证明越限后不再继续读。"""
+
+    def __init__(self, data: bytes) -> None:
+        super().__init__(data)
+        self.consumed = 0
+
+    def read(self, size: int = -1) -> bytes:  # type: ignore[override]
+        chunk = super().read(size)
+        self.consumed += len(chunk)
+        return chunk
+
+
+def _upload(stream: io.BytesIO) -> UploadFile:
+    return UploadFile(stream, filename="x.csv")
+
+
+async def test_under_limit_returns_full_content():
+    data = "code,name\n600519.SH,贵州茅台\n".encode()
+    got = await _read_upload_capped(_upload(io.BytesIO(data)), 1024, "too large")
+    assert got == data
+
+
+async def test_at_limit_is_allowed():
+    data = b"x" * 64
+    got = await _read_upload_capped(_upload(io.BytesIO(data)), 64, "too large")
+    assert got == data
+
+
+async def test_over_limit_raises_400_with_the_message_the_endpoint_passes():
+    data = b"x" * 200
+    with pytest.raises(HTTPException) as exc:
+        await _read_upload_capped(_upload(io.BytesIO(data)), 64, "文件过大")
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "文件过大"
+
+
+async def test_over_limit_stops_reading_at_the_first_chunk_past_the_cap(monkeypatch):
+    # 4 块的文件, 上限 1.5 块: 第 2 块越限即拒绝, 第 3/4 块不应被读取。
+    monkeypatch.setattr(watchlist_api, "_UPLOAD_CHUNK_BYTES", 16)
+    stream = _CountingStream(b"x" * 64)
+    with pytest.raises(HTTPException):
+        await _read_upload_capped(_upload(stream), 24, "too large")
+    assert stream.consumed == 32
+
+
+async def test_empty_upload_returns_empty_bytes():
+    got = await _read_upload_capped(_upload(io.BytesIO(b"")), 64, "too large")
+    assert got == b""


### PR DESCRIPTION
## 问题与复现

`POST /api/watchlist/import-csv` 与 `POST /api/watchlist/import-image` 都是先 `data = await file.read()` 再比较 `len(data)`。上限 (5MB / 12MB) 只在整个文件已经进入进程内存之后才生效: 一个远超上限的上传 (例如误选的几 GB 导出/截图, 或者恶意请求) 会先被完整读进内存, 然后才收到「文件过大」。这与 issue #204 修复前扩展数据上传的问题同类, `ext_data.py` 的注释也明确写了要避免的就是这种写法:

> 通过分块写入临时文件, 超限即拒绝, 避免 `await file.read()` 把整个文件读入内存。

复现: 对 `/api/watchlist/import-csv` 上传一个 500MB 的 `.csv`, 观察后端进程 RSS 先增长约 500MB, 之后才返回 400。

影响用户: 所有使用自选 CSV/TXT 导入 (#228) 或截图导入的用户; 单机部署下一次误操作即可把后端内存顶满。

## 根因

`UploadFile.read()` 不带参数时读到 EOF, 长度检查发生在读取完成之后, 上限对内存峰值不起作用。`ext_data._write_upload_capped` 已经用「分块读、累计超限即停」解决了同一问题, 但它把内容落到临时文件; 自选导入的两个端点需要的是字节串 (随后交给 `import_watchlist_csv` / `import_watchlist_image`), 所以没有复用。

## 解决方案

`api/watchlist.py` 新增 `_read_upload_capped(file, max_bytes, too_large)`: 按 1MB 分块 `await file.read(chunk)`, 累计超过 `max_bytes` 的那一块立即 `HTTPException(400, too_large)` 并停止读取, 否则拼接返回完整字节。两个端点改为调用它, 状态码与文案 (`400` / 「文件过大（上限 5MB）」/「图片过大（上限 12MB）」) 与原先完全一致, 只是拒绝发生在越限的那一块, 内存占用不超过上限 + 一块。

未合并进 `ext_data._write_upload_capped` 的原因: 那个函数的契约是落盘 + 413, 这里是返回字节 + 400 (前端按 detail 文案展示), 合并会改动两处已有行为; 保持最小范围。

## 兼容性

API 契约不变 (路径、状态码、错误文案、成功响应)。不涉及配置、缓存、Parquet、数据源和资产类型。

## 性能

不在实时或列表热路径。正常大小的上传多了一次拼接 (`b"".join`), 5MB 以内可忽略; 超限上传从「读完再拒」变为「越限即拒」, 是纯粹的改善。

## 验证结果

```
python -m pytest backend/tests/test_watchlist_upload_size_limit.py backend/tests/test_watchlist_csv.py backend/tests/test_ext_upload_size_limit.py -q
```

- 新增 `test_watchlist_upload_size_limit.py` 5 例: 未超限返回完整内容、恰好等于上限放行、超限抛 400 且文案为端点传入的文案、**越限后不再继续读取** (把分块改成 16 字节, 64 字节文件、上限 24 字节, 断言只消费了 32 字节)、空上传返回空字节。
- `test_watchlist_csv.py` 与 `test_watchlist_ocr.py` 的 `_mock_upload` 原来 `AsyncMock(return_value=content)` 每次 `read()` 都返回同一段内容, 对分块读取来说等于无限大的文件; 改为 `side_effect=[content, b""]`, 与真实 `UploadFile` 一致 (读尽返回 `b""`)。两个文件其余用例不变并通过 (csv 34 例、ocr 14 例), 其中 `test_import_csv_rejects_oversized_bytes` 覆盖 5MB+1 仍返回 400。
- 未修复代码上运行新测试: `test_over_limit_stops_reading_at_the_first_chunk_past_the_cap` 因函数不存在而无法通过 (原实现没有可停止读取的点)。
- `ruff check` 对改动文件无新增告警 (`api/watchlist.py` 47 条为原有的 RUF001 全角标点告警, 修改前后计数相同); `git diff --check` 通过。
- 全量后端 `python -m pytest backend/tests -q`: 修改前基线 1638 passed; 修改后 **1643 passed, 100 warnings in 75.87s (0:01:15)** (Windows 11, Python 3.12)。

## 界面证据

无界面变化。

## 风险与回滚

风险: 无; 行为差异只在超限上传的拒绝时机。回滚: 还原 `api/watchlist.py` 与三个测试文件即可。
