### PR TITLE
fix(kline): 实时行情覆写当日日K分区时补写 quote_ts

### DIFF
--- a/backend/app/services/kline_sync.py
+++ b/backend/app/services/kline_sync.py
@@ -318,11 +318,15 @@ def sync_daily_by_quotes(repo: KlineRepository) -> int:
             "close": q.get("last_price"),
             "volume": q.get("volume"),
             "amount": q.get("amount"),
+            # 快照时刻标记: data_integrity 靠 quote_ts 区分盘中快照与盘后权威历史,
+            # 缺失会让盘中覆写的分区在停机后被当成完整历史, 永远不进修复。
+            "quote_ts": q.get("timestamp"),
         })
 
     df = pl.DataFrame(records)
     if df.is_empty():
         return 0
+    df = df.with_columns(pl.col("quote_ts").cast(pl.Int64, strict=False))
 
     # 分区日期用北京交易日 (与 quote_service._build_daily 的 cn_today 一致),
     # 避免 UTC 服务器在盘中把日分区写成服务器本地日期。

--- a/backend/tests/test_data_integrity.py
+++ b/backend/tests/test_data_integrity.py
@@ -624,3 +624,40 @@ def test_pipeline_self_heals_snapshot_day(tmp_path, monkeypatch):
     )
     assert enriched_left == [f"date={yesterday.isoformat()}", f"date={today.isoformat()}"]
     assert result["enriched_days"] > 0
+
+
+def test_quotes_flush_partition_keeps_quote_ts_for_integrity_scan(tmp_path, monkeypatch):
+    """实时行情覆写当日分区必须写 quote_ts, 否则停机后自检漏判盘中快照。
+
+    盘中手动触发盘后管道时, "今天已有数据 → 实时行情覆写"分支会用
+    tf.quotes.get_by_universes 整分区覆写。若覆写不带 quote_ts, 停机后次日
+    启动自检把这份半日数据当成 batch 权威历史, 停机时刻的 close/volume 永久
+    留存并污染 lookback 指标 —— 正是本模块要拦的场景。
+    """
+    from app.services import kline_sync
+    from app.tickflow import client as tf_client
+    from app.tickflow.repository import DataStore, KlineRepository
+
+    snapshot_ms = _ts_ms(FRIDAY, time(11, 58))
+
+    class _FakeQuotes:
+        @staticmethod
+        def get_by_universes(universes):
+            return [{
+                "symbol": "600001.SH",
+                "open": 10.0, "high": 10.2, "low": 9.8, "last_price": 10.1,
+                "volume": 1000.0, "amount": 10100.0,
+                "timestamp": snapshot_ms,
+            }]
+
+    monkeypatch.setattr(tf_client, "get_client", lambda: SimpleNamespace(quotes=_FakeQuotes))
+    monkeypatch.setattr(kline_sync, "cn_today", lambda: FRIDAY)
+
+    repo = KlineRepository(DataStore(tmp_path))
+    assert kline_sync.sync_daily_by_quotes(repo) == 1
+
+    issues = scan_recent_integrity(tmp_path, today=TODAY)
+    assert [(i.day, i.table, i.kind) for i in issues] == [(FRIDAY, "kline_daily", "snapshot")]
+
+    part_dir = tmp_path / "kline_daily" / f"date={FRIDAY.isoformat()}"
+    assert _quote_ts_max_ms(part_dir) == snapshot_ms


### PR DESCRIPTION
## 1. 问题与复现

`kline_daily` 当日分区有两个写入方，但只有一个写 `quote_ts`：

- `quote_service._build_daily` → 写 `quote_ts`（`timestamp` → `quote_ts`）。
- `kline_sync.sync_daily_by_quotes` → **不写 `quote_ts`**，且用的是 `flush_live_daily` 的整分区覆写语义。

`data_integrity` 模块的判据完全建立在 `quote_ts` 上（模块 docstring：`null` = batch 拉取/盘后计算写入的权威历史 → 完整）。于是走过 `sync_daily_by_quotes` 的分区在自检眼里是"权威历史"，即使它其实是盘中半日快照。

复现路径（盘后管道分支 3）：

1. 盘中（如 11:58）用户在数据页手动触发一次同步。此时 `today_exists`（QuoteService 已落盘）+ `QUOTE_POOL` + `daily_data_provider == tickflow` → 走 `sync_daily_by_quotes`，整分区覆写，`quote_ts` 消失。
2. 用户随后关机。
3. 次日启动 `boot_integrity_check` → `scan_recent_integrity` 读该分区的 `max(quote_ts)` → 列不存在 → `None` → `_is_snapshot` 返回 `False` → 不算坏分区。
4. 停机时刻的 `close`（= 11:58 的价）与半日 `volume` 永久留在历史里，并污染后续 lookback 类指标 —— 正是该模块 docstring 里要拦的场景。

## 2. 根因

`sync_daily_by_quotes` 手工拼 record dict 时只搬了 OHLCV，漏了实时行情响应里的 `timestamp` 字段：

```python
records.append({
    "symbol": q.get("symbol"),
    "open": q.get("open"), "high": q.get("high"), "low": q.get("low"),
    "close": q.get("last_price"),
    "volume": q.get("volume"),
    "amount": q.get("amount"),
})   # ← 少了 timestamp → quote_ts
```

`flush_live_daily` 是整分区覆写（`_atomic_write_parquet`），所以之前由 QuoteService 写进去的 `quote_ts` 也一并被抹掉，分区从"可判别"退化成"不可判别"。

## 3. 解决方案

在 record 里补 `"quote_ts": q.get("timestamp")`，并显式 `cast(pl.Int64, strict=False)`（与 `_build_daily` 同口径、与 `DAILY_STORAGE_SCHEMA` 的 `quote_ts: Int64` 一致；上游缺字段时为 null，等价于当前行为）。

只补这一列，没有把 `_build_daily` 的其它逻辑（停牌股旧日快照过滤、`open/high/low` 用 `close` 兜底）搬过来 —— 那是各自独立的问题，不在本 PR 范围内。

## 4. 兼容性

- **Parquet schema**：`quote_ts` 本就在 `DAILY_STORAGE_SCHEMA` 里，且是 `scan_daily_parquet` 的既有列；历史分区缺该列时由 `missing_columns="insert"` 兜底，旧数据仍可读。
- **行为变化（需要留意）**：盘后执行该分支时，分区会带上真实的收盘时刻 `quote_ts`。若某次执行时上游快照的 `max(quote_ts)` 尚未越过 15:00 定版线，次日自检会把该分区判为盘中快照并触发一次自动修复（batch 重拉）。这与 `quote_service` 已有的定版边界判据（"final 快照未达定版边界…本轮跳过落盘"）口径一致：未越线的快照本来就不是权威收盘价，重拉是期望行为，而不是误报。
- API、配置、前端契约均未变化；不涉及 provider 路由（该分支本身已被 `daily_data_provider == "tickflow"` 与 `Cap.QUOTE_POOL` 门控）。

## 5. 性能

每行多一个 Int64 列，全市场约 5500 行；不进入实时轮询热路径（该函数每次盘后管道执行一次）。

## 6. 验证结果

补测放在 `backend/tests/test_data_integrity.py`（该文件本就是 `quote_ts` 判据的归属地），端到端串起真实的 `KlineRepository` 落盘 → `scan_recent_integrity`。

**修复前（源码为未修改的 main，仅加测试）：**

```
$ python -m pytest tests/test_data_integrity.py::test_quotes_flush_partition_keeps_quote_ts_for_integrity_scan -q
        repo = KlineRepository(DataStore(tmp_path))
        assert kline_sync.sync_daily_by_quotes(repo) == 1

        issues = scan_recent_integrity(tmp_path, today=TODAY)
>       assert [(i.day, i.table, i.kind) for i in issues] == [(FRIDAY, "kline_daily", "snapshot")]
E       AssertionError: assert [] == [(datetime.da..., 'snapshot')]
E
E         Right contains one more item: (datetime.date(2026, 8, 21), 'kline_daily', 'snapshot')

FAILED tests/test_data_integrity.py::test_quotes_flush_partition_keeps_quote_ts_for_integrity_scan
1 failed in 5.50s
```

（把行为断言换成机制断言时，同样先失败：`assert _quote_ts_max_ms(part_dir) == snapshot_ms` → `AssertionError: assert None == 1787284680000`。）

**修复后：**

```
$ python -m pytest tests/test_data_integrity.py -q
33 passed, 5 warnings in 2.98s

$ python -m pytest tests/test_data_integrity.py tests/test_pipeline_and_monitor_fixes.py \
    tests/test_daily_batch_asset.py tests/test_kline_daily_latest.py \
    tests/test_final_sync_confirmation.py tests/test_realtime_mode.py \
    tests/test_quote_index_merge.py tests/test_parquet_schema_compat.py -q
61 passed, 8 warnings in 7.44s

$ python -m pytest tests -q --ignore=tests/test_watchdog.py
1791 passed, 100 warnings in 112.19s
```

`tests/test_watchdog.py` 在本地未修改的 main 上同样挂起，与本 PR 无关，故排除。

```
$ python -m ruff check app/services/kline_sync.py tests/test_data_integrity.py --statistics
Found 30 errors.     # 与修改前逐条相同, 本 PR 未新增告警
$ git diff --check   # 通过
```

## 7. 界面证据

无界面变化。

## 8. 风险与回滚

- 未在真实 TickFlow Key 下跑完整盘后管道；复现与验证基于真实仓库落盘 + 桩件行情响应。
- 主要风险即上文"行为变化"一条：盘后执行该分支且上游快照未越过 15:00 定版线时，会多出一次自动修复任务。若维护者认为该分支写入应当无条件视为权威历史，则本 PR 需改为在 `data_integrity` 侧另立判据，而不是补列 —— 但那会让"实时来源的分区"与"batch 权威历史"彻底无法区分。
- 回滚：还原本 PR 两个文件即可，已写入的 `quote_ts` 列对旧代码是可忽略的额外列。
