### PR TITLE
fix(rotation): 轮动信号缺失日按日期归位补齐, 新晋概念不再被误判为退潮

### DIFF
--- a/backend/app/services/concept_rotation_analyzer.py
+++ b/backend/app/services/concept_rotation_analyzer.py
@@ -125,13 +125,11 @@ def _compute_rotation_signals(dates: list[str], columns: dict) -> dict:
     dates_asc = list(reversed(dates))
 
     # 收集每个概念在各日期的 (排名, 涨幅)。排名 = 该日在列中的索引 + 1。
-    concept_data: dict[str, list[tuple[int, float]]] = {}
+    concept_data: dict[str, dict[str, tuple[int, float]]] = {}
     for d in dates_asc:
         col = columns.get(d) or []
         for idx, (name, pct) in enumerate(col):
-            concept_data.setdefault(name, []).append((idx + 1, pct))
-
-    n_dates = len(dates_asc)
+            concept_data.setdefault(name, {})[d] = (idx + 1, pct)
 
     def _stats(ranks_pcts: list[tuple[int, float]]) -> dict:
         ranks = [r for r, _ in ranks_pcts]
@@ -151,10 +149,10 @@ def _compute_rotation_signals(dates: list[str], columns: dict) -> dict:
     institutional: list[dict] = []
     hot_money: list[dict] = []
 
-    for concept, rp in concept_data.items():
-        # 缺失日补 (大排名, 0 涨幅) 保持时间轴对齐
-        if len(rp) < n_dates:
-            rp = rp + [(999, 0.0)] * (n_dates - len(rp))
+    for concept, by_date in concept_data.items():
+        # 缺失日按日期归位补 (大排名, 0 涨幅) —— 补位必须落在缺席的那一天,
+        # 一律追加到末尾会把"只在最近几日上榜"的新晋概念读成退潮。
+        rp = [by_date.get(d, (999, 0.0)) for d in dates_asc]
         s = _stats(rp)
         s["concept"] = concept
 

--- a/backend/tests/test_concept_rotation_signals.py
+++ b/backend/tests/test_concept_rotation_signals.py
@@ -1,0 +1,60 @@
+"""概念/行业轮动信号预计算 (_compute_rotation_signals) 单元测试。"""
+from __future__ import annotations
+
+from app.services.concept_rotation_analyzer import _compute_rotation_signals
+
+# dates 与服务口径一致: 最新在最前
+_DATES = ["2026-01-09", "2026-01-08", "2026-01-07", "2026-01-06", "2026-01-05"]
+
+
+def _column(names_pcts: list[tuple[str, float]]) -> list[list]:
+    return [[name, pct] for name, pct in names_pcts]
+
+
+def _baseline_columns() -> dict[str, list[list]]:
+    """每日 40 个陪跑概念, 排名稳定, 用于把待测概念挤到指定名次。"""
+    filler = [(f"陪跑{i:02d}", 0.01 - i * 0.0001) for i in range(40)]
+    return {d: _column(filler) for d in _DATES}
+
+
+def test_missing_early_days_do_not_shift_ranks_forward():
+    """概念只在最近两日出现时, 缺失日必须补在时间轴左端 (早期), 不能补在右端。
+
+    补位若一律追加到列表末尾, "只在最近两日上榜且排第一"的新晋概念会被读成
+    "早期第一、最新掉出榜外", 从而被误判为退潮。
+    """
+    columns = _baseline_columns()
+    for d, pct in (("2026-01-09", 0.09), ("2026-01-08", 0.08)):
+        columns[d] = _column([("新晋题材", pct)]) + columns[d]
+
+    signals = _compute_rotation_signals(_DATES, columns)
+    by_name = {
+        item["concept"]: item
+        for group in signals.values()
+        for item in group
+    }
+    assert "新晋题材" in by_name
+    # ranks[0]=最早日, ranks[-1]=最新日: 最早两日缺席(999), 最近两日排第一
+    assert by_name["新晋题材"]["ranks"] == [999, 999, 999, 1, 1]
+
+    rising = [item["concept"] for item in signals["rising"]]
+    fading = [item["concept"] for item in signals["fading"]]
+    assert "新晋题材" in rising
+    assert "新晋题材" not in fading
+
+
+def test_missing_recent_days_pad_at_the_right_end():
+    """概念只在最早两日出现时, 缺失日补在时间轴右端 (最新)。"""
+    columns = _baseline_columns()
+    for d, pct in (("2026-01-05", 0.09), ("2026-01-06", 0.08)):
+        columns[d] = _column([("退潮题材", pct)]) + columns[d]
+
+    signals = _compute_rotation_signals(_DATES, columns)
+    by_name = {
+        item["concept"]: item
+        for group in signals.values()
+        for item in group
+    }
+    assert "退潮题材" in by_name
+    assert by_name["退潮题材"]["ranks"] == [1, 1, 999, 999, 999]
+    assert "退潮题材" in [item["concept"] for item in signals["fading"]]


### PR DESCRIPTION
## 问题

`app/services/concept_rotation_analyzer._compute_rotation_signals` 把「缺失日」的占位一律追加到序列末尾:

```python
concept_data.setdefault(name, []).append((idx + 1, pct))
...
# 缺失日补 (大排名, 0 涨幅) 保持时间轴对齐
if len(rp) < n_dates:
    rp = rp + [(999, 0.0)] * (n_dates - len(rp))
```

`columns[日期]` 只包含**当日有有效 `avg_pct` 的维度成员**(`rps_rotation.build_rps_rotation` 第 4 步已 `filter(is_not_null & is_not_nan)`,成分股当日全部停牌/无行情的概念会整列缺席),所以某个概念在部分日期缺席是正常数据形态。此时:

- 实际值被压到序列左端(早期),占位被塞到右端(最新);
- 而下游一律按「`ranks[0]` = 最早日、`ranks[-1]` = 最新日」解读(见函数 docstring 与 prompt 里「排名时间方向: 左→右 = 旧→新」)。

结果是**只在最近几日上榜的新晋概念被读成退潮**:一个前 3 日缺席、最近 2 日排第 1 的概念,`ranks` 变成 `[1, 1, 999, 999, 999]` → `earliest_rank=1`、`latest_rank=999` → 落进 `fading`(退潮预警)且因 `rank_std` 变大同时落进 `hot_money`,而它本应落进 `rising`(新晋强势)。喂给 AI 的排名轨迹文本 `1→1→—→—→—` 也与真实时间方向完全相反。

`pcts` 同样错位,`_build_signal_block` 的「区间均涨」被补位的 0.0 稀释到错误位置。

## 复现(修改源码前,在 origin/main `9a4bdcd` 上运行)

新增 `backend/tests/test_concept_rotation_signals.py` 后先跑,确认失败:

```
$ python -m pytest tests/test_concept_rotation_signals.py -q
F.                                                                       [100%]
================================== FAILURES ===================================
_____________ test_missing_early_days_do_not_shift_ranks_forward ______________
        assert "新晋题材" in by_name
        # ranks[0]=最早日, ranks[-1]=最新日: 最早两日缺席(999), 最近两日排第一
>       assert by_name["新晋题材"]["ranks"] == [999, 999, 999, 1, 1]
E       assert [1, 1, 999, 999, 999] == [999, 999, 999, 1, 1]
E
E         At index 0 diff: 1 != 999
E         Use -v to get more diff

tests\test_concept_rotation_signals.py:38: AssertionError
=========================== short test summary info ===========================
FAILED tests/test_concept_rotation_signals.py::test_missing_early_days_do_not_shift_ranks_forward
1 failed, 1 passed in 0.17s
```

(第二个用例 `test_missing_recent_days_pad_at_the_right_end` 在修改前后都通过,用于锁住「确实缺席最近几日时占位应在右端」的相反方向,防止把补位方向整体写反。)

## 修改

按日期归位补齐,而不是按长度追加:

```python
concept_data.setdefault(name, {})[d] = (idx + 1, pct)
...
rp = [by_date.get(d, (999, 0.0)) for d in dates_asc]
```

只动补位逻辑,分类阈值、排序、输出结构均不变。

## 验证

```
$ python -m pytest tests/test_concept_rotation_signals.py -q
..                                                                       [100%]
2 passed in 0.10s

$ python -m pytest tests/test_concept_rotation_signals.py tests/test_ai_analysis_focus.py -q
.......                                                                  [100%]
7 passed in 0.39s
```

全量后端测试:

```
$ python -m pytest tests -q --ignore=tests/test_watchdog.py
1792 passed, 100 warnings in 84.68s (0:01:24)
```

(`tests/test_watchdog.py` 在本机未改动的 main 上也会挂住,故 `--ignore` 排除;改动前的同一命令同样全绿。)
