### PR TITLE
fix(factors): 删除因子被拒绝时定义已被删掉 (删除路径未 fail-closed)

### DIFF
--- a/backend/app/api/factors.py
+++ b/backend/app/api/factors.py
@@ -381,14 +381,16 @@ def delete_custom_factor(factor_id: str, request: Request, force: bool = Query(d
     data_dir = _data_dir(request)
     from app.factors.registry import get_factor
 
-    if get_factor(factor_id) is None and not store.delete_one(data_dir, factor_id):
-        raise HTTPException(status_code=404, detail=f"因子不存在: {factor_id}")
+    # 引用检查必须排在存在性判定之前: 下面用来探测「盘上是否有定义」的
+    # store.delete_one 本身就会删文件, 反过来会出现「拒绝删除」但定义已被删掉。
     references = _find_references(data_dir, factor_id)
     if references and not force:
         raise HTTPException(
             status_code=409,
             detail={"message": "该因子仍有引用, 拒绝删除 (可带 force=true 强制)", "references": references},
         )
+    if get_factor(factor_id) is None and not store.delete_one(data_dir, factor_id):
+        raise HTTPException(status_code=404, detail=f"因子不存在: {factor_id}")
     try:
         unregister_factor(factor_id)
     except ValueError as exc:

--- a/backend/tests/test_factor_delete_fail_closed.py
+++ b/backend/tests/test_factor_delete_fail_closed.py
@@ -1,0 +1,80 @@
+"""删除自定义因子: 有引用时必须 fail-closed —— 拒绝的同时定义文件不能已经被删掉。
+
+触发路径: 定义在磁盘上但没进注册表 (load_into_registry 对注册失败的定义只告警跳过,
+如复合因子的成员已被强制删除)。此时 get_factor() 为 None, 端点的 404 守卫会走到
+第二个分支, 而那个分支本身就会把文件删掉。
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.factors import router
+
+FACTOR_ID = "uf_orphan_delete_guard"
+
+
+@pytest.fixture()
+def env(tmp_path):
+    """磁盘上有一个未注册的自定义因子, 且被一个策略引用。"""
+    factor_dir = tmp_path / "user_data" / "custom_factors"
+    factor_dir.mkdir(parents=True)
+    factor_path = factor_dir / f"{FACTOR_ID}.json"
+    factor_path.write_text(
+        json.dumps({
+            "id": FACTOR_ID,
+            "kind": "custom",
+            "label": "孤儿因子",
+            "formula": "rank(-ts_sum(change_pct, 5))",
+            "version": 1,
+            "status": "draft",
+        }, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    strategies_dir = tmp_path / "strategies"
+    strategies_dir.mkdir(parents=True)
+    (strategies_dir / "s1.json").write_text(
+        json.dumps({"id": "s1", "factors": [FACTOR_ID]}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.repo = SimpleNamespace(store=SimpleNamespace(data_dir=Path(tmp_path)))
+    return TestClient(app), factor_path
+
+
+def test_delete_with_references_keeps_definition(env):
+    """409 拒绝删除时定义必须还在盘上, 否则用户既看不到因子也无法恢复。"""
+    client, factor_path = env
+
+    response = client.delete(f"/api/factors/custom/{FACTOR_ID}")
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["references"] == ["strategies/s1.json"]
+    assert factor_path.exists()
+
+
+def test_delete_with_force_removes_definition(env):
+    """force=true 仍按原语义强制删除。"""
+    client, factor_path = env
+
+    response = client.delete(f"/api/factors/custom/{FACTOR_ID}?force=true")
+
+    assert response.status_code == 200
+    assert response.json()["removed_references"] == ["strategies/s1.json"]
+    assert not factor_path.exists()
+
+
+def test_delete_missing_factor_returns_404(env):
+    """不存在的因子仍返回 404。"""
+    client, _ = env
+
+    response = client.delete("/api/factors/custom/uf_not_there_at_all")
+
+    assert response.status_code == 404


### PR DESCRIPTION
## 问题与复现

`DELETE /api/factors/custom/{factor_id}` 在「有引用 → 拒绝删除」这条路径上会**先把定义文件删掉再报错**:接口返回 409「该因子仍有引用, 拒绝删除 (可带 force=true 强制)」,但 `data/user_data/custom_factors/{id}.json` 已经不在了。用户按提示改带 `force=true` 重试,只会拿到 404,定义无法恢复;被引用的策略同时静默失去这一列。

复现条件(全部是设计上允许出现的状态):

1. 磁盘上有自定义/复合因子定义,但**没进注册表**。`store.load_into_registry`(`app/factors/store.py:165-189`)对注册失败的定义只 `logger.warning("custom factor 注册失败 %s")` 并跳过 —— 例如复合因子的成员此前被 `force=true` 删掉、或自定义因子的公式在扩展数据字段变更后编译不过。此时 `get_factor(id)` 为 `None`,文件还在。
2. `data/strategies/*.json` 里有策略引用该因子(`_find_references` 走的是文本包含判定)。
3. 调用 `DELETE /api/factors/custom/{id}`(不带 `force`)。

结果:409 + 文件已被删除。

## 根因

`backend/app/api/factors.py:378-393`

```python
    if get_factor(factor_id) is None and not store.delete_one(data_dir, factor_id):
        raise HTTPException(status_code=404, detail=f"因子不存在: {factor_id}")
    references = _find_references(data_dir, factor_id)
    if references and not force:
        raise HTTPException(status_code=409, detail={...})
```

`store.delete_one`(`app/factors/store.py:53-58`)不是谓词 —— 它 `unlink()` 文件后返回 `True`:

```python
def delete_one(data_dir: Path, factor_id: str) -> bool:
    target = _path(data_dir, factor_id)
    if target.exists():
        target.unlink()
        return True
    return False
```

`and` 的短路求值决定了:只要 `get_factor(factor_id) is None`(即上面那个「在盘上但没注册」的状态),`delete_one` 就会被求值,文件当场被删。随后的引用检查再抛 409,于是「拒绝」这条 fail-closed 路径实际上已经改了磁盘。

这正是 `CONTRIBUTING.md` §5.1 / §12 点名的情况:删除用户文件必须 fail-closed,失败路径不得继续执行副作用。

## 解决方案

把 fail-closed 的引用检查移到存在性判定之前,保证任何拒绝路径都不碰磁盘:

```python
    # 引用检查必须排在存在性判定之前: 下面用来探测「盘上是否有定义」的
    # store.delete_one 本身就会删文件, 反过来会出现「拒绝删除」但定义已被删掉。
    references = _find_references(data_dir, factor_id)
    if references and not force:
        raise HTTPException(status_code=409, detail={...})
    if get_factor(factor_id) is None and not store.delete_one(data_dir, factor_id):
        raise HTTPException(status_code=404, detail=f"因子不存在: {factor_id}")
```

只调换两段的顺序,没有引入新的存在性探测接口。走到 `delete_one` 时已经确定「要删」,它的返回值此时才是合法的「盘上原本有没有」判定。刻意没有改用 `store.load_all` 之类做存在性检查:那会让 JSON 已损坏的定义变成 404 而删不掉,属于新的回归。

`app/factors/store.py` 未改动。

## 兼容性

- 三条出口的状态码与响应体全部保持原样:有引用且不带 force → 409(含 `references` 列表);不存在 → 404;正常/`force=true` → 200 `{"ok", "id", "removed_references"}`。
- 唯一的行为差异:「不存在的因子 id」恰好又能在某个策略 JSON 文本里匹配到时,会先返回 409 而不是 404。对真实不存在的 id,`_find_references` 返回空表,仍走 404。
- 不涉及数据格式、缓存、Parquet、provider 能力。

## 性能

`_find_references` 提前执行,不改变调用次数(原来在 404 之后也一样会执行一次)。不在实时行情或列表热路径。

## 验证结果

环境:Windows,Python 3.12,`python -m pytest`。

新增 `backend/tests/test_factor_delete_fail_closed.py`,在 `tmp_path` 下造出「盘上有定义 + 未注册 + 被策略引用」的状态,走 `TestClient` 打真实路由。

**修复前**(未改动 `app/api/factors.py`,只加新测试):

```
$ python -m pytest tests/test_factor_delete_fail_closed.py -q
F..                                                                      [100%]
================================== FAILURES ===================================
________________ test_delete_with_references_keeps_definition _________________
        response = client.delete(f"/api/factors/custom/{FACTOR_ID}")

        assert response.status_code == 409
        assert response.json()["detail"]["references"] == ["strategies/s1.json"]
>       assert factor_path.exists()
E       AssertionError: assert False
E        +  where False = exists()
E        +    where exists = WindowsPath('.../user_data/custom_factors/uf_orphan_delete_guard.json').exists
tests\test_factor_delete_fail_closed.py:60: AssertionError
=========================== short test summary info ===========================
FAILED tests/test_factor_delete_fail_closed.py::test_delete_with_references_keeps_definition
1 failed, 2 passed in 9.28s
```

即:接口确实返回了 409 且引用列表正确,但定义文件已经被删掉 —— 与描述完全一致。

**修复后**:

```
$ python -m pytest tests/test_factor_delete_fail_closed.py -q
...                                                                      [100%]
3 passed in 11.56s
```

受影响模块定向回归(因子 API / 注册表 / 存储 / 因子库 / 扩展因子):

```
$ python -m pytest tests/test_factor_delete_fail_closed.py tests/test_factor_api.py tests/test_factor_registry.py tests/test_factor_store.py tests/test_factor_library_v2.py tests/test_ext_factors.py -q
55 passed in 2.37s
```

Ruff:`app/api/factors.py` 在未修改分支与本分支上均 `All checks passed!`;新测试文件 `All checks passed!`。

`git diff --check` 无输出。

全量后端测试按仓库现状排除 `tests/test_watchdog.py`(该用例在本机未修改分支上也会挂住)。本机高负载下 `tests/backtest/test_worker_process.py`、`tests/test_mining_manager.py` 里的子进程/计时用例偶发失败(每次失败的用例名都不同,单独重跑通过,未修改分支同样偶发),与本改动无关。

## 界面证据

无 UI 结构变化;可见差异是「因子仍有引用,拒绝删除」提示之后因子仍留在列表里(修复前会消失)。该状态需要一个注册失败的定义才能构造,以上面的接口 + 文件系统断言代替截图。

## 风险与回滚

- 剩余风险:末尾的 `unregister_factor` 若抛 `ValueError`(内置因子不可注销)仍会发生在 `delete_one` 之后。该分支需要 `get_factor()` 为 `None` 同时 `factor_id` 又是内置目录因子,当前代码路径构造不出来,本 PR 不做扩大改动。
- 覆盖测试:新增用例同时锁住了 `force=true` 仍能删除、以及不存在的因子仍返回 404 两条边界。
- 回滚:调换回两段代码的顺序即可,无状态、无数据迁移。
