### PR TITLE
fix(kline): 分钟K增量同步窗口统一按北京时区

### DIFF
--- a/backend/app/services/kline_sync.py
+++ b/backend/app/services/kline_sync.py
@@ -1277,29 +1277,38 @@ def fetch_adj_factor_single(symbol: str) -> pl.DataFrame:
     return _normalize_adj_factor(raw)
 
 
+def _as_beijing(d: datetime) -> datetime:
+    """落盘的分钟 datetime 是北京墙钟 naive, 带上北京时区再交给取数窗口。
+
+    naive 值经 _datetime_to_ms 会被 .timestamp() 按服务器本地时区解释, 与同
+    窗口另一端的服务器本地时间混用后整体错位 (UTC 容器上错 8 小时)。
+    """
+    return d if d.tzinfo is not None else d.replace(tzinfo=CN_TZ)
+
+
 def _latest_minute_datetime(repo: KlineRepository) -> datetime | None:
-    """本地分钟 K 数据的最新时间。"""
+    """本地分钟 K 数据的最新时间 (北京时区)。"""
     try:
         res = repo.execute_one("SELECT max(datetime) FROM kline_minute")
         if res and res[0]:
             d = res[0]
             if isinstance(d, datetime):
-                return d
-            return datetime.fromisoformat(str(d))
+                return _as_beijing(d)
+            return _as_beijing(datetime.fromisoformat(str(d)))
     except Exception:  # noqa: BLE001
         pass
     return None
 
 
 def _earliest_minute_datetime(repo: KlineRepository) -> datetime | None:
-    """本地分钟 K 数据的最早时间 (用于向前扩展的起点)。"""
+    """本地分钟 K 数据的最早时间 (北京时区, 用于向前扩展的起点)。"""
     try:
         res = repo.execute_one("SELECT min(datetime) FROM kline_minute")
         if res and res[0]:
             d = res[0]
             if isinstance(d, datetime):
-                return d
-            return datetime.fromisoformat(str(d))
+                return _as_beijing(d)
+            return _as_beijing(datetime.fromisoformat(str(d)))
     except Exception:  # noqa: BLE001
         pass
     return None
@@ -1421,7 +1430,9 @@ def sync_and_persist_minute(
     # 迁移:旧版按 symbol= 分区转为 date= 分区
     _migrate_symbol_to_date_partition(repo)
 
-    now = datetime.now()
+    # 窗口两端统一为北京时区: 起止点会与本地分钟 K 的北京墙钟混用, 用服务器
+    # 本地时间会让窗口整体错位 (UTC 容器上起点晚于终点, 增量补拉一个请求都发不出)。
+    now = cn_now()
 
     if extend_backward:
         # 向前扩展模式: 从本地最早数据往前补, 叠加已有数据避免缺口。

--- a/backend/tests/test_kline_sync_timezone.py
+++ b/backend/tests/test_kline_sync_timezone.py
@@ -5,7 +5,11 @@ fetch_minute_single 构造的 naive datetime 会被 _datetime_to_ms 的 .timesta
 """
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import polars as pl
 
 from app.market_time import CN_TZ
 from app.services import kline_sync
@@ -41,3 +45,70 @@ def test_fetch_minute_single_window_is_beijing_wall_clock(monkeypatch):
     end = datetime.fromtimestamp(captured["end_ms"] / 1000, tz=CN_TZ)
     assert (start.date(), start.hour, start.minute) == (date(2026, 8, 14), 9, 25)
     assert (end.date(), end.hour, end.minute) == (date(2026, 8, 14), 15, 5)
+
+
+def _capture_minute_window(monkeypatch, tmp_path, local_dt: datetime, **kwargs) -> dict:
+    """桩掉 sync_and_persist_minute 的外部依赖, 只截获传给取数层的时间窗口。
+
+    local_dt 模拟 kline_minute 里的极值 (落盘口径为北京墙钟 naive)。
+    """
+    captured: dict = {}
+
+    def _fake_sync_minute_batch(symbols, **call_kwargs):
+        captured.update(call_kwargs)
+        return pl.DataFrame()
+
+    monkeypatch.setattr(kline_sync.preferences, "get_minute_data_provider", lambda: "tickflow")
+    monkeypatch.setattr(kline_sync.preferences, "get_minute_sync_segment_days", lambda: 20)
+    monkeypatch.setattr(kline_sync, "_cleanup_null_datetime_minute", lambda repo: None)
+    monkeypatch.setattr(kline_sync, "_migrate_symbol_to_date_partition", lambda repo: None)
+    monkeypatch.setattr(kline_sync, "resolve_limit", lambda *a, **kw: SimpleNamespace(batch=100, rpm=30))
+    monkeypatch.setattr(kline_sync, "sync_minute_batch", _fake_sync_minute_batch)
+
+    repo = MagicMock()
+    repo.store.data_dir = tmp_path
+    repo.execute_one = lambda sql: (local_dt,)
+    kline_sync.sync_and_persist_minute(
+        ["600000.SH"],
+        repo,
+        CapabilitySet({Cap.KLINE_MINUTE_BATCH: CapabilityLimits()}),
+        **kwargs,
+    )
+    return captured
+
+
+def test_sync_and_persist_minute_incremental_window_is_beijing_wall_clock(monkeypatch, tmp_path):
+    """增量分钟同步: 起点取自本地分钟 K 的北京墙钟, 终点必须同口径。
+
+    终点用服务器本地墙钟时, _datetime_to_ms 会把两端按同一本地时区换算 →
+    UTC 容器上起点(北京 14:30)反而晚于终点, 一个请求都发不出去, 分钟 K 永远
+    停在首次拉取的位置。
+    """
+    local_latest = datetime(2026, 8, 14, 14, 30)  # 本地最新分钟 K: 北京墙钟 naive
+
+    captured = _capture_minute_window(monkeypatch, tmp_path, local_latest)
+    start, end = captured["start_time"], captured["end_time"]
+
+    assert start.utcoffset() == timedelta(hours=8)
+    assert end.utcoffset() == timedelta(hours=8)
+    assert start < end
+    assert datetime.fromtimestamp(
+        kline_sync._datetime_to_ms(start) / 1000, tz=CN_TZ
+    ) == local_latest.replace(tzinfo=CN_TZ)
+
+
+def test_sync_and_persist_minute_extend_backward_window_is_beijing_wall_clock(monkeypatch, tmp_path):
+    """向前扩展: 终点取自本地最早分钟 K 的北京墙钟, 同样不能被服务器时区重解释。"""
+    local_earliest = datetime(2026, 8, 14, 9, 30)
+
+    captured = _capture_minute_window(
+        monkeypatch, tmp_path, local_earliest, days=5, extend_backward=True,
+    )
+    start, end = captured["start_time"], captured["end_time"]
+
+    assert start.utcoffset() == timedelta(hours=8)
+    assert end.utcoffset() == timedelta(hours=8)
+    assert end - start == timedelta(days=7)  # 5 交易日 x 7/5
+    assert datetime.fromtimestamp(
+        kline_sync._datetime_to_ms(end) / 1000, tz=CN_TZ
+    ) == local_earliest.replace(tzinfo=CN_TZ)


### PR DESCRIPTION
## 1. 问题与复现

盘后管道 Step 2.5 的分钟 K 增量同步 (`daily_pipeline` → `kline_sync.sync_and_persist_minute`) 在**服务器时区不是 UTC+8 时拉不到增量数据**：

- UTC 容器 (Docker `python:slim` 默认)：**一个 SDK 请求都发不出去**，本地分钟 K 永远停在首次全量拉取的位置，此后每轮同步都写入 0 行。
- 其他非 UTC+8 时区：窗口起点被整体平移 `8h - 服务器偏移`，重复拉取或漏拉。

复现条件：本地 `kline_minute` 已有数据（走增量分支，即 `force_full_days=False` 的默认路径）。首次拉取（本地无数据）不受影响，所以问题只在"用了一段时间之后"暴露。

`extend_backward=True`（分时向前扩展历史）同理。

用最小桩件复现（`_latest_minute_datetime` 返回 30 分钟前的北京墙钟，截获传给 `tf.klines.batch` 的窗口）：

```
######## 修复前, TZ=UTC0 (Docker 默认) ########
server local now : 2026-09-08 22:11:29
beijing now      : 2026-09-09 06:11:29+08:00
local latest (BJ): 2026-09-09 05:41:00
SDK requests     : 0            <-- 一个请求都没有发出
rows written     : 0

######## 修复前, 服务器时区 UTC+9 ########
local latest (BJ): 2026-09-09 05:41:00
SDK requests     : 1
  window sent (as Beijing): 2026-09-09 04:41:00+08:00 ~ 2026-09-09 06:11:30+08:00   span=1:30:30
                            ^^^^^ 应为 05:41, 起点早了 1 小时

######## 修复后, TZ=UTC0 与 UTC+9 结果一致 ########
SDK requests     : 1
  window sent (as Beijing): 2026-09-09 05:41:00+08:00 ~ 2026-09-09 06:11:15+08:00   span=0:30:15
```

## 2. 根因

窗口两端来自**两套不同的时钟**，而 `_datetime_to_ms` 用 `dt.timestamp()` 把 naive 值一律按**服务器本地时区**解释：

- 起点 `start_time = _latest_minute_datetime(repo)`：读 `max(datetime) FROM kline_minute`。按 CONTRIBUTING §3.3，分钟 K 的 `datetime` 是**北京墙钟 naive**（`_enforce_minute_beijing_wallclock` 在入库前强制归一）。
- 终点 `end_time = now = datetime.now()`：**服务器本地墙钟 naive**。

于是在 UTC 容器上，起点（北京 15:00）被当成 UTC 15:00，比终点（UTC 07:00）还晚 —— `sync_minute_batch` 的 `while seg_start < end_time` 直接不成立，`time_segments` 为空，循环一次都不进。

这正是 `market_time.py` 模块注释和 `fetch_minute_single` 已经处理过的同一类问题：`fetch_minute_single` 显式给窗口带上 `tzinfo=CN_TZ`（并有 `tests/test_kline_sync_timezone.py` 守住），但盘后批量路径没有跟上。

## 3. 解决方案

把窗口两端统一到北京时区：

- `_latest_minute_datetime` / `_earliest_minute_datetime` 读出的是北京墙钟，返回前带上 `CN_TZ`（新增 `_as_beijing`，已带时区的值原样返回）。
- `sync_and_persist_minute` 的 `now` 改用 `cn_now()`。

这样 `_datetime_to_ms` 拿到的是 aware datetime，`.timestamp()` 不再受服务器时区影响；段切分 `seg_start + SEG_CHUNK` 与 `min(..., end_time)` 也都在同一时区内比较。

没有改 `_datetime_to_ms` 本身：它同时服务日 K / 复权因子等仍传 naive 的调用方，改全局语义会影响本 PR 之外的口径。

## 4. 兼容性

- **数据格式**：不动 Parquet schema、分区布局、`datetime` 落盘口径（仍是北京墙钟 naive，由 `_enforce_minute_beijing_wallclock` 收口）。
- **provider 插件化**：自定义分钟源经 `_try_custom_minute` 收到的 `start_time/end_time` 变为 aware。这不是新契约 —— `fetch_minute_single` 早已从同一入口传 aware 值；内置 `stocksdk` 只用 `strftime("%Y%m%d")` 取日期，YAML 自定义源同样按 `strftime` 渲染，两者对 tzinfo 不敏感。
- **其他调用方**：`fetch_intraday_monitor_batch` 传给 `sync_minute_batch` 的窗口本来就基于 `cn_now()`（aware），`/api/kline` 的分时补拉两端同为 naive、自洽，均未受影响。
- 无配置迁移、无 API 变更、无用户数据改写。

## 5. 性能

不进入实时热路径。修复后 UTC 部署会从"每轮 0 个请求"恢复为正常的增量请求量（与 UTC+8 部署一致），这是恢复既有设计行为，不是新增开销。

## 6. 验证结果

补测写在既有的时区契约文件 `backend/tests/test_kline_sync_timezone.py` 里（该文件本就是为 `fetch_minute_single` 的同类问题建立的）。

**修复前（源码为未修改的 main，仅加测试）：**

```
$ python -m pytest tests/test_kline_sync_timezone.py -q
>       assert start.utcoffset() == timedelta(hours=8)
E       assert None == datetime.timedelta(seconds=28800)
E        +  where None = <built-in method utcoffset of datetime.datetime object at 0x...>()
E        +    where ... = datetime.datetime(2026, 8, 14, 14, 30).utcoffset

>       assert start.utcoffset() == timedelta(hours=8)
E       assert None == datetime.timedelta(seconds=28800)
E        +    where ... = datetime.datetime(2026, 8, 7, 9, 30).utcoffset

FAILED tests/test_kline_sync_timezone.py::test_sync_and_persist_minute_incremental_window_is_beijing_wall_clock
FAILED tests/test_kline_sync_timezone.py::test_sync_and_persist_minute_extend_backward_window_is_beijing_wall_clock
2 failed, 1 passed in 0.73s
```

**修复后：**

```
$ python -m pytest tests/test_kline_sync_timezone.py -q
3 passed in 0.52s

$ python -m pytest tests/test_minute_routing.py tests/test_minute_timezone_contract.py \
    tests/test_minute_refresh.py tests/test_minute_range_api.py tests/test_minute_history_days.py \
    tests/test_kline_minute_live.py tests/test_minute_strategy.py -q
122 passed in 3.40s

$ python -m pytest tests -q --ignore=tests/test_watchdog.py
1792 passed, 101 warnings in 105.71s
```

`tests/test_watchdog.py` 在本地未修改的 main 上同样挂起，与本 PR 无关，故排除。

```
$ python -m ruff check app/services/kline_sync.py tests/test_kline_sync_timezone.py --statistics
Found 28 errors.     # 与修改前逐条相同, 本 PR 未新增告警
$ git diff --check   # 通过
```

说明：断言用 `utcoffset() == timedelta(hours=8)` 表达"窗口必须带北京时区"这一契约，而不是只断言换算出的时刻 —— 后者在 UTC+8 的开发机上修复前也会通过，无法复现问题。同一测试里也一并断言了换算回北京时间后的时刻与本地最新分钟 K 一致。

## 7. 界面证据

无界面变化。

## 8. 风险与回滚

- 未在真实 UTC 容器 + 真实 TickFlow Key 下跑完整盘后管道，复现与验证均基于桩件与单元测试。
- 若某个第三方分钟插件的 `get_minute` 对 aware datetime 做了 `.replace(tzinfo=None)` 之外的假设（如与内部 naive 值直接比较），可能需要各自适配；内置两个源已确认不受影响。
- 回滚：还原本 PR 两个文件即可，无数据迁移。
