### PR TITLE
fix(reports): AI 报告 created_at 改用北京墙钟, 修复 UTC 部署下「8 小时前」

### DIFF
--- a/backend/app/services/json_report_store.py
+++ b/backend/app/services/json_report_store.py
@@ -21,6 +21,8 @@ import threading
 import time
 from pathlib import Path
 
+from app.market_time import cn_now
+
 logger = logging.getLogger(__name__)
 
 
@@ -121,6 +123,9 @@ class JsonReportStore:
 
     @staticmethod
     def _now_iso() -> str:
-        """当前本地时间 ISO 字符串(带秒精度,前端 toLocaleString 友好)。"""
-        from datetime import datetime
-        return datetime.now().isoformat(timespec="seconds")
+        """当前北京时间 ISO 字符串(带秒精度,前端 toLocaleString 友好)。
+
+        用北京墙钟而非宿主机时钟: 容器默认 UTC 时, 前端把这串 naive 时间按浏览器
+        本地时区解析, 刚生成的报告会显示成「8 小时前」。
+        """
+        return cn_now().replace(tzinfo=None).isoformat(timespec="seconds")

--- a/backend/tests/test_json_report_store_timezone.py
+++ b/backend/tests/test_json_report_store_timezone.py
@@ -1,0 +1,42 @@
+"""AI 报告 created_at 时区测试 — 必须是北京墙钟, 不随服务器时区漂移。
+
+三类 AI 报告(财务分析 / 个股分析 / 大盘复盘)共用 JsonReportStore 补 created_at,
+前端 fmtRelative 用 `new Date(created_at)` 按浏览器本地时区解析这串 naive 时间。
+服务端若用宿主机时钟(Docker 镜像默认 UTC), 刚生成的报告会被显示成「8 小时前」,
+「今天是否已生成过报告」的判定(created_at 前 10 位 == 浏览器今天)也会误判。
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.services.json_report_store import JsonReportStore
+
+CN_TZ = timezone(timedelta(hours=8))
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    s = JsonReportStore("ai_reports.json", 20, id_prefix="rpt")
+    monkeypatch.setattr(s, "_path", lambda: tmp_path / "ai_reports.json")
+    return s
+
+
+def test_created_at_follows_beijing_clock(store):
+    """created_at 与北京墙钟一致(宿主机时区非 UTC+8 时旧实现偏移整时区差)。"""
+    saved = store.save_report({"symbol": "600519.SH", "content": "正文"})
+
+    got = datetime.fromisoformat(saved["created_at"])
+    expected = datetime.now(CN_TZ).replace(tzinfo=None)
+    assert abs((got - expected).total_seconds()) < 5
+
+
+def test_created_at_keeps_naive_second_precision_format(store):
+    """格式不变: 秒精度、无时区后缀, 历史记录与前端解析保持兼容。"""
+    saved = store.save_report({"symbol": "600519.SH", "content": "正文"})
+
+    created_at = saved["created_at"]
+    assert len(created_at) == 19
+    assert created_at[10] == "T"
+    assert datetime.fromisoformat(created_at).tzinfo is None


### PR DESCRIPTION
## 问题与复现

三类 AI 报告(财务分析 `ai_reports.json` / 个股分析 `ai_stock_reports.json` / 大盘复盘 `ai_market_recaps.json`)共用 `JsonReportStore` 补 `created_at`，取的是**宿主机时钟**。容器默认 UTC(`app/market_time.py` 开头就写明「python:slim 镜像默认 UTC」),于是 Docker 部署下:

- 北京时间 15:35 生成的复盘,落盘成 `"created_at": "2026-06-27T07:35:00"`;
- 前端 `fmtRelative` 用 `new Date(created_at)` 按**浏览器本地时区**解析这串 naive 时间(`frontend/src/pages/StockAnalysis.tsx:354`、`components/financials/ReportHistoryPanel.tsx:115`、`components/stock-analysis/StockAnalysisDialog.tsx:254`、`components/financials/AiAnalysisDialog.tsx:264`),北京时区的浏览器上**刚生成的报告显示成「8 小时前」**;
- `frontend/src/pages/Review.tsx:60` 的 `fmtArchivedAt` 同理,归档时间少 8 小时;
- `frontend/src/lib/stockAnalysisStore.ts:151-157` 用 `created_at.slice(0, 10) === 浏览器今天` 判断「今天是否已生成过报告」,北京 00:00-08:00 这段窗口会判失败,重复提示用户再生成一次(多花一次 AI 调用)。

`app/services/market_recap_reports.py` 的文档里给的样例 `"created_at": "2026-06-27T15:35:00"`(收盘后的北京墙钟)也说明这里的口径本来就应该是北京时间。

## 根因

`backend/app/services/json_report_store.py`

```python
    @staticmethod
    def _now_iso() -> str:
        """当前本地时间 ISO 字符串(带秒精度,前端 toLocaleString 友好)。"""
        from datetime import datetime
        return datetime.now().isoformat(timespec="seconds")
```

`datetime.now()` 无时区,取的是进程所在宿主机的墙钟。`CONTRIBUTING.md` §3.3 明确要求「A 股交易时段统一按北京时间处理;服务器时区不能成为业务逻辑的隐式输入」,仓库为此提供了 `app/market_time.cn_now()` / `cn_today()`,`kline.py` / `quote_service.py` / `ext_pull.py` / `depth_service.py` 等 17 个模块都已改用,`json_report_store` 是漏掉的一处。

## 解决方案

改用 `app.market_time.cn_now()`,再 `replace(tzinfo=None)` 保持**原有 naive 秒精度格式完全不变**:

```python
        return cn_now().replace(tzinfo=None).isoformat(timespec="seconds")
```

没有改成带 `+08:00` 的 aware 字符串,是为了不动历史记录与前端解析的兼容面(见下)。`app.market_time` 不依赖 app 内任何模块,模块级 import 不引入循环依赖。

## 兼容性

- 存储格式不变:仍是 `YYYY-MM-DDTHH:MM:SS`,长度 19、无时区后缀。历史 JSON 可继续读取。
- 排序不变:`list_reports` / `_save_all` 按 `created_at` 字符串降序,新旧记录格式一致,混排结果正确。
- 裁剪到 `max_reports` 的语义不变。
- 前端 `AiReport.created_at` 类型契约不变,无需改动。
- 行为变化仅限「宿主机时区非 UTC+8 时,新写入的时间戳换成北京墙钟」;UTC+8 的机器上完全无变化。

## 性能

不在实时/列表热路径。`cn_now()` 是一次 `datetime.now(tz)`,与原 `datetime.now()` 同量级。

## 验证结果

环境:Windows,宿主机时区 UTC+9(比北京快 1 小时),Python 3.12,`python -m pytest`。

**修复前**(未改动 `app/services/json_report_store.py`,只加新测试):

```
$ python -m pytest tests/test_json_report_store_timezone.py -q
F.                                                                       [100%]
================================== FAILURES ===================================
____________________ test_created_at_follows_beijing_clock ____________________
        got = datetime.fromisoformat(saved["created_at"])
        expected = datetime.now(CN_TZ).replace(tzinfo=None)
>       assert abs((got - expected).total_seconds()) < 5
E       assert 3599.211483 < 5
E        +  where 3599.211483 = abs(3599.211483)
E        +      where ... = (datetime.datetime(2026, 9, 9, 7, 5, 40) - datetime.datetime(2026, 9, 9, 6, 5, 40, 788517)).total_seconds
tests\test_json_report_store_timezone.py:32: AssertionError
=========================== short test summary info ===========================
FAILED tests/test_json_report_store_timezone.py::test_created_at_follows_beijing_clock
1 failed, 1 passed in 0.68s
```

差值正好是宿主机与北京的时区差(UTC+9 → 3600 秒);UTC 容器上会是 28800 秒。

**修复后**:

```
$ python -m pytest tests/test_json_report_store_timezone.py -q
..                                                                       [100%]
2 passed in 0.12s
```

受影响模块定向回归(报告 / 复盘 / 个股分析相关用例):

```
$ python -m pytest tests -q -k "report or recap or analysis or review" --ignore=tests/test_watchdog.py
37 passed, 1755 deselected, 5 warnings in 7.62s
```

Ruff(`app/services/json_report_store.py` 与新测试文件本次改动未引入新告警;该文件在未修改分支上同样报 1 条历史 `RUF100`,按「不为清理历史告警做无关改动」保留):

```
$ ruff check tests/test_json_report_store_timezone.py
All checks passed!
```

`git diff --check` 无输出。

全量后端测试按仓库现状排除 `tests/test_watchdog.py`(该用例在本机未修改分支上也会挂住)。本机高负载下 `tests/backtest/test_worker_process.py`、`tests/test_mining_manager.py` 里的子进程/计时用例偶发失败,单独重跑通过,未修改分支同样偶发,与本改动无关。

## 界面证据

无 UI 结构变化;可见差异是报告列表里的相对时间文案(UTC 部署下由「8 小时前」变回「刚刚」)。该差异依赖服务器时区,无法在 UTC+8 开发机上截出对比图,故以上面的时区断言测试作为证据。

## 风险与回滚

- 剩余风险:非北京时区的浏览器仍会把这串 naive 时间按本地时区渲染。这是既有契约(全站按北京墙钟展示),本 PR 不改变它;若后续要彻底解决,应统一改成带偏移的 aware 字符串并同步前端,属另一个改动。
- 回滚:还原 `_now_iso` 一个方法即可,存储格式没变,不需要数据迁移。
