### PR TITLE
perf(ext-data): CSV 编码转换改为分块进行, 峰值内存不再随文件线性增长

### DIFF
--- a/backend/app/services/ext_data.py
+++ b/backend/app/services/ext_data.py
@@ -477,7 +477,13 @@ def ensure_utf8_csv(file_path: Path) -> Path:
         except UnicodeDecodeError:
             continue
         out_path = file_path.with_suffix(file_path.suffix + ".utf8")
-        out_path.write_text(text, encoding="utf-8")
+        # newline="" 关闭写入时的换行转换。默认转换在 Windows 上把文本里的 \n
+        # 写成 \r\n，源文件本来就是 CRLF 时就变成 \r\r\n，多出来的 \r 被 Polars
+        # 当作最后一列内容的一部分：列名变成 "收盘价\r"，每行的值变成 "12.34\r"，
+        # 该列于是被推断为字符串而不是数值。本函数针对的同花顺/东财/通达信和
+        # Windows Excel 导出文件用的正是 CRLF。
+        with out_path.open("w", encoding="utf-8", newline="") as f:
+            f.write(text)
         logger.info("CSV 编码转换 %s → %s (%s)", file_path.name, out_path.name, enc)
         return out_path
     # 都无法解码：返回原路径，让 Polars 抛出更精确的原始错误

--- a/backend/app/services/ext_data.py
+++ b/backend/app/services/ext_data.py
@@ -1,6 +1,7 @@
 """扩展数据服务 — 配置管理 + 文件解析 + Parquet 存储。"""
 from __future__ import annotations
 
+import codecs
 import copy
 import json
 import logging
@@ -453,6 +454,44 @@ def apply_config_mapping(df: pl.DataFrame, config: ExtConfig, data_dir: Path) ->
     return df
 
 
+# 编码识别与转换的分块大小，与 ext_data 上传写入用的块大小一致。
+_TRANSCODE_CHUNK_BYTES = 1024 * 1024
+
+
+def _decodes_as(file_path: Path, encoding: str) -> bool:
+    """整个文件能否按 encoding 完整解码，逐块判断，不把文件读进内存。"""
+    decoder = codecs.getincrementaldecoder(encoding)()
+    try:
+        with file_path.open("rb") as src:
+            while chunk := src.read(_TRANSCODE_CHUNK_BYTES):
+                decoder.decode(chunk)
+            decoder.decode(b"", True)  # 结尾处的半个字符也算解码失败
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def _transcode_to_utf8(file_path: Path, out_path: Path, encoding: str) -> bool:
+    """按 encoding 逐块转成 UTF-8 写入 out_path；解码失败则删除半成品返回 False。
+
+    增量解码器负责跨块边界的多字节字符：GBK 一个汉字两字节，正好落在块边界
+    上时前半截会被留到下一块，不会被误判成解码失败。
+    """
+    decoder = codecs.getincrementaldecoder(encoding)()
+    try:
+        with (
+            file_path.open("rb") as src,
+            out_path.open("w", encoding="utf-8", newline="") as dst,
+        ):
+            while chunk := src.read(_TRANSCODE_CHUNK_BYTES):
+                dst.write(decoder.decode(chunk))
+            dst.write(decoder.decode(b"", True))
+    except UnicodeDecodeError:
+        out_path.unlink(missing_ok=True)
+        return False
+    return True
+
+
 def ensure_utf8_csv(file_path: Path) -> Path:
     """确保 CSV 文件以 UTF-8 编码可读，非 UTF-8（如 GBK/GB18030）则转换。
 
@@ -463,27 +502,14 @@ def ensure_utf8_csv(file_path: Path) -> Path:
     返回值：若已是 UTF-8 则返回原路径；否则在同目录写一个 *.utf8 文件并返回它
     （调用方用临时目录，随目录一起清理）。
     """
-    raw = file_path.read_bytes()
     # BOM 处理：UTF-8-SIG 等带 BOM 文件直接交给 Polars（它认识 BOM）
-    try:
-        raw.decode("utf-8")
+    if _decodes_as(file_path, "utf-8"):
         return file_path  # 已是合法 UTF-8
-    except UnicodeDecodeError:
-        pass
     # 依次尝试常见中文编码，第一个能完整解码的即为命中
     for enc in ("gb18030", "gbk", "gb2312", "big5"):
-        try:
-            text = raw.decode(enc)
-        except UnicodeDecodeError:
-            continue
         out_path = file_path.with_suffix(file_path.suffix + ".utf8")
-        # newline="" 关闭写入时的换行转换。默认转换在 Windows 上把文本里的 \n
-        # 写成 \r\n，源文件本来就是 CRLF 时就变成 \r\r\n，多出来的 \r 被 Polars
-        # 当作最后一列内容的一部分：列名变成 "收盘价\r"，每行的值变成 "12.34\r"，
-        # 该列于是被推断为字符串而不是数值。本函数针对的同花顺/东财/通达信和
-        # Windows Excel 导出文件用的正是 CRLF。
-        with out_path.open("w", encoding="utf-8", newline="") as f:
-            f.write(text)
+        if not _transcode_to_utf8(file_path, out_path, enc):
+            continue
         logger.info("CSV 编码转换 %s → %s (%s)", file_path.name, out_path.name, enc)
         return out_path
     # 都无法解码：返回原路径，让 Polars 抛出更精确的原始错误

--- a/backend/tests/test_ext_csv_transcode_memory.py
+++ b/backend/tests/test_ext_csv_transcode_memory.py
@@ -1,0 +1,72 @@
+"""CSV 编码转换的内存占用回归测试。
+
+上传路径专门用 `_write_upload_capped` 分块落盘（issue #204），docstring 写明
+是为了「避免 `await file.read()` 把整个文件读入内存(大文件可能触发高内存占用、
+进程 OOM 或服务不可用)」。但紧接着的 `ensure_utf8_csv` 曾用 `read_bytes()`
+把同一个文件整个读回内存再整体解码，把这层保护抵消掉：50MB 上限的文件实测
+峰值 302MB（6.05×），解码出的 str 比原字节还大。
+
+这里用 tracemalloc 量峰值，判据是「与文件大小无关」而不是某个绝对值：转换
+按块进行时峰值只跟块大小有关，文件翻倍不会让峰值翻倍。
+"""
+from __future__ import annotations
+
+import tracemalloc
+from pathlib import Path
+
+from app.services.ext_data import ensure_utf8_csv
+
+_ROW = "浦发银行,600000,12.34,上海证券交易所\r\n"
+_HEADER = "名称,代码,收盘价,交易所\r\n"
+
+
+def _gbk_csv(path: Path, size_bytes: int) -> Path:
+    body = _ROW * (size_bytes // len(_ROW.encode("gb18030")))
+    path.write_bytes((_HEADER + body).encode("gb18030"))
+    return path
+
+
+def _peak_bytes(path: Path) -> int:
+    tracemalloc.start()
+    try:
+        ensure_utf8_csv(path)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    return peak
+
+
+def test_transcode_peak_memory_is_far_below_the_file(tmp_path: Path) -> None:
+    path = _gbk_csv(tmp_path / "big.csv", 8 * 1024 * 1024)
+
+    peak = _peak_bytes(path)
+
+    # 分块转换时峰值只跟块大小有关。修复前是文件的 6 倍。
+    assert peak < path.stat().st_size
+
+
+def test_transcode_peak_memory_does_not_grow_with_the_file(tmp_path: Path) -> None:
+    small = _peak_bytes(_gbk_csv(tmp_path / "small.csv", 2 * 1024 * 1024))
+    large = _peak_bytes(_gbk_csv(tmp_path / "large.csv", 8 * 1024 * 1024))
+
+    # 文件大 4 倍，峰值不应跟着涨：留一倍余量给解释器噪声。
+    assert large < small * 2
+
+
+def test_multibyte_character_on_a_chunk_boundary_survives(tmp_path: Path) -> None:
+    # GBK 一个汉字两字节，分块时可能正好被切开。增量解码器负责把半个字符
+    # 留到下一块；若改成逐块独立 decode，这里会解码失败并整份回退。
+    import polars as pl
+
+    from app.services.ext_data import _TRANSCODE_CHUNK_BYTES
+
+    filler = "浦发银行" * ((_TRANSCODE_CHUNK_BYTES // 8) + 1)
+    text = f"名称,备注\r\n浦发银行,{filler}\r\n"
+    path = tmp_path / "boundary.csv"
+    path.write_bytes(text.encode("gb18030"))
+    assert path.stat().st_size > _TRANSCODE_CHUNK_BYTES
+
+    df = pl.read_csv(ensure_utf8_csv(path), infer_schema_length=10000)
+
+    assert df.columns == ["名称", "备注"]
+    assert df["备注"][0] == filler

--- a/backend/tests/test_ext_csv_transcode_newline.py
+++ b/backend/tests/test_ext_csv_transcode_newline.py
@@ -1,0 +1,83 @@
+"""CSV 编码转换的换行保真回归测试。
+
+ensure_utf8_csv 把 GBK 系 CSV 转成 UTF-8 再交给 Polars。转换本身用
+`write_text`，默认换行转换在 Windows 上把文本里的 \n 写成 \r\n；源文件本来
+就是 CRLF 时结果是 \r\r\n。多出来的 \r 会落在最后一列，使列名带上 \r、每行
+的值也带上 \r，该列于是从数值被推断成字符串。
+
+而本函数针对的正是同花顺 / 东财 / 通达信和 Windows 中文 Excel 导出的文件，
+这些工具导出的就是 CRLF，所以这条路径上的文件基本都会命中。
+
+判据取“同一份内容的 UTF-8 版本”：它不经过转换，是这份数据本该被解析成的
+样子，转换后的 GBK 版本必须与它逐列一致。纯本地文件操作，不需要数据源。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+from app.services.ext_data import ensure_utf8_csv
+
+# 名称/代码/收盘价三列，CRLF 换行，最后一列是数值——受损时最容易看出来。
+CSV_TEXT = "名称,代码,收盘价\r\n浦发银行,600000,12.34\r\n招商银行,600036,45.67\r\n"
+
+
+def _read(path: Path) -> pl.DataFrame:
+    return pl.read_csv(ensure_utf8_csv(path), infer_schema_length=10000)
+
+
+def test_gbk_crlf_csv_parses_the_same_as_its_utf8_twin(tmp_path: Path) -> None:
+    gbk = tmp_path / "gbk.csv"
+    gbk.write_bytes(CSV_TEXT.encode("gb18030"))
+    utf8 = tmp_path / "utf8.csv"
+    utf8.write_bytes(CSV_TEXT.encode("utf-8"))
+
+    converted = _read(gbk)
+    untouched = _read(utf8)
+
+    # UTF-8 那份原样返回，不经过转换，所以它就是判据。
+    assert converted.columns == untouched.columns
+    assert converted.dtypes == untouched.dtypes
+    assert converted.to_dicts() == untouched.to_dicts()
+
+
+def test_gbk_crlf_csv_keeps_the_last_column_numeric(tmp_path: Path) -> None:
+    path = tmp_path / "gbk.csv"
+    path.write_bytes(CSV_TEXT.encode("gb18030"))
+
+    df = _read(path)
+
+    # 列名不带 \r，最后一列仍是数值——修复前分别是 "收盘价\r" 和 String。
+    assert df.columns == ["名称", "代码", "收盘价"]
+    assert df["收盘价"].dtype == pl.Float64
+    assert df["收盘价"].to_list() == [12.34, 45.67]
+
+
+def test_transcoded_file_has_no_extra_carriage_return(tmp_path: Path) -> None:
+    path = tmp_path / "gbk.csv"
+    path.write_bytes(CSV_TEXT.encode("gb18030"))
+
+    out = ensure_utf8_csv(path)
+
+    assert out != path  # 确实走了转换分支
+    assert out.read_bytes().count(b"\r") == path.read_bytes().count(b"\r")
+
+
+def test_lf_only_source_stays_lf(tmp_path: Path) -> None:
+    # 反向保护：源文件是 LF 时不能被转换成 CRLF。
+    lf_text = CSV_TEXT.replace("\r\n", "\n")
+    path = tmp_path / "gbk_lf.csv"
+    path.write_bytes(lf_text.encode("gb18030"))
+
+    out = ensure_utf8_csv(path)
+
+    assert out.read_bytes().count(b"\r") == 0
+    assert _read(path)["收盘价"].dtype == pl.Float64
+
+
+def test_utf8_source_is_returned_unchanged(tmp_path: Path) -> None:
+    path = tmp_path / "utf8.csv"
+    path.write_bytes(CSV_TEXT.encode("utf-8"))
+
+    assert ensure_utf8_csv(path) == path


### PR DESCRIPTION
> 基于 #262（同一函数的换行修复）。先合 #262 再看这个；单独 rebase 到 main 也可以，我来处理。

## 问题

上传路径专门做了分块落盘（issue #204），`_write_upload_capped` 的 docstring 写得很清楚：

> 避免一次性 `await file.read()` 把整个文件读入内存(大文件可能触发高内存占用、进程 OOM 或服务不可用)

而下一步 `ensure_utf8_csv` 把同一个文件整个读回内存：

```python
raw = file_path.read_bytes()      # 50MB 上限的文件，这里就是 50MB
...
text = raw.decode(enc)            # 再解出一份 str，GBK→UTF-8 还会变大
```

分块保护到此为止。真正决定内存占用的是编码转换这一步，而它按整份文件算。

## 实测

`tracemalloc` 量 `ensure_utf8_csv` 的峰值，文件是上限大小的 GBK CSV：

```
file on disk: 50.0 MB (gb18030)
peak python memory during conversion: 302.7 MB
ratio to file size: 6.05x
```

50MB 的上限对应 302MB 的峰值，而且是每个并发上传各一份。8MB 的文件峰值 38.2MB，2MB 的文件峰值 9.6MB——峰值跟着文件线性涨，这正是分块保护想避免的形状。

## 改动

编码识别和转换都改成逐块进行，块大小 1MB，与上传写入用的块大小一致：

- `_decodes_as(path, encoding)`：用增量解码器逐块判断整份文件能否解码，不落盘、不进内存。
- `_transcode_to_utf8(src, dest, encoding)`：逐块解码写出；中途解码失败就删掉半成品返回 False，让外层继续试下一种编码。

增量解码器负责跨块边界的多字节字符——GBK 一个汉字两字节，正好被块边界切开时前半截会留到下一块。这点单独有测试覆盖，因为改成逐块独立 `decode` 就会在这里整份误判。

候选编码的顺序、UTF-8 原样返回、全部失败时返回原路径交给 Polars 报错，这些都没变。

修复后同一份 50MB 文件：

```
peak python memory during conversion: 4.5 MB
ratio to file size: 0.09x
```

## 测试

新增 `backend/tests/test_ext_csv_transcode_memory.py`：

- 8MB 文件的转换峰值小于文件本身
- 文件从 2MB 涨到 8MB（4 倍），峰值不跟着涨
- 汉字正好跨在块边界上时仍能正确转换，内容逐字节相同

判据取「与文件大小无关」而不是某个绝对数值，这样换机器、换 Python 版本都不会因为常数漂移而误报。

修复前三条全部失败：

```
E  AssertionError: assert 38200214 < 8388601
E  assert 38200194 < (9557638 * 2)
E  ImportError: cannot import name '_TRANSCODE_CHUNK_BYTES'
```

## 验证结果

Windows 11，`backend` 目录下实际执行：

```
python -m pytest tests/test_ext_csv_transcode_memory.py -q   → 3 passed
python -m pytest tests -q                                    → 1735 passed
```

基线 1727 passed；#262 加了 5 条，本 PR 再加 3 条。前端未改动，未执行 `pnpm build`。
