### PR TITLE
fix(ext-data): CSV 编码转换保留原始换行, 避免最后一列被推断为字符串

### DIFF
--- a/backend/app/services/ext_data.py
+++ b/backend/app/services/ext_data.py
@@ -477,7 +477,13 @@ def ensure_utf8_csv(file_path: Path) -> Path:
         except UnicodeDecodeError:
             continue
         out_path = file_path.with_suffix(file_path.suffix + ".utf8")
-        out_path.write_text(text, encoding="utf-8")
+        # newline="" 关闭写入时的换行转换。默认转换在 Windows 上把文本里的 \n
+        # 写成 \r\n，源文件本来就是 CRLF 时就变成 \r\r\n，多出来的 \r 被 Polars
+        # 当作最后一列内容的一部分：列名变成 "收盘价\r"，每行的值变成 "12.34\r"，
+        # 该列于是被推断为字符串而不是数值。本函数针对的同花顺/东财/通达信和
+        # Windows Excel 导出文件用的正是 CRLF。
+        with out_path.open("w", encoding="utf-8", newline="") as f:
+            f.write(text)
         logger.info("CSV 编码转换 %s → %s (%s)", file_path.name, out_path.name, enc)
         return out_path
     # 都无法解码：返回原路径，让 Polars 抛出更精确的原始错误

--- a/backend/tests/test_ext_csv_transcode_newline.py
+++ b/backend/tests/test_ext_csv_transcode_newline.py
@@ -1,0 +1,83 @@
+"""CSV 编码转换的换行保真回归测试。
+
+ensure_utf8_csv 把 GBK 系 CSV 转成 UTF-8 再交给 Polars。转换本身用
+`write_text`，默认换行转换在 Windows 上把文本里的 \n 写成 \r\n；源文件本来
+就是 CRLF 时结果是 \r\r\n。多出来的 \r 会落在最后一列，使列名带上 \r、每行
+的值也带上 \r，该列于是从数值被推断成字符串。
+
+而本函数针对的正是同花顺 / 东财 / 通达信和 Windows 中文 Excel 导出的文件，
+这些工具导出的就是 CRLF，所以这条路径上的文件基本都会命中。
+
+判据取“同一份内容的 UTF-8 版本”：它不经过转换，是这份数据本该被解析成的
+样子，转换后的 GBK 版本必须与它逐列一致。纯本地文件操作，不需要数据源。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+from app.services.ext_data import ensure_utf8_csv
+
+# 名称/代码/收盘价三列，CRLF 换行，最后一列是数值——受损时最容易看出来。
+CSV_TEXT = "名称,代码,收盘价\r\n浦发银行,600000,12.34\r\n招商银行,600036,45.67\r\n"
+
+
+def _read(path: Path) -> pl.DataFrame:
+    return pl.read_csv(ensure_utf8_csv(path), infer_schema_length=10000)
+
+
+def test_gbk_crlf_csv_parses_the_same_as_its_utf8_twin(tmp_path: Path) -> None:
+    gbk = tmp_path / "gbk.csv"
+    gbk.write_bytes(CSV_TEXT.encode("gb18030"))
+    utf8 = tmp_path / "utf8.csv"
+    utf8.write_bytes(CSV_TEXT.encode("utf-8"))
+
+    converted = _read(gbk)
+    untouched = _read(utf8)
+
+    # UTF-8 那份原样返回，不经过转换，所以它就是判据。
+    assert converted.columns == untouched.columns
+    assert converted.dtypes == untouched.dtypes
+    assert converted.to_dicts() == untouched.to_dicts()
+
+
+def test_gbk_crlf_csv_keeps_the_last_column_numeric(tmp_path: Path) -> None:
+    path = tmp_path / "gbk.csv"
+    path.write_bytes(CSV_TEXT.encode("gb18030"))
+
+    df = _read(path)
+
+    # 列名不带 \r，最后一列仍是数值——修复前分别是 "收盘价\r" 和 String。
+    assert df.columns == ["名称", "代码", "收盘价"]
+    assert df["收盘价"].dtype == pl.Float64
+    assert df["收盘价"].to_list() == [12.34, 45.67]
+
+
+def test_transcoded_file_has_no_extra_carriage_return(tmp_path: Path) -> None:
+    path = tmp_path / "gbk.csv"
+    path.write_bytes(CSV_TEXT.encode("gb18030"))
+
+    out = ensure_utf8_csv(path)
+
+    assert out != path  # 确实走了转换分支
+    assert out.read_bytes().count(b"\r") == path.read_bytes().count(b"\r")
+
+
+def test_lf_only_source_stays_lf(tmp_path: Path) -> None:
+    # 反向保护：源文件是 LF 时不能被转换成 CRLF。
+    lf_text = CSV_TEXT.replace("\r\n", "\n")
+    path = tmp_path / "gbk_lf.csv"
+    path.write_bytes(lf_text.encode("gb18030"))
+
+    out = ensure_utf8_csv(path)
+
+    assert out.read_bytes().count(b"\r") == 0
+    assert _read(path)["收盘价"].dtype == pl.Float64
+
+
+def test_utf8_source_is_returned_unchanged(tmp_path: Path) -> None:
+    path = tmp_path / "utf8.csv"
+    path.write_bytes(CSV_TEXT.encode("utf-8"))
+
+    assert ensure_utf8_csv(path) == path


### PR DESCRIPTION
## 问题

`ensure_utf8_csv` 把 GBK 系 CSV 转成 UTF-8 交给 Polars，转换本身会破坏最后一列。

写出用的是 `out_path.write_text(text, encoding="utf-8")`，默认开启换行转换：文本里的 `\n` 在 Windows 上被写成 `\r\n`。源文件本来就是 CRLF 时，结果是 `\r\r\n`。多出来的那个 `\r` 落在最后一列里，列名变成 `"收盘价\r"`，每行的值变成 `"12.34\r"`，于是这一列从数值被推断成字符串。

而这个函数的 docstring 点名的正是「同花顺/东财/通达信和 Windows 中文 Excel 导出的 CSV」——这些工具导出的就是 CRLF，所以走到这条分支的文件基本都会命中。

## 实测

同一份内容，一份 GBK 一份 UTF-8。UTF-8 那份不经过转换，就是这份数据本该被解析成的样子：

```
--- GBK + CRLF（经过转换）
   columns: ['名称', '代码', '收盘价\r']
   dtypes : ['String', 'Int64', 'String']
   last col values: ['12.34\r', '45.67\r']

--- UTF-8 + CRLF（原样返回）
   columns: ['名称', '代码', '收盘价']
   dtypes : ['String', 'Int64', 'Float64']
   last col values: [12.34, 45.67]
```

同一份数据，只因为编码不同，收盘价一边是 `Float64` 一边是带回车的字符串。

字节层面：源文件 3 个 `\r`，转换后 6 个。源文件是 LF 的 GBK 文件同样受影响——转换后凭空多出 3 个 `\r`。

列名那一侧在 `/{config_id}/upload` 路径上会被 `_clean_col_names` 的 `.strip()` 顺手擦掉，所以此前不容易被发现；但值那一侧没有任何地方擦，数值列变字符串是照旧的。`app/services/ext_data.py` 的 `parse_upload_file` 不走 `_clean_col_names`，列名也是照旧带 `\r`。

## 改动

写出时 `newline=""`，关掉换行转换。只改这一处，行为上就是「转换只改编码，不改换行」。

有效转义原样解码，UTF-8 文件仍然原样返回，四种候选编码的尝试顺序不变。

## 测试

新增 `backend/tests/test_ext_csv_transcode_newline.py`，判据取「同一份内容的 UTF-8 版本」：

- GBK+CRLF 转换后与 UTF-8 版本逐列一致（列名、dtype、每行的值）
- GBK+CRLF 的最后一列仍是 `Float64`，列名不带 `\r`
- 转换后文件的 `\r` 数量与源文件相同
- 源文件是 LF 时转换后仍是 LF（反向保护）
- UTF-8 文件原样返回，不走转换分支

修复前 5 条里有 4 条失败：

```
E  assert ['名称', '代码', '收盘价\r'] == ['名称', '代码', '收盘价']
E  assert 6 == 3
E  assert 3 == 0
```

## 验证结果

Windows 11，`backend` 目录下实际执行：

```
python -m pytest tests/test_ext_csv_transcode_newline.py -q   → 5 passed
python -m pytest tests -q                                     → 1732 passed
```

修复前基线为 1727 passed，新增 5 条测试后为 1732，其余用例无变化。前端未改动，未执行 `pnpm build`。
