### PR TITLE
fix(notifications): 飞书推送按传入的 max_attempts 退避与记日志

### DIFF
--- a/backend/app/services/webhook_adapter.py
+++ b/backend/app/services/webhook_adapter.py
@@ -141,10 +141,10 @@ def _post_feishu(webhook_url: str, payload: dict, secret: str, max_attempts: int
         except Exception as e:  # noqa: BLE001 — 网络/超时, 可重试
             last_err = str(e)
 
-        if attempt < _FEISHU_MAX_ATTEMPTS:
+        if attempt < max_attempts:
             time.sleep(min(2 ** (attempt - 1), 3))  # 退避: 1s, 2s
 
-    logger.warning("飞书 Webhook 推送最终失败(已重试 %d 次): %s", _FEISHU_MAX_ATTEMPTS, last_err)
+    logger.warning("飞书 Webhook 推送最终失败(已重试 %d 次): %s", max_attempts, last_err)
     return False
 
 

--- a/backend/tests/test_notification_adapters.py
+++ b/backend/tests/test_notification_adapters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import logging
 
 from app.services import email_adapter, webhook_adapter
 
@@ -98,3 +99,42 @@ def test_email_adapter_uses_starttls_login_and_multiple_recipients(monkeypatch):
     assert message["To"] == "one@example.com, two@example.com"
     assert message["Subject"] == "监控告警"
     assert smtp.calls[-1] == ("quit",)
+
+
+def _unreachable(*_args, **_kwargs):
+    raise ConnectionError("unreachable")
+
+
+def test_feishu_single_attempt_returns_without_backoff_and_logs_the_real_count(monkeypatch, caplog):
+    # 设置页「发送测试消息」传 max_attempts=1: 失败即返回, 不等退避, 日志计数如实。
+    sleeps: list[float] = []
+    monkeypatch.setattr(webhook_adapter.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr("httpx.post", _unreachable)
+    with caplog.at_level(logging.WARNING, logger=webhook_adapter.__name__):
+        ok = webhook_adapter.send_feishu(
+            "https://open.feishu.cn/open-apis/bot/v2/hook/abc", "标题", "正文", max_attempts=1
+        )
+    assert ok is False
+    assert sleeps == []
+    assert "已重试 1 次" in caplog.text
+
+
+def test_feishu_production_retries_keep_backoff(monkeypatch, caplog):
+    # 生产路径 (默认 3 次) 的退避与日志不变: 1s、2s 两次退避, 日志写 3 次。
+    sleeps: list[float] = []
+    calls = {"n": 0}
+
+    def unreachable(*_args, **_kwargs):
+        calls["n"] += 1
+        raise ConnectionError("unreachable")
+
+    monkeypatch.setattr(webhook_adapter.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr("httpx.post", unreachable)
+    with caplog.at_level(logging.WARNING, logger=webhook_adapter.__name__):
+        ok = webhook_adapter.send_feishu(
+            "https://open.feishu.cn/open-apis/bot/v2/hook/abc", "标题", "正文"
+        )
+    assert ok is False
+    assert calls["n"] == 3
+    assert sleeps == [1, 2]
+    assert "已重试 3 次" in caplog.text


### PR DESCRIPTION
## 问题与复现

`webhook_adapter._post_feishu` 有 `max_attempts` 参数 (设置页「发送测试消息」传 1, 见 `api/settings.py` 的注释「诊断用途单次尝试: 失败即返回, 不等生产退避重试」), 但循环体内两处仍然用的是模块常量 `_FEISHU_MAX_ATTEMPTS`(3):

```python
if attempt < _FEISHU_MAX_ATTEMPTS:
    time.sleep(min(2 ** (attempt - 1), 3))
...
logger.warning("飞书 Webhook 推送最终失败(已重试 %d 次): %s", _FEISHU_MAX_ATTEMPTS, last_err)
```

复现: 飞书 Webhook 配置成一个不可达地址, 点设置页「发送测试消息」:

1. 唯一一次尝试失败后, `attempt(1) < 3` 成立, 仍然 `sleep(1)` 再返回 —— 请求多等 1 秒, 与「失败即返回」相反;
2. 后端日志写 `飞书 Webhook 推送最终失败(已重试 3 次)`, 而实际只试了 1 次。

这条 WARNING 是维护者特意从 debug 提到 warning 的 (docstring: 「保证『推送丢了』在日志里可见」), 计数错误会让人按 3 次去排查网络抖动。

影响用户: 所有使用飞书通道并用「发送测试消息」诊断配置的用户; 生产路径 (max_attempts=3) 不受影响。

## 根因

`max_attempts` 参数在 40fea32 (webhook test message button) 引入时只改了 `range(1, max_attempts + 1)`, 退避判断与最终日志沿用了常量。

## 解决方案

两处改为使用 `max_attempts`。行为差异只在 `max_attempts != 3` 时出现 (当前唯一调用点是测试消息的 `1`): 不再多等 1 秒, 日志计数如实。生产路径逐字节不变。

## 兼容性

无配置、缓存、数据、API 变化。

## 性能

不在热路径; 测试消息端点在失败时少等 1 秒。

## 验证结果

```
python -m pytest backend/tests/test_notification_adapters.py -q
```

新增 `test_feishu_single_attempt_returns_without_backoff_and_logs_the_real_count`: monkeypatch `httpx.post` 抛网络异常、`time.sleep` 记录调用, `send_feishu(..., max_attempts=1)` 断言返回 False、**没有调用 sleep**、WARNING 里写的是「已重试 1 次」。未修复代码上实际运行: `1 failed, 1 passed` (该测试失败, 生产退避测试通过); 修复后 5 例全部通过。另加 `test_feishu_production_retries_keep_backoff`: 默认 3 次路径仍 sleep 两次 (1s、2s), 证明生产退避未变。

- `ruff check` 对改动文件无新增告警; `git diff --check` 通过。
- 全量后端 `python -m pytest backend/tests -q` (Windows 11, Python 3.12): 1637 passed, 3 failed 的是 `test_worker_process::test_spawn_walkforward_reuses_shared_matrix_across_folds` 与 `test_mining_manager` 两例, 均与本改动无关 (本分支只改 `webhook_adapter.py` 与其测试), 单独重跑 `12 passed`; 同一台机器上 main 的前两次全量均为全绿, 属时序抖动。

## 界面证据

无界面变化。

## 风险与回滚

风险: 无。回滚: 还原 `webhook_adapter.py` 两行即可。
