### PR TITLE
fix(settings): 端点清单缓存未预热时端点测速 500

### DIFF
--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -1666,7 +1666,9 @@ async def test_endpoint(req: TestEndpointIn) -> dict:
     import statistics
 
     base = req.url.rstrip("/")
-    rounds = max(1, min(10, req.rounds or _endpoints_cache.get("data", {}).get("testRounds", 5)))
+    # 缓存初值的 "data" 是 None(键存在, get 的默认值不生效), 端点清单未预热时要兜底
+    manifest = _endpoints_cache.get("data") or {}
+    rounds = max(1, min(10, req.rounds or manifest.get("testRounds", 5)))
     health_url = base + "/health"
 
     latencies: list[float] = []

--- a/backend/tests/test_endpoint_latency_cold_cache.py
+++ b/backend/tests/test_endpoint_latency_cold_cache.py
@@ -1,0 +1,48 @@
+"""端点测速接口: 端点清单缓存未预热时的默认轮数不能崩。
+
+_endpoints_cache 的初值是 {"ts": 0.0, "data": None} —— 进程启动后直到第一次
+GET /api/settings/endpoints 之前, "data" 键存在但值为 None。前端 endpoints 查询
+有 5 分钟 staleTime, 后端(看门狗自愈/重启)重启后用户再点测速, 就落在这个窗口里。
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.api import settings as settings_api
+
+
+@pytest.fixture(autouse=True)
+def _cold_cache_and_fake_ping(monkeypatch):
+    """还原进程刚启动时的缓存初值, 并把网络探测换成固定延迟。"""
+    monkeypatch.setattr(settings_api, "_endpoints_cache", {"ts": 0.0, "data": None})
+
+    async def _ping(url: str, timeout: float = 10.0) -> float:
+        return 12.5
+
+    monkeypatch.setattr(settings_api, "_http_ping", _ping)
+
+
+async def test_latency_test_falls_back_to_default_rounds_on_cold_cache():
+    """缓存未预热且请求不带 rounds 时, 回退到默认 5 轮而不是 500。"""
+    result = await settings_api.test_endpoint(
+        settings_api.TestEndpointIn(url="https://api.example.com"),
+    )
+
+    assert result["ok"] is True
+    assert result["rounds"] == 5
+    assert result["success"] == 5
+    assert result["median_ms"] == 12.5
+
+
+async def test_latency_test_uses_manifest_rounds_when_cache_is_warm(monkeypatch):
+    """缓存已预热时仍取 endpoints.json 的 testRounds。"""
+    monkeypatch.setattr(
+        settings_api, "_endpoints_cache", {"ts": 0.0, "data": {"testRounds": 2}},
+    )
+
+    result = await settings_api.test_endpoint(
+        settings_api.TestEndpointIn(url="https://api.example.com"),
+    )
+
+    assert result["rounds"] == 2
+    assert result["success"] == 2


### PR DESCRIPTION
## 问题与复现

进程启动后、第一次 `GET /api/settings/endpoints` 之前,调用 `POST /api/settings/test_endpoint` 且不带 `rounds`,直接 500。

```
$ POST /api/settings/test_endpoint  {"url": "https://api.example.com"}
HTTP 500 Internal Server Error
AttributeError: 'NoneType' object has no attribute 'get'
  app/api/settings.py:1669
```

看起来像「只有直接调 API 才会碰到」,但 UI 上有一条很自然的路径:

- `frontend/src/components/EndpointTestDialog.tsx:28-31` 的 `listEndpoints` 查询设了 `staleTime: 5 * 60 * 1000`;
- 后端重启(手动重启、容器重拉,或 `app/watchdog.py` 的自愈退出后被 supervisor 拉起)后,前端在这 5 分钟内**不会**重新请求 `/endpoints`,后端的 `_endpoints_cache` 却已经回到初值;
- 用户此时点「测速」/「全部测速」,`testRounds` 取自旧的前端缓存 —— 若远端 `endpoints.json` 未提供该字段则为 `undefined`,`JSON.stringify` 会把 `rounds` 整个丢掉,请求打到后端就正好落在这个窗口里,整排端点全部报错。

## 根因

`backend/app/api/settings.py:1576`

```python
_endpoints_cache: dict = {"ts": 0.0, "data": None}
```

`backend/app/api/settings.py:1669`

```python
    rounds = max(1, min(10, req.rounds or _endpoints_cache.get("data", {}).get("testRounds", 5)))
```

`dict.get(key, default)` 只在**键不存在**时返回默认值。`"data"` 这个键从模块加载起就存在,值是 `None`,所以 `{}` 兜底根本不生效,后面直接在 `None` 上调 `.get`。写这个缓存的地方只有 `list_endpoints`(`settings.py:1629-1630`),它也从不把 `data` 重置回 `None`,所以窗口就是「进程启动 → 第一次 `/endpoints`」。

`app/main.py` 只注册了 `CapabilityDenied` 一个异常处理器,`AttributeError` 直接逃到 Starlette,返回 500。

## 解决方案

先按 `or {}` 兜底拿到清单,再取 `testRounds`,默认 5 轮的语义不变:

```python
    # 缓存初值的 "data" 是 None(键存在, get 的默认值不生效), 端点清单未预热时要兜底
    manifest = _endpoints_cache.get("data") or {}
    rounds = max(1, min(10, req.rounds or manifest.get("testRounds", 5)))
```

`or {}` 与同文件 `list_endpoints` 里 `cached = _endpoints_cache.get("data")` + `if cached is not None` 的判定口径一致。只动这一处,不改端点发现、缓存 TTL、回退列表和响应结构。

## 兼容性

- 请求/响应契约不变。缓存已预热时 `rounds` 仍取 `endpoints.json` 的 `testRounds`,显式传 `rounds` 时仍优先用显式值,`max(1, min(10, ...))` 的钳制范围不变。
- 前端 `api.testEndpoint` 与 `EndpointTestDialog` 不需要改。

## 性能

不在实时/列表热路径。改动是一次 `or` 判断,无额外 IO。

## 验证结果

环境:Windows,Python 3.12,`python -m pytest`(仓库 `asyncio_mode = "auto"`)。

**修复前**(未改动 `app/api/settings.py`,只加新测试):

```
$ python -m pytest tests/test_endpoint_latency_cold_cache.py -q
    base = req.url.rstrip("/")
>   rounds = max(1, min(10, req.rounds or _endpoints_cache.get("data", {}).get("testRounds", 5)))
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   AttributeError: 'NoneType' object has no attribute 'get'
app\api\settings.py:1669: AttributeError
=========================== short test summary info ===========================
FAILED tests/test_endpoint_latency_cold_cache.py::test_latency_test_falls_back_to_default_rounds_on_cold_cache
1 failed, 1 passed in 1.87s
```

同一状态下走完整 HTTP 栈(`TestClient(app, raise_server_exceptions=False)`,把 `_endpoints_cache["data"]` 置回 `None` 后 POST 该端点)确认外部可见结果是 500:

```
HTTP 500 Internal Server Error
```

**修复后**:

```
$ python -m pytest tests/test_endpoint_latency_cold_cache.py -q
..                                                                       [100%]
2 passed in 3.18s
```

同一段 HTTP 复现脚本改后返回 `HTTP 200`。

受影响模块定向回归(设置 / 端点 / 通知 / 能力 / 偏好相关用例):

```
$ python -m pytest tests -q -k "setting or endpoint or notification or capability or preference" --ignore=tests/test_watchdog.py
89 passed, 1703 deselected, 2 warnings in 7.62s
```

Ruff:`app/api/settings.py` 在未修改分支与本分支上都是 `Found 51 errors`(全部为历史的全角标点 / 导入排序 / 无效 noqa),本次改动**未新增任何告警**,也没有为清理历史告警做无关改动;新测试文件 `All checks passed!`。

`git diff --check` 无输出。

全量后端测试按仓库现状排除 `tests/test_watchdog.py`(该用例在本机未修改分支上也会挂住)。本机高负载下 `tests/backtest/test_worker_process.py`、`tests/test_mining_manager.py` 里的子进程/计时用例偶发失败,单独重跑通过,未修改分支同样偶发,与本改动无关。

## 界面证据

无 UI 结构变化。可见差异是「端点测速」对话框在后端刚重启时不再整排显示请求失败,而是正常给出中位延迟;该场景依赖后端重启时序,以上面的接口级证据(500 → 200)代替截图。

## 风险与回滚

- 剩余风险:`TestEndpointIn.rounds` 仍是无边界的 `int | None`,`rounds: -5` / `rounds: 9999` 会被静默钳到 1 / 10 而不是 422 —— 这与同文件 `DataSourceJobTimeoutPrefs`(`Field(ge=60)`)、`MiningSchedulePrefs`(`Field(ge=0, le=4)`)的声明式校验不一致。属另一个问题,本 PR 不夹带。
- 回滚:还原这两行即可,无状态、无数据迁移。
