### PR TITLE
fix(intraday): hide average when amount is unavailable

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -151,7 +151,7 @@ class MyProvider:
 
     def get_minute(self, symbols, start_time, end_time, asset_type="stock",
                    on_chunk_done=None, freq="1m") -> pl.DataFrame:
-        """分钟K: [symbol, datetime(北京墙钟), open, high, low, close, volume, amount]"""
+        """分钟K: [symbol, datetime(北京墙钟), open, high, low, close, volume, amount(元, 可空)]"""
 
     def get_intraday_batch(self, symbols, count=300, asset_type="stock") -> pl.DataFrame:
         """(声明 full_minute 数据集时实现) 全量分钟修复轮: 给定标的当日 1 分钟K,
@@ -207,6 +207,9 @@ provider 不应自行切换或回退到其他数据源。
 `date` 语义对齐；不要返回 UTC 或带时区的时间。前端分时图按交易时段时轴
 （09:30–11:30 / 13:00–15:00）映射每根K线，UTC 口径的帧会导致全部点位落在时轴外、
 分时图空白。
+
+`amount` 单位为元；数据源无法提供可靠的分钟成交额时应返回 `null`，不得伪造。
+成交额缺失后无法继续计算累计成交均价，前端会停止绘制后续均价线并显示 `—`。
 
 入口守卫（`kline_sync._enforce_minute_beijing_wallclock`）对所有分钟源强制归一：
 带时区 → 自动换算成北京墙钟；naive 但整体呈 UTC 特征（如 01:30）→ 自动 +8 纠偏并

--- a/frontend/src/components/EChartsIntraday.tsx
+++ b/frontend/src/components/EChartsIntraday.tsx
@@ -63,7 +63,7 @@ function getLimitPrices(prevClose: number, priceLimit?: PriceLimitInfo): {
   return { limitUp, limitDown, upPct, downPct }
 }
 
-function buildOption(data: MinuteKlineRow[], prevClose: number | undefined, avgPrices: number[], lineColor: string, areaColor: string, yMode: YMode, ct: ChartTheme, priceLimit?: PriceLimitInfo, showLimitLines = true, showAvgLine = true, priceLines: Props['priceLines'] = []): EChartsOption {
+function buildOption(data: MinuteKlineRow[], prevClose: number | undefined, avgPrices: (number | null)[], lineColor: string, areaColor: string, yMode: YMode, ct: ChartTheme, priceLimit?: PriceLimitInfo, showLimitLines = true, showAvgLine = true, priceLines: Props['priceLines'] = []): EChartsOption {
   // 将数据映射到全天时间轴上的正确位置
   const timeIndexMap = new Map(FULL_DAY_TIMES.map((t, i) => [t, i]))
   const closes = new Array(FULL_DAY_TIMES.length).fill(null) as (number | null)[]
@@ -601,7 +601,7 @@ export function EChartsIntraday({
               </span>
               {showAvgLine && <span className="flex items-center gap-x-1">
                 <span style={{ display: 'inline-block', width: 14, height: 2, background: THEME.avgLine }} />
-                <span style={{ color: THEME.avgLine }}>{avg?.toFixed(2)}</span>
+                <span style={{ color: THEME.avgLine }}>{avg != null ? avg.toFixed(2) : '—'}</span>
               </span>}
               <span className="text-muted">量</span>
               <span className="text-secondary">{d.volume.toFixed(0)}</span>

--- a/frontend/src/components/EChartsMultiDayIntraday.tsx
+++ b/frontend/src/components/EChartsMultiDayIntraday.tsx
@@ -25,7 +25,7 @@ interface Props {
 interface InfoPoint {
   date: string
   row: MinuteKlineRow
-  average: number
+  average: number | null
   prevClose: number | null
 }
 
@@ -65,7 +65,7 @@ function buildModel(sessions: MinuteKlineSession[]) {
     }
 
     const averagePrices = computeIntradayAverage(session.rows)
-    const rowsByTime = new Map<string, { row: MinuteKlineRow; average: number }>()
+    const rowsByTime = new Map<string, { row: MinuteKlineRow; average: number | null }>()
     session.rows.forEach((row, index) => {
       rowsByTime.set(formatMinuteTime(row.datetime), {
         row,
@@ -105,7 +105,8 @@ function buildModel(sessions: MinuteKlineSession[]) {
         },
       })
       prevRef = row.close
-      priceValues.push(row.low, row.high, average)
+      priceValues.push(row.low, row.high)
+      if (average != null) priceValues.push(average)
       pointByIndex.set(index, {
         date: session.date,
         row,
@@ -422,7 +423,7 @@ export function EChartsMultiDayIntraday({
               {changePct != null && (
                 <span style={{ color: infoColor }}>{changePct >= 0 ? '+' : ''}{changePct.toFixed(2)}%</span>
               )}
-              <span className="text-muted">均价</span><span style={{ color: COLORS.average }}>{info.average.toFixed(2)}</span>
+              <span className="text-muted">均价</span><span style={{ color: COLORS.average }}>{info.average != null ? info.average.toFixed(2) : '—'}</span>
               <span className="text-muted">量</span><span className="text-secondary">{info.row.volume.toFixed(0)}</span>
               <span className="text-muted">额</span><span className="text-secondary">{formatAmount(info.row.amount)}</span>
             </>

--- a/frontend/src/lib/intraday-chart.ts
+++ b/frontend/src/lib/intraday-chart.ts
@@ -7,8 +7,8 @@ export function formatMinuteTime(datetime: string): string {
   return `${match[1]}:${match[2]}`
 }
 
-export function computeIntradayAverage(data: MinuteKlineRow[]): number[] {
-  const result: number[] = []
+export function computeIntradayAverage(data: MinuteKlineRow[]): (number | null)[] {
+  const result: (number | null)[] = []
   let amount = 0
   let volume = 0
   let hasAmount = true
@@ -19,7 +19,7 @@ export function computeIntradayAverage(data: MinuteKlineRow[]): number[] {
       hasAmount = false
     }
     volume += row.volume * 100
-    result.push(hasAmount && volume > 0 ? amount / volume : row.close)
+    result.push(hasAmount && volume > 0 ? amount / volume : null)
   }
   return result
 }


### PR DESCRIPTION
## 问题与复现

这是 #258 复审建议的后续修复。#258 避免了分钟 `amount=null` 导致的崩溃，但累计均价在成交额缺失后回退为每分钟收盘价。对于整日不提供成交额的数据源，黄色均价线会与价格线完全重合，信息条中的现价和均价也始终相同，形成“存在真实均价”的误导。

## 根因

`computeIntradayAverage()` 在累计成交额不可用或累计成交量为零时返回 `row.close`。这保证了返回值是数字，却把“无法计算”错误表达成了“均价等于现价”。

## 解决方案

- 将均价计算结果改为 `number | null`
- 成交额完整时继续按累计成交额 / 累计成交量计算
- 从首个缺失或非有限成交额开始返回 `null`，停止绘制后续均价线
- 单日和多日分时的信息条在均价不可用时显示 `—`
- 多日图的价格范围计算忽略空均价
- 插件开发文档明确分钟 `amount` 单位为元且允许为空；为空时不得伪造均价

## 兼容性

- 数字成交额的数据源计算和展示保持不变
- 不修改后端 API、缓存、持久化或查询键，无数据迁移
- 单日和多日分时使用同一可空均价契约

## 性能

计算复杂度仍为单次 O(n) 遍历，没有新增请求、缓存或渲染循环。

## 验证

- `corepack pnpm build`：通过（TypeScript + Vite，2740 modules）
- `git diff --check`：通过
- 函数级样本检查：
  - 成交额完整：`[10, 10.666666666666666]`
  - 从首根缺失：`[null, null]`
  - 中途缺失：`[10, null, null]`

## 界面变化

成交额为空时不再出现与价格线重合的黄色均价线；单日和多日信息条的均价位置显示 `—`。成交额完整时界面不变。

## 风险与回滚

唯一行为变化是“不可计算的均价”从收盘价改为空值。回退本提交即可恢复 #258 合并时的降级行为。