### PR TITLE
fix(frontend): display plugin data source names

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -64,6 +64,7 @@ import { useDialogBackdrop } from '@/lib/useDialogBackdrop'
 import { resolveWatchlistGroupColor } from '@/lib/watchlist-group-colors'
 import { computeGroupPcts, groupPctColor, groupPctTitle } from '@/lib/watchlistGroupStats'
 import { fmtPct } from '@/lib/format'
+import { findDataSource } from '@/lib/dataSources'
 import { toggleTheme, useTheme } from '@/lib/theme'
 import { setCurrentTotal as setAlertTotal, useUnreadAlerts } from '@/lib/monitorBadge'
 import { ExtensionSlot } from '@/extensions/ExtensionSlot'
@@ -493,10 +494,10 @@ export function Layout() {
   const realtimeUnavailable = quoteMode === 'none'
   const isWatchlistMode = quoteMode === 'watchlist'
   const realtimeModeLabel = isWatchlistMode ? '自选股' : '全市场'
-  // 当前实时行情数据源名称 (custom 时显示源名, tickflow 时不显示)
+  // 当前实时行情数据源名称 (插件/自定义源显示源名, tickflow 不显示)
   const realtimeProvider = prefs?.realtime_data_provider
   const realtimeProviderName = realtimeProvider && realtimeProvider !== 'tickflow'
-    ? (dataSources?.custom?.find(s => s.name === realtimeProvider)?.display_name || realtimeProvider)
+    ? (findDataSource(dataSources, realtimeProvider)?.display_name || realtimeProvider)
     : null
   const realtimeToggleDisabled = toggleQuote.isPending || isPaused
   const realtimeActive = realtimeEnabled && isRunning && isTrading

--- a/frontend/src/lib/dataSources.ts
+++ b/frontend/src/lib/dataSources.ts
@@ -1,0 +1,11 @@
+import type { DataSourcesResponse } from './api'
+
+export function findDataSource(
+  sources: DataSourcesResponse | undefined,
+  name: string | undefined,
+) {
+  if (!sources || !name) return undefined
+  return sources.builtin.find(source => source.name === name)
+    ?? sources.plugins.find(source => source.name === name)
+    ?? sources.custom.find(source => source.name === name)
+}

--- a/frontend/src/pages/Data.tsx
+++ b/frontend/src/pages/Data.tsx
@@ -36,6 +36,7 @@ import { QK } from '@/lib/queryKeys'
 import { PageHeader } from '@/components/PageHeader'
 import { useAdjFactorSyncGate } from '@/components/AdjFactorSyncGate'
 import { formatScheduleDatePart, formatScheduleTimePart, isToday } from '@/lib/format'
+import { findDataSource } from '@/lib/dataSources'
 
 // 拆分出的子组件
 import { StatCard, type FieldTab, type CapLimitValue } from '@/components/data/StatCard'
@@ -193,7 +194,7 @@ export function Data() {
   const activeProvider = prefs.data?.daily_data_provider || 'tickflow'
   const activeDataSourceName = activeProvider === 'tickflow'
     ? 'TickFlow'
-    : (dataSources.data?.custom?.find(s => s.name === activeProvider)?.display_name || activeProvider)
+    : (findDataSource(dataSources.data, activeProvider)?.display_name || activeProvider)
 
   // —— 能力路由门控 (全项目统一判定) ——
   // usable = 生效源当前能否提供该能力 (含插件/自定义源; TickFlow 档位不足则不可用),


### PR DESCRIPTION
## 问题与复现

`/api/settings/data-sources` 将数据源分为 `builtin`、`plugins` 和 `custom` 三组返回。选择一个内置插件数据源后：

- 侧栏实时行情状态只在 `custom` 中查找名称，因此显示插件内部名称，而不是 `plugin.yaml` 声明的 `display_name`。
- 数据页顶部的当前数据源名称存在同样问题。

例如插件 `{ name: "demo_plugin", display_name: "Demo Plugin" }` 生效时，界面显示 `demo_plugin`。

## 根因

后端插件发现和能力路由已经支持 `plugins`，前端 API 类型也包含该数组，但 `Layout` 和 `Data` 仍保留插件机制引入前的 `dataSources.custom.find(...)` 查找逻辑。

## 解决方案

- 新增 `findDataSource()`，按 `builtin -> plugins -> custom` 统一解析数据源元数据。
- 侧栏实时行情和数据页顶部复用该函数获取 `display_name`。
- 保留找不到元数据时回退内部名称的现有行为。

这是面向所有插件的通用修复，没有绑定具体 provider。

## 兼容性

- 不修改后端接口、preferences、缓存或数据文件。
- TickFlow 和用户自定义 HTTP 数据源的显示行为不变。
- 插件不可用或元数据尚未加载时仍回退 provider 内部名称。

## 性能

仅在两个现有组件渲染时依次查询三个小型内存数组，不增加请求、轮询或实时热路径工作。

## 验证结果

- `./node_modules/.bin/tsc -b && ./node_modules/.bin/vite build`：通过。
- `findDataSource` 定向运行时检查：5 个断言通过，覆盖 builtin、plugin、custom、未知名称和未加载响应。
- `git diff --check`：通过。
- `pnpm lint`：未执行成功。当前前端未声明或安装 ESLint，且本机 pnpm 供应链策略在运行脚本前因 `esbuild` ignored build 中止；本次没有声称 lint 通过。

## 界面证据

未附截图。本次不改变布局或样式，只将插件内部名称替换为 API 已返回的 `display_name`；尚未在真实插件选择状态下完成手工视觉检查。

## 风险与回滚

风险局限于同名数据源：查找顺序与后端加载行为保持插件优先于同名自定义源。若出现展示回归，可直接回滚本提交，数据路由和存储不受影响。

## 自检

- [x] 改动只处理插件数据源名称解析。
- [x] 未修改 provider、能力矩阵或金融数据口径。
- [x] 未提交锁文件、生成物、本地路径、密钥或用户数据。
- [x] 前端生产构建及补丁检查通过。
- [ ] 尚未附真实插件状态截图；已在上方披露。
