### PR TITLE
fix(intraday): handle missing minute amount

### DIFF
--- a/frontend/src/components/EChartsIntraday.tsx
+++ b/frontend/src/components/EChartsIntraday.tsx
@@ -30,7 +30,8 @@ interface Props {
   showAvgLine?: boolean
 }
 
-function fmtAmt(v: number): string {
+function fmtAmt(v: number | null | undefined): string {
+  if (v == null || !Number.isFinite(v)) return '—'
   if (v >= 1_000_000_000) return `${(v / 1_000_000_000).toFixed(2)}亿`
   if (v >= 10_000) return `${(v / 10_000).toFixed(0)}万`
   return v.toFixed(0)

--- a/frontend/src/components/EChartsMultiDayIntraday.tsx
+++ b/frontend/src/components/EChartsMultiDayIntraday.tsx
@@ -29,7 +29,8 @@ interface InfoPoint {
   prevClose: number | null
 }
 
-function formatAmount(value: number): string {
+function formatAmount(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return '—'
   if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(2)}亿`
   if (value >= 10_000) return `${(value / 10_000).toFixed(0)}万`
   return value.toFixed(0)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -208,7 +208,7 @@ export interface MinuteKlineRow {
   low: number
   close: number
   volume: number
-  amount: number
+  amount: number | null
 }
 
 export interface MinuteKlineSession {

--- a/frontend/src/lib/intraday-chart.ts
+++ b/frontend/src/lib/intraday-chart.ts
@@ -11,10 +11,15 @@ export function computeIntradayAverage(data: MinuteKlineRow[]): number[] {
   const result: number[] = []
   let amount = 0
   let volume = 0
+  let hasAmount = true
   for (const row of data) {
-    amount += row.amount
+    if (typeof row.amount === 'number' && Number.isFinite(row.amount)) {
+      amount += row.amount
+    } else {
+      hasAmount = false
+    }
     volume += row.volume * 100
-    result.push(volume > 0 ? amount / volume : row.close)
+    result.push(hasAmount && volume > 0 ? amount / volume : row.close)
   }
   return result
 }


### PR DESCRIPTION
## 问题

分钟行情数据源可能无法提供可靠的分钟成交额，此时 `amount` 会是 `null`。当前前端仍将其声明为必填数字，并在单日分时信息条中直接调用 `toFixed()`，导致整个页面抛出 `Cannot read properties of null (reading toFixed)`。累计均价计算也会被空值污染。

## 修复

- 将 `MinuteKlineRow.amount` 的前端契约改为 `number | null`
- 单日和多日分时的信息条在成交额缺失或非有限时显示 `—`
- 成交额不完整时，均价线回退到对应分钟收盘价，避免生成错误或非有限的累计均价
- 成交额正常的数据源保持原有展示和均价计算不变

## 验证

- `corepack pnpm build`
- `git diff --check`
- 使用返回 `amount: null` 的分钟数据源手工验证：页面保持可用，成交额显示为 `—`，控制台不再出现 `toFixed` 异常

## 风险与回滚

改动仅影响分钟成交额缺失或非有限的记录。若需回滚，可直接回退本提交；正常数字成交额的路径没有行为变化。