### PR TITLE
feat(ai): AI 产物发布闸 — 策略保存为草稿、复盘推送需确认

### DIFF
--- a/backend/app/api/market_recap.py
+++ b/backend/app/api/market_recap.py
@@ -19,7 +19,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from app.services import auction_benchmark, dragon_tiger, market_recap_reports
+from app.services import auction_benchmark, dragon_tiger, market_recap_reports, preferences
 from app.services.market_recap import recap_market_stream
 
 logger = logging.getLogger(__name__)
@@ -131,8 +131,8 @@ def list_reports(request: Request):
 
 
 @router.post("/reports")
-def save_report(request: Request, req: SaveReportRequest):
-    """保存一条复盘报告。"""
+def save_report(request: Request, req: SaveReportRequest, push: bool = False):
+    """保存一条复盘报告。push=True 或 review_push_mode=auto 时才推送到外部渠道。"""
     report = market_recap_reports.save_report({
         "as_of": req.as_of,
         "focus": req.focus,
@@ -141,13 +141,14 @@ def save_report(request: Request, req: SaveReportRequest):
         "emotion_score": req.emotion_score,
         "emotion_label": req.emotion_label,
     })
-    # 推送到飞书(可选): 与定时复盘共用同一开关 review_push_enabled 与 _maybe_push_review。
+    # 推送门控: manual 模式需显式 push=True; auto 模式保持归档即推。
     # 内部 try/except 静默降级, 不影响归档返回值。
-    from app.jobs.daily_pipeline import _maybe_push_review
-    _maybe_push_review(req.content, {
-        "as_of": req.as_of,
-        "emotion_label": req.emotion_label,
-    })
+    if push or preferences.get_review_push_mode() == "auto":
+        from app.jobs.daily_pipeline import _maybe_push_review
+        _maybe_push_review(req.content, {
+            "as_of": req.as_of,
+            "emotion_label": req.emotion_label,
+        })
     return {"ok": True, "report": report}
 
 

--- a/backend/app/api/strategy.py
+++ b/backend/app/api/strategy.py
@@ -560,7 +560,11 @@ def _set_meta_string_field(block: str, field: str, value: str) -> str:
     )
     if count:
         return next_block
+    return _insert_meta_field(block, field, _py_string(value))
 
+
+def _insert_meta_field(block: str, field: str, value_repr: str) -> str:
+    """在 META 字典末尾(闭合 `}` 之前)插入一个字段。value_repr 已是 Python 源码。"""
     lines = block.splitlines(keepends=True)
     key_indent = None
     for line in lines:
@@ -585,7 +589,33 @@ def _set_meta_string_field(block: str, field: str, value: str) -> str:
             newline = lines[i][len(body):]
             lines[i] = body.rstrip() + "," + newline
         break
-    lines.insert(insert_at, f'{key_indent}"{field}": {_py_string(value)},\n')
+    lines.insert(insert_at, f'{key_indent}"{field}": {value_repr},\n')
+    return "".join(lines)
+
+
+def _set_meta_bool_field(code: str, field: str, value: bool) -> str:
+    """设置 META 里的布尔字段(纯文本改写, 不执行代码): 存在则替换, 不存在则追加。"""
+    found = find_meta_assignment(code)
+    if found is None:
+        raise ValueError("找不到 META 字典")
+    meta_node = found[1]
+    lines = code.splitlines(keepends=True)
+    start = meta_node.lineno - 1
+    end = meta_node.end_lineno or meta_node.lineno
+    block = "".join(lines[start:end])
+
+    value_repr = "True" if value else "False"
+    key_pattern = re.compile(
+        rf"(?m)^(\s*[\"']{re.escape(field)}[\"']\s*:\s*)(?:True|False|[\"'][^\"'\n]*[\"'])"
+    )
+    next_block, count = key_pattern.subn(
+        lambda m: f"{m.group(1)}{value_repr}",
+        block,
+        count=1,
+    )
+    if not count:
+        next_block = _insert_meta_field(block, field, value_repr)
+    lines[start:end] = next_block.splitlines(keepends=True)
     return "".join(lines)
 
 
@@ -732,6 +762,13 @@ def _save_strategy_code(req: StrategyCodeSaveRequest, request: Request, *, legac
     path.parent.mkdir(parents=True, exist_ok=True)
 
     prepared = _prepare_strategy_code(req)
+
+    # AI 新建策略默认草稿态(research_only=True): 不进公开列表、不可运行, 需显式 publish。
+    # 仅 create 注入; update 保留既有 research_only, 避免静默取消已发布状态。
+    if expected_source == "ai" and (legacy_ai_path or req.mode == "create"):
+        prepared["code"] = _set_meta_bool_field(prepared["code"], "research_only", True)
+        prepared["meta"] = AIStrategyGenerator._extract_meta(prepared["code"])
+
     previous_code = path.read_text(encoding="utf-8") if path.exists() else None
     path.write_text(prepared["code"], encoding="utf-8")
 
@@ -763,6 +800,7 @@ def _save_strategy_code(req: StrategyCodeSaveRequest, request: Request, *, legac
         "source": expected_source,
         "path": str(path),
         "meta": prepared["meta"],
+        "research_only": prepared["meta"].get("research_only", False),
     }
 
 
@@ -1060,6 +1098,45 @@ async def ai_save(req: AISaveRequest, request: Request):
         return {"ok": True, "path": result["path"]}
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.post("/{strategy_id}/publish")
+def publish_ai_strategy(strategy_id: str, request: Request):
+    """把 research_only 的 AI 草稿策略翻转为公开(research_only=False)。
+
+    门 = 人的显式动作: 只有 AI 来源且仍处于草稿态的策略才能被发布。
+    发布后即进入公开列表、可 run、可监控。
+    """
+    sid = _validate_strategy_id(strategy_id)
+    engine = _get_engine(request)
+    try:
+        s = engine.get(sid)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=f"策略 {sid} 不存在") from e
+
+    if s.source != "ai":
+        raise HTTPException(status_code=400, detail="仅 AI 策略可经发布端点上线")
+    if not s.meta.get("research_only"):
+        raise HTTPException(status_code=400, detail="该策略已是公开状态")
+
+    path = s.file_path
+    if path is None:
+        raise HTTPException(status_code=400, detail="策略源文件路径无效, 无法发布")
+    previous_code = path.read_text(encoding="utf-8")
+    path.write_text(_set_meta_bool_field(previous_code, "research_only", False), encoding="utf-8")
+
+    try:
+        engine.reload()
+        loaded = engine.get(sid)
+        if loaded.meta.get("research_only"):
+            raise ValueError("发布后策略仍为草稿态")
+    except Exception as e:
+        _restore_strategy_file(path, previous_code)
+        engine.reload()
+        raise ValueError(f"策略发布失败: {e}") from e
+
+    _invalidate_strategy_runtime(request)
+    return {"ok": True, "strategy_id": sid}
 
 
 @router.delete("/{strategy_id}")

--- a/backend/app/jobs/daily_pipeline.py
+++ b/backend/app/jobs/daily_pipeline.py
@@ -944,9 +944,11 @@ async def _run_scheduled_review(repo) -> None:
             quote_service.push_review_event(json.dumps(
                 {"type": "done", "archived": True}, ensure_ascii=False))
 
-        # 推送到飞书(可选): 运行时读取配置, 用户改设置下次触发即生效。
+        # 推送门控: review_push_mode=manual 时定时复盘只归档不推送,
+        # 由用户对当日报告显式确认后才推; auto 时保持既有自动推送行为。
         # 失败静默降级, 不影响已归档的报告。
-        _maybe_push_review(content, meta)
+        if _prefs.get_review_push_mode() == "auto":
+            _maybe_push_review(content, meta)
     except Exception as e:  # noqa: BLE001
         logger.exception("scheduled review failed: %s", e)
         # 兜底: 异常时通知前端停止「生成中」状态, 避免页面卡在 streaming

--- a/backend/app/services/preferences.py
+++ b/backend/app/services/preferences.py
@@ -684,6 +684,26 @@ def set_review_push_channels(channels: list[str]) -> list[str]:
     return cleaned
 
 
+REVIEW_PUSH_MODES = frozenset({"auto", "manual"})
+
+
+def get_review_push_mode() -> str:
+    """复盘推送触发方式: auto=归档后自动推; manual=仅显式 push。默认 manual。
+
+    定时复盘与手动保存复盘共用此开关。manual 时定时路径只归档不推送,
+    手动路径需 save_report 显式传 push=True 才推。
+    """
+    mode = load().get("review_push_mode", "manual")
+    return mode if mode in REVIEW_PUSH_MODES else "manual"
+
+
+def set_review_push_mode(mode: str) -> str:
+    """保存复盘推送触发方式, 白名单外的值回退 manual。"""
+    mode = mode if mode in REVIEW_PUSH_MODES else "manual"
+    save({"review_push_mode": mode})
+    return mode
+
+
 
 # ===== 实时监控 =====
 

--- a/backend/scripts/demo_ai_publish_gate.py
+++ b/backend/scripts/demo_ai_publish_gate.py
@@ -1,0 +1,98 @@
+"""AI 策略发布闸最小 demo — 验证「草稿 → 显式发布」门 与 复盘推送模式。
+
+运行方式(在 backend/ 目录下, 已安装依赖):
+    python scripts/demo_ai_publish_gate.py
+
+不启动服务, 直接调用内部函数(与单测同款 SimpleNamespace 请求桩), 全程落在临时目录。
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.api.strategy import (
+    StrategyCodeSaveRequest,
+    _save_strategy_code,
+    publish_ai_strategy,
+)
+from app.services import preferences
+from app.strategy.engine import StrategyEngine
+
+_CODE = '''"""demo 策略"""
+import polars as pl
+
+META = {
+    "id": "ai_demo",
+    "name": "demo",
+    "description": "demo",
+    "tags": [],
+    "params": [],
+    "scoring": {},
+}
+
+ENTRY_SIGNALS = []
+EXIT_SIGNALS = []
+STOP_LOSS = -0.05
+MAX_HOLD_DAYS = 20
+
+def filter(df: pl.DataFrame, params: dict) -> pl.Expr:
+    return pl.lit(True)
+'''
+
+
+def _request(data_dir: Path, engine: StrategyEngine):
+    repo = SimpleNamespace(store=SimpleNamespace(data_dir=data_dir))
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(repo=repo, strategy_engine=engine)))
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        data_dir = Path(tmp)
+        engine = StrategyEngine(strategy_dirs=[data_dir / "strategies" / "custom",
+                                               data_dir / "strategies" / "ai"])
+        request = _request(data_dir, engine)
+
+        print("== 1. 保存 AI 策略(默认草稿) ==")
+        result = _save_strategy_code(StrategyCodeSaveRequest(
+            strategy_id="ai_demo", target_source="ai", mode="create",
+            code=_CODE, name="demo",
+        ), request)
+        public = [m["id"] for m in engine.list_strategies() if not m.get("research_only")]
+        print(f"   research_only={result['research_only']} (期望 True)")
+        print(f"   公开列表={public} (期望不含 ai_demo)")
+
+        print("== 2. 显式 publish ==")
+        print("   ", publish_ai_strategy("ai_demo", request))
+        print(f"   research_only={engine.get('ai_demo').meta['research_only']} (期望 False)")
+
+        print("== 3. 重复 publish 应被拒 ==")
+        try:
+            publish_ai_strategy("ai_demo", request)
+        except Exception as exc:  # noqa: BLE001
+            print(f"   被拒: {exc}")
+
+        print("== 4. 自定义策略 publish 应被拒 ==")
+        _save_strategy_code(StrategyCodeSaveRequest(
+            strategy_id="custom_demo", target_source="custom", mode="create",
+            code=_CODE.replace("ai_demo", "custom_demo"), name="custom",
+        ), request)
+        try:
+            publish_ai_strategy("custom_demo", request)
+        except Exception as exc:  # noqa: BLE001
+            print(f"   被拒: {exc}")
+
+    # 复盘推送模式(隔离到临时文件, 不污染真实偏好)
+    prefs_path = Path(tempfile.mkdtemp()) / "preferences.json"
+    preferences._path = lambda: prefs_path  # noqa: SLF001 - demo 隔离
+    preferences._invalidate_cache()
+    print("== 5. 复盘推送模式 review_push_mode ==")
+    print(f"   默认 = {preferences.get_review_push_mode()} (期望 manual)")
+    print(f"   设为 auto = {preferences.set_review_push_mode('auto')}")
+    print(f"   非法值回退 = {preferences.set_review_push_mode('bogus')} (期望 manual)")
+
+    print("\n全部通过")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_review_push_mode.py
+++ b/backend/tests/test_review_push_mode.py
@@ -1,0 +1,32 @@
+"""复盘推送触发方式 review_push_mode 测试 — auto/manual 白名单与默认值。"""
+from __future__ import annotations
+
+import pytest
+
+from app.services import preferences
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    path = tmp_path / "preferences.json"
+    monkeypatch.setattr(preferences, "_path", lambda: path)
+    preferences._invalidate_cache()
+    yield path
+    preferences._invalidate_cache()
+
+
+def test_review_push_mode_defaults_to_manual():
+    assert preferences.get_review_push_mode() == "manual"
+
+
+def test_set_and_get_review_push_mode():
+    assert preferences.set_review_push_mode("auto") == "auto"
+    assert preferences.get_review_push_mode() == "auto"
+
+    assert preferences.set_review_push_mode("manual") == "manual"
+    assert preferences.get_review_push_mode() == "manual"
+
+
+def test_set_review_push_mode_rejects_invalid_value():
+    assert preferences.set_review_push_mode("bogus") == "manual"
+    assert preferences.get_review_push_mode() == "manual"

--- a/backend/tests/test_strategy_publish.py
+++ b/backend/tests/test_strategy_publish.py
@@ -1,0 +1,156 @@
+"""AI 策略草稿门测试 — 保存即 research_only 草稿, 显式 publish 才公开。
+
+覆盖:
+  1. AI 策略保存后为草稿态(research_only=True), 不进公开列表
+  2. 自定义策略不受门控(零回归)
+  3. publish 翻转草稿 → 公开
+  4. publish 拒绝非 AI 策略 / 已公开策略
+  5. _set_meta_bool_field 的插入与替换两条路径
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.strategy import (
+    StrategyCodeSaveRequest,
+    _save_strategy_code,
+    _set_meta_bool_field,
+    publish_ai_strategy,
+)
+from app.strategy.ai_generator import AIStrategyGenerator
+from app.strategy.engine import StrategyEngine
+
+
+def _code(strategy_id: str, name: str = "测试策略") -> str:
+    return f'''"""测试策略"""
+import polars as pl
+
+META = {{
+    "id": "{strategy_id}",
+    "name": "{name}",
+    "description": "测试描述",
+    "tags": ["测试"],
+    "params": [],
+    "scoring": {{}},
+}}
+
+ENTRY_SIGNALS = []
+EXIT_SIGNALS = []
+STOP_LOSS = -0.05
+MAX_HOLD_DAYS = 20
+
+RULES = """
+1. 测试规则一
+2. 测试规则二
+3. 测试规则三
+"""
+
+def filter(df: pl.DataFrame, params: dict) -> pl.Expr:
+    return pl.lit(True)
+'''
+
+
+def _request(tmp_path):
+    ai_dir = tmp_path / "strategies" / "ai"
+    custom_dir = tmp_path / "strategies" / "custom"
+    engine = StrategyEngine(strategy_dirs=[custom_dir, ai_dir])
+    repo = SimpleNamespace(store=SimpleNamespace(data_dir=tmp_path))
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(repo=repo, strategy_engine=engine)))
+
+
+def _save_ai(tmp_path, sid: str) -> dict:
+    """保存一个 AI 来源的新建策略, 返回 (request, save_result)。"""
+    request = _request(tmp_path)
+    req = StrategyCodeSaveRequest(
+        strategy_id=sid,
+        target_source="ai",
+        mode="create",
+        code=_code("wrong"),
+        name="AI 草稿",
+    )
+    return request, _save_strategy_code(req, request)
+
+
+def test_ai_strategy_saved_as_research_only_draft(tmp_path):
+    request, result = _save_ai(tmp_path, "ai_draft")
+
+    assert result["ok"] is True
+    assert result["research_only"] is True
+    assert request.app.state.strategy_engine.get("ai_draft").meta["research_only"] is True
+    # 草稿态不进公开列表(list_strategies 对 research_only 过滤)
+    public_ids = {
+        meta["id"]
+        for meta in request.app.state.strategy_engine.list_strategies()
+        if not meta.get("research_only")
+    }
+    assert "ai_draft" not in public_ids
+
+
+def test_custom_strategy_not_gated(tmp_path):
+    request = _request(tmp_path)
+    req = StrategyCodeSaveRequest(
+        strategy_id="custom_draft",
+        target_source="custom",
+        mode="create",
+        code=_code("wrong"),
+        name="自定义策略",
+    )
+
+    result = _save_strategy_code(req, request)
+
+    assert result["research_only"] is False
+    assert request.app.state.strategy_engine.get("custom_draft").meta.get("research_only") is not True
+
+
+def test_publish_ai_strategy_flips_to_public(tmp_path):
+    request, _ = _save_ai(tmp_path, "ai_draft")
+
+    result = publish_ai_strategy("ai_draft", request)
+
+    assert result == {"ok": True, "strategy_id": "ai_draft"}
+    assert request.app.state.strategy_engine.get("ai_draft").meta["research_only"] is False
+
+
+def test_publish_rejects_non_ai_strategy(tmp_path):
+    request = _request(tmp_path)
+    req = StrategyCodeSaveRequest(
+        strategy_id="custom_pub",
+        target_source="custom",
+        mode="create",
+        code=_code("wrong"),
+        name="自定义策略",
+    )
+    _save_strategy_code(req, request)
+
+    with pytest.raises(HTTPException) as exc_info:
+        publish_ai_strategy("custom_pub", request)
+
+    assert exc_info.value.status_code == 400
+    assert "AI 策略" in exc_info.value.detail
+
+
+def test_publish_rejects_already_public(tmp_path):
+    request, _ = _save_ai(tmp_path, "ai_draft")
+    publish_ai_strategy("ai_draft", request)
+
+    with pytest.raises(HTTPException) as exc_info:
+        publish_ai_strategy("ai_draft", request)
+
+    assert exc_info.value.status_code == 400
+    assert "已是公开状态" in exc_info.value.detail
+
+
+def test_set_meta_bool_field_insert_then_replace():
+    code = 'META = {\n    "id": "x",\n}\n'
+
+    inserted = _set_meta_bool_field(code, "research_only", True)
+    assert '"research_only": True' in inserted
+    assert AIStrategyGenerator._extract_meta(inserted)["research_only"] is True
+
+    replaced = _set_meta_bool_field(inserted, "research_only", False)
+    assert '"research_only": False' in replaced
+    assert '"research_only": True' not in replaced
+    assert AIStrategyGenerator._extract_meta(replaced)["research_only"] is False


### PR DESCRIPTION
**Problem**

AI 生成的产物目前在生成后会自动进入公开状态，缺少一道「人工确认」的门：

1. AI 策略保存后立即出现在公开列表，可被运行 / 监控，但 AI 生成的代码未经人工复核，可能引入错误或不符预期的策略。
2. 定时复盘在归档后默认自动推送到外部渠道，用户无法先审阅再决定是否外发，可能把未审阅的内容推给他人。

**Solution**

复用已贯穿全链路（公开列表过滤、详情 404、挖矿禁发）的 `research_only` 标志，把「公开」这个动作从「生成即公开」改为「显式确认」：

1. AI 策略：保存时注入 `research_only=True` 作为草稿态，不进公开列表、不可运行；新增 `POST /{strategy_id}/publish` 端点，由人显式调用后翻转 `research_only=False` 才上线。
2. AI 复盘推送：新增偏好项 `review_push_mode`（默认 `manual`）。`manual` 时定时复盘只归档不推送，手动保存需显式传 `push=True` 才推；`auto` 保持既有行为。

选择复用 `research_only` 而非新增字段，是因为它已在列表 / 详情 / 挖矿三处生效，只需在「写入」与「翻转」两个点接入，改动面最小且不破坏既有语义。META 改写用「AST 定位 + 正则替换」的纯文本方式，不执行策略代码。

**Changes**

- `app/api/strategy.py`：新增 `_set_meta_bool_field`（布尔字段插入 / 替换），AI 新建策略注入 `research_only=True`；新增 `POST /{strategy_id}/publish` 端点。
- `app/services/preferences.py`：新增 `review_push_mode` 偏好项与 `get_review_push_mode` / `set_review_push_mode`。
- `app/jobs/daily_pipeline.py`：定时复盘仅在 `review_push_mode=auto` 时推送。
- `app/api/market_recap.py`：`save_report` 增加 `push` 参数，`push=True` 或 `auto` 才推送。
- 新增测试 `tests/test_strategy_publish.py`、`tests/test_review_push_mode.py`，新增 demo 脚本 `scripts/demo_ai_publish_gate.py`。

**Testing**

- 新增 2 个测试文件共 9 个用例：AI 保存即草稿、自定义零回归、publish 翻转、拒绝非 AI / 已公开、`_set_meta_bool_field` 插入 / 替换；`review_push_mode` 默认 manual、set/get 往返、非法值回退。
- demo 脚本 `python scripts/demo_ai_publish_gate.py` 可端到端验证「草稿 → 发布 → 重复拒绝 → 自定义拒绝 → 推送模式往返」。
- 本机未装 polars / fastapi 等依赖，测试按仓库既有风格（`SimpleNamespace` 请求桩、`tmp_path`、`StrategyEngine(strategy_dirs=...)`）编写，已通过 `python -m py_compile` 语法校验，但尚未实跑。

**Notes for Reviewer**

- 有意不改 `ai_generator.py`：其 `_extract_meta` 用 `ast.literal_eval` 返回全量 dict，`research_only` 天然保留，无需改动。
- `publish` 写入 `False` 后会 `engine.reload()` 二次校验，失败则回滚源文件，避免「写盘成功但引擎未加载」的脏状态。
- 门控范围覆盖所有 `source == "ai"` 的策略（而非仅 `ai_` 前缀），已在设计阶段确认。
- 复盘推送默认值从「自动推送」变为「manual 需确认」——这是有意为之的默认行为变更，请确认是否需要在 release note 中标注。
