### PR TITLE
fix(ext-data): 定时拉取的时间窗口与落盘日期改用北京时间

### DIFF
--- a/backend/app/services/ext_pull.py
+++ b/backend/app/services/ext_pull.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import httpx
 
+from app.market_time import cn_now, cn_today
 from app.services.ext_data import (
     ExtConfig,
     ExtConfigStore,
@@ -42,14 +43,19 @@ def outbound_headers(user_headers: dict[str, str] | None = None) -> dict[str, st
 
 
 def _in_time_window(start: str | None, end: str | None) -> bool:
-    """检查当前本地时间是否在每日时间窗口内。
+    """检查当前北京时间是否在每日时间窗口内。
 
     start/end 为 "HH:MM" 格式。两者都为 None 时不限制(返回 True)。
     支持跨午夜窗口(如 22:00-02:00)。
+
+    用北京时间而不是本地时间: 这个窗口是照着 A 股交易时段设的, 而
+    market_time 模块开篇就写明「服务器/容器本地时区不可靠 (python:slim
+    镜像默认 UTC)」。UTC 容器里 9:30-15:00 的窗口实际落在北京 17:30-23:00,
+    每天都在收盘之后。
     """
     if not start or not end:
         return True
-    now = datetime.now().strftime("%H:%M")
+    now = cn_now().strftime("%H:%M")
     if start <= end:
         return start <= now < end
     # 跨午夜: 如 22:00-02:00
@@ -218,7 +224,8 @@ async def fetch_and_ingest(
     Returns:
         (rows_written, date_str)
     """
-    day = target_date or date.today()
+    # 同上: 落盘分区按北京日期, 否则 UTC 容器在北京时间 08:00 之前写的是前一天。
+    day = target_date or cn_today()
     rows = await fetch_rows_for_date(config, day)
     if not rows:
         raise ValueError("提取到的行数为 0")

--- a/backend/tests/test_ext_pull_time_window.py
+++ b/backend/tests/test_ext_pull_time_window.py
@@ -1,0 +1,103 @@
+"""扩展数据定时拉取的时间基准测试 — 窗口与落盘日期都按北京时间。
+
+背景: `app/market_time.py` 开篇写明「服务器/容器本地时区不可靠 (python:slim
+镜像默认 UTC), 交易时段判断、实时行情落盘日期等必须显式使用北京时间, 否则
+Docker 部署时轮询窗口与真实交易时段完全错开」。
+
+拉取窗口正是照着 A 股交易时段设的, 落盘分区正是行情日期, 两处却都用了裸的
+`datetime.now()` / `date.today()`。UTC 容器里 09:30-15:00 的窗口实际落在北京
+17:30-23:00, 每天都在收盘之后; 北京时间 08:00 之前落盘写的是前一天的分区。
+
+判据不依赖跑测试的机器在哪个时区: 固定一个北京时刻, 断言窗口按它判断。
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pytest
+
+from app.market_time import CN_TZ
+from app.services import ext_pull
+
+
+@pytest.fixture
+def at_beijing(monkeypatch: pytest.MonkeyPatch):
+    """把北京时间钉在给定时刻。"""
+
+    def freeze(moment: datetime):
+        monkeypatch.setattr(ext_pull, "cn_now", lambda: moment)
+        monkeypatch.setattr(ext_pull, "cn_today", lambda: moment.date())
+
+    return freeze
+
+
+def test_window_follows_beijing_time_not_the_machine_clock(at_beijing) -> None:
+    # 北京 10:00, 正在早盘。
+    at_beijing(datetime(2026, 3, 2, 10, 0, tzinfo=CN_TZ))
+    assert ext_pull._in_time_window("09:30", "15:00") is True
+
+    # 北京 17:30 — UTC 容器上「本地 09:30」正是这个时刻, 修复前会误判为在窗口内。
+    at_beijing(datetime(2026, 3, 2, 17, 30, tzinfo=CN_TZ))
+    assert ext_pull._in_time_window("09:30", "15:00") is False
+
+
+def test_window_across_midnight_still_works(at_beijing) -> None:
+    at_beijing(datetime(2026, 3, 2, 23, 0, tzinfo=CN_TZ))
+    assert ext_pull._in_time_window("22:00", "02:00") is True
+    at_beijing(datetime(2026, 3, 2, 1, 0, tzinfo=CN_TZ))
+    assert ext_pull._in_time_window("22:00", "02:00") is True
+    at_beijing(datetime(2026, 3, 2, 12, 0, tzinfo=CN_TZ))
+    assert ext_pull._in_time_window("22:00", "02:00") is False
+
+
+def test_no_window_configured_is_still_unrestricted(at_beijing) -> None:
+    at_beijing(datetime(2026, 3, 2, 3, 0, tzinfo=CN_TZ))
+    assert ext_pull._in_time_window(None, None) is True
+    assert ext_pull._in_time_window("09:30", None) is True
+    assert ext_pull._in_time_window(None, "15:00") is True
+
+
+async def test_default_landing_date_is_the_beijing_date(at_beijing, monkeypatch) -> None:
+    """不传 target_date 时按北京日期落盘。
+
+    北京 00:30 对应 UTC 前一天 16:30, 裸 date.today() 在 UTC 容器上会把当天的
+    数据写进前一天的分区。
+    """
+    at_beijing(datetime(2026, 3, 2, 0, 30, tzinfo=CN_TZ))
+    seen: dict[str, date] = {}
+
+    async def fake_fetch(config, target_date):
+        seen["fetched"] = target_date
+        return [{"symbol": "000001.SZ", "v": 1}]
+
+    def fake_write(rows, config, data_dir, snapshot_date):
+        seen["written"] = snapshot_date
+        return len(rows)
+
+    monkeypatch.setattr(ext_pull, "fetch_rows_for_date", fake_fetch)
+    monkeypatch.setattr(ext_pull, "rows_to_parquet", fake_write)
+
+    written, day_str = await ext_pull.fetch_and_ingest(object(), "/tmp")
+
+    assert written == 1
+    assert seen["fetched"] == date(2026, 3, 2)
+    assert seen["written"] == date(2026, 3, 2)
+    assert day_str == "2026-03-02"
+
+
+async def test_an_explicit_target_date_still_wins(at_beijing, monkeypatch) -> None:
+    # 历史回补路径不受影响。
+    at_beijing(datetime(2026, 3, 2, 10, 0, tzinfo=CN_TZ))
+    seen: dict[str, date] = {}
+
+    async def fake_fetch(config, target_date):
+        seen["fetched"] = target_date
+        return [{"symbol": "000001.SZ", "v": 1}]
+
+    monkeypatch.setattr(ext_pull, "fetch_rows_for_date", fake_fetch)
+    monkeypatch.setattr(ext_pull, "rows_to_parquet", lambda *a, **k: 1)
+
+    _, day_str = await ext_pull.fetch_and_ingest(object(), "/tmp", date(2026, 1, 5))
+
+    assert seen["fetched"] == date(2026, 1, 5)
+    assert day_str == "2026-01-05"


### PR DESCRIPTION
## 问题

定时拉取的每日时间窗口和落盘分区日期都按**服务器本地时间**判断, 而这两件事正是
`app/market_time.py` 开篇明确要求必须用北京时间的:

> 服务器/容器本地时区不可靠 (python:slim 镜像默认 UTC), 交易时段判断、实时行情落盘日期等
> 必须显式使用北京时间, 否则 Docker 部署时轮询窗口与真实交易时段完全错开
> (北京 9:15-15:05 = UTC 1:15-7:05)

而 `ext_pull` 里是:

```python
def _in_time_window(start, end):
    now = datetime.now().strftime("%H:%M")     # 裸本地时间
...
    day = target_date or date.today()          # 裸本地日期
```

本仓库带 Dockerfile, 镜像里就是 UTC, 也就是那段注释点名的部署方式。

## 实测

在一台 UTC+9 的机器上, 用围绕本机时钟的一小时窗口:

```
window 20:00-21:00  (本机 20:17, 北京 19:17)
  _in_time_window (本地) : True
  按北京时间应为          : False
```

本机和北京差 1 小时就已经判反; UTC 容器里差 8 小时。照 A 股交易时段设的
`09:30-15:00` 窗口, 在 UTC 容器上实际落在**北京 17:30-23:00**, 每天都在收盘之后,
也就是说这个窗口从来没有在开盘期间生效过。

落盘日期同理: 北京 00:30 是 UTC 前一天 16:30, `date.today()` 会把当天的数据写进
前一天的分区。

## 改动

两处都改用 `market_time` 已有的 `cn_now()` / `cn_today()`——这个模块就是为这件事
建的。窗口的跨午夜逻辑、`start/end` 任一为空即不限制、历史回补显式传 `target_date`
的路径, 都没有变。

`_in_time_window` 的 docstring 原本写「当前本地时间」, 一并改成「当前北京时间」,
因为行为和文字现在是一致的了。

## 测试

新增 `backend/tests/test_ext_pull_time_window.py`, 判据不依赖跑测试的机器在哪个时区
——固定一个北京时刻再断言:

- 北京 10:00 在 `09:30-15:00` 内; 北京 17:30 (UTC 容器上的「本地 09:30」) 不在
- 跨午夜窗口 `22:00-02:00` 在 23:00 和 01:00 都成立, 12:00 不成立
- `start`/`end` 任一为空仍然不限制
- 不传 `target_date` 时按北京日期落盘 (北京 00:30 落 2026-03-02, 不是前一天)
- 显式传入的目标日期仍以传入值为准

修复前这些用例直接报 `AttributeError: module 'app.services.ext_pull' has no attribute
'cn_now'`——模块里根本没有北京时间这个概念, 这也正是问题本身。行为层面的证据是上面
那段实测。

## 验证结果

Windows 11, `backend` 目录下实际执行:

```
python -m pytest tests/test_ext_pull_time_window.py -q                     → 5 passed
python -m pytest tests -q --ignore=tests/test_watchdog.py                  → 1766 passed, 0 failed
```

`tests/test_watchdog.py` 在我这台机器上会挂住不返回, 所以单独排除了。这不是本改动引起的:
在父提交上单跑同一个文件同样挂住 (两边都是 120 秒超时 kill), 且该文件不引用 `ext_pull`、
`cn_now`、`cn_today` 或时间窗口。其余全部用例通过。

前端未改动, 未执行 `pnpm build`。
