### PR TITLE
fix(fundamentals): 换报告期公告当日不再丢失上一期财务因子值 (与矩阵路径口径对齐)

### DIFF
--- a/backend/app/backtest/fundamentals.py
+++ b/backend/app/backtest/fundamentals.py
@@ -103,11 +103,18 @@ def attach_fundamental_factors(
     columns = sorted(
         {FUNDAMENTAL_FACTORS[name]["column"] for name in missing_columns}
     )
-    right = snapshot.select(["symbol", "_announce", *columns]).sort(["symbol", "_announce"])
+    # asof 键取生效日 (公告日次日) 而非公告日: 直接用公告日回看会在换报告期的
+    # 公告当日取到「尚未生效」的新一期并被门控置 null, 打断上一期的前向填充,
+    # 与矩阵路径 (searchsorted side="right") 不一致。
+    right = (
+        snapshot.select(["symbol", "_announce", *columns])
+        .with_columns(pl.col("_announce").dt.offset_by("1d").alias("_effective"))
+        .sort(["symbol", "_effective"])
+    )
     joined = panel.join_asof(
         right,
         left_on="date",
-        right_on="_announce",
+        right_on="_effective",
         by="symbol",
         strategy="backward",
         check_sortedness=False,  # 双侧均已按 (symbol, key) 排序, 免除逐组检查开销
@@ -128,7 +135,7 @@ def attach_fundamental_factors(
         expressions.append(
             pl.when(announced).then(value).otherwise(None).alias(name)
         )
-    return joined.with_columns(expressions)
+    return joined.with_columns(expressions).drop("_effective")
 
 
 def build_fundamental_matrices(

--- a/backend/tests/test_fundamental_factors.py
+++ b/backend/tests/test_fundamental_factors.py
@@ -85,7 +85,7 @@ def test_attach_replaces_with_newer_announcement():
     assert roe[4] is None            # 4-5 公告日
     assert roe[5] == 20.0            # 4-6 起 20.0
     assert roe[13] == 20.0           # 4-14
-    assert roe[14] is None           # 4-15 二次公告日, 当天仍不可用 (严格大于)
+    assert roe[14] == 20.0           # 4-15 二次公告日: 新一期尚未生效, 仍保留上一期
     assert roe[15] == 33.0           # 4-16 起新公告生效
 
 
@@ -119,6 +119,25 @@ def test_matrix_field_matches_polars_attach():
                 assert np.isnan(actual), (name, row["date"], row["symbol"], actual)
             else:
                 np.testing.assert_allclose(actual, expected, rtol=1e-6)
+
+
+def test_matrix_field_matches_polars_attach_across_two_announcements():
+    """换报告期时两条路径仍须一致: 新公告当日应保留上一期值(前向填充不断档)。"""
+    panel = _daily_panel(date(2026, 4, 1), 20, ("600000.SH",))
+    snapshot = _snapshot_frame([
+        {"symbol": "600000.SH", "announce": "2026-04-05", "roe": 20.0},
+        {"symbol": "600000.SH", "announce": "2026-04-15", "roe": 33.0},
+    ])
+    attached = attach_fundamental_factors(panel, snapshot, ["roe_latest"]).sort("date")
+    market = build_market_data_matrix(panel)
+    matrix = build_fundamental_matrices(market, snapshot, ["roe_latest"])["roe_latest"]
+    column = market.symbols.index("600000.SH")
+    for row_index, value in enumerate(attached["roe_latest"].to_list()):
+        actual = matrix[row_index, column]
+        if value is None:
+            assert np.isnan(actual), (row_index, actual)
+        else:
+            np.testing.assert_allclose(actual, value, rtol=1e-6)
 
 
 def test_bps_nonpositive_gives_null_pb():


### PR DESCRIPTION
## 问题

财务因子有两条并行实现,模块内明确要求同口径:

- `attach_fundamental_factors` (polars 面板路径:回测加载口 `engine.py`、因子检验 `factor.py`、挖掘 `mining_runtime.py`)
- `build_fundamental_matrices` (矩阵路径),其 docstring 写着「**与 `attach_fundamental_factors` 同一口径**: 公告日次一交易日起前向填充」

两者在**换报告期的公告当日**结果不一致。

polars 路径先按公告日做 asof 回看,再用严格大于门控:

```python
right = snapshot.select(["symbol", "_announce", *columns]).sort(["symbol", "_announce"])
joined = panel.join_asof(right, left_on="date", right_on="_announce", by="symbol", strategy="backward", ...)
announced = pl.col("_announce").is_not_null() & (pl.col("date") > pl.col("_announce"))
```

当日期正好等于**新一期**的公告日时,`join_asof` 已经把行匹配到那条「当天还不能用」的新记录上,门控随即把整行置 null —— 上一期**已经生效**的值就此丢失,因子序列出现一天空洞。矩阵路径不会:它对每条公告做 `searchsorted(..., side="right")` 后 `target[start:, col] = value`,新一期从公告次日才覆盖,公告当日自然保留上一期,即真正的前向填充。

后果:

- 同一份配置在矩阵回测与 polars 面板路径(因子检验 / 挖掘)上给出不同的因子值;
- 换报告期公告当日该标的因子为 null,按模块 docstring「下游 IC/分层/评分对 null 自动剔除」直接掉出当日截面。A 股财报公告高度集中(4 月底 / 8 月底 / 10 月底),这一天恰好是大批标的同时换期,截面样本会成片缺口。

点时(point-in-time)语义上正确的值是上一期:4-15 早盘时,4-5 公告的那期财报确实已经公开可用。

## 复现(修改源码前,在 origin/main `9a4bdcd` 上运行)

仓库已有 `test_matrix_field_matches_polars_attach` 锁定两条路径一致,但用例里每个标的只有一条公告,覆盖不到换期。补一个两条公告的同类用例后:

```
$ python -m pytest tests/test_fundamental_factors.py -q
....F.....                                                               [100%]
================================== FAILURES ===================================
______ test_matrix_field_matches_polars_attach_across_two_announcements _______
        attached = attach_fundamental_factors(panel, snapshot, ["roe_latest"]).sort("date")
        market = build_market_data_matrix(panel)
        matrix = build_fundamental_matrices(market, snapshot, ["roe_latest"])["roe_latest"]
        column = market.symbols.index("600000.SH")
        for row_index, value in enumerate(attached["roe_latest"].to_list()):
            actual = matrix[row_index, column]
            if value is None:
>               assert np.isnan(actual), (row_index, actual)
E               AssertionError: (14, np.float32(20.0))
E               assert np.False_
E                +  where np.False_ = <ufunc 'isnan'>(np.float32(20.0))
E                +    where <ufunc 'isnan'> = np.isnan

tests\test_fundamental_factors.py:138: AssertionError
=========================== short test summary info ===========================
FAILED tests/test_fundamental_factors.py::test_matrix_field_matches_polars_attach_across_two_announcements
1 failed, 9 passed in 10.21s
```

`row_index=14` 即 2026-04-15(第二条公告日):矩阵路径给 20.0(上一期),polars 路径给 null。

两条路径的完整序列(公告 4-05 → roe 20.0,公告 4-15 → roe 33.0,面板 4-01 ~ 4-20):

```
# 修改前
polars : [None, None, None, None, None, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, None, 33.0, 33.0, 33.0, 33.0, 33.0]
matrix : [nan, nan, nan, nan, nan, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 33.0, 33.0, 33.0, 33.0, 33.0]
```

## 修改

asof 键改成**生效日**(公告日次日),让回看只命中已经生效的报告期;严格大于的门控保留不动(公告前仍为 null)。

```python
right = (
    snapshot.select(["symbol", "_announce", *columns])
    .with_columns(pl.col("_announce").dt.offset_by("1d").alias("_effective"))
    .sort(["symbol", "_effective"])
)
joined = panel.join_asof(..., right_on="_effective", ...)
```

`_effective` 在返回前 drop 掉,输出列与改动前完全一致。矩阵路径不动。

## 验证

```
# 修改后
polars : [None, None, None, None, None, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 33.0, 33.0, 33.0, 33.0, 33.0]
matrix : [nan, nan, nan, nan, nan, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 33.0, 33.0, 33.0, 33.0, 33.0]
```

```
$ python -m pytest tests/test_fundamental_factors.py -q
..........                                                               [100%]
10 passed in 1.05s
```

`test_attach_replaces_with_newer_announcement` 里 `roe[14] is None` 这条断言同步改为 `roe[14] == 20.0`:它原本把「新一期尚未生效」记成了「当天没有任何可用值」,与同文件的矩阵一致性契约和 `build_fundamental_matrices` 的「前向填充」描述相抵触。首次公告前保持 null 的断言(`roe[4] is None`)不变。

全量后端测试:

```
$ python -m pytest tests -q --ignore=tests/test_watchdog.py
1791 passed, 100 warnings in 120.03s (0:02:00)
```

(`tests/test_watchdog.py` 在本机未改动的 main 上也会挂住,故 `--ignore` 排除。)
