### PR TITLE
fix(financial): 公告日为空的旧行不再压过带公告日的新行

### DIFF
--- a/backend/app/services/financial_sync.py
+++ b/backend/app/services/financial_sync.py
@@ -160,7 +160,8 @@ def _merge_report_history(*frames: pl.DataFrame) -> pl.DataFrame:
     语义(区分"覆盖"与"填空"): 每列独立取 announce_date 最新的非空值 —
     新同步行有值则覆盖旧值, 新行缺的列(如 fuyao 不提供的字段)由旧行补齐,
     实现多数据源并集共存。历史报告期不可变, 合并不会引入过期数据。
-    无 announce_date 的帧按输入顺序, 后写优先(与旧行为 keep="last" 一致)。
+    无 announce_date 的帧按输入顺序, 后写优先(与旧行为 keep="last" 一致);
+    公告日为空视为最旧, 不得压过带公告日的行。
     """
     valid = [
         frame
@@ -176,7 +177,10 @@ def _merge_report_history(*frames: pl.DataFrame) -> pl.DataFrame:
     sort_keys = ["symbol", "period_end"] + (
         ["announce_date"] if "announce_date" in merged.columns else []
     )
-    merged = merged.sort(sort_keys, nulls_last=True)
+    # 公告日为空排在最前: 排到最后会让"公告日未知"的旧行在逐列 last() 时胜出,
+    # 产出 announce_date 是新公告、数值却是旧值的自相矛盾行。symbol/period_end
+    # 已在上面过滤掉空值, 不受该参数影响。
+    merged = merged.sort(sort_keys, nulls_last=False)
     value_cols = [c for c in merged.columns if c not in ("symbol", "period_end")]
     return (
         merged.group_by("symbol", "period_end")

--- a/backend/tests/test_fundamental_factors.py
+++ b/backend/tests/test_fundamental_factors.py
@@ -191,3 +191,41 @@ def test_financial_sync_merges_history(tmp_path: Path):
     assert row.height == 1
     assert row["roe"].item() == 9.5
     assert merged2.height == 2  # 修正不增加行数
+
+
+def test_financial_sync_merge_unknown_announce_date_does_not_win():
+    """公告日未知的旧行不得压过带公告日的新行。
+
+    多源并存时旧行可能没有 announce_date (provider 不提供 / 上游缺该字段)。
+    这类"公告日未知"的行若排在真实公告日之后, 逐列取最后一个非空值时反而胜出,
+    合并结果会出现「announce_date 是新公告、数值仍是旧值」的自相矛盾行,
+    点时因子据此在公告日之后放出的是修正前的数。
+    """
+    from app.services import financial_sync as fs
+
+    revised = pl.DataFrame({
+        "symbol": ["600000.SH"],
+        "period_end": ["2025-12-31"],
+        "announce_date": ["2026-02-01"],
+        "roe": [9.5],
+    })
+    # 旧行有 announce_date 列但取值为空
+    old_null = pl.DataFrame({
+        "symbol": ["600000.SH"],
+        "period_end": ["2025-12-31"],
+        "announce_date": [None],
+        "roe": [9.0],
+    })
+    row = fs._merge_report_history(old_null, revised).to_dicts()[0]
+    assert row["announce_date"] == "2026-02-01"
+    assert row["roe"] == 9.5
+
+    # 旧帧整列缺失 (另一数据源不提供该字段) — 文档承诺"后写优先"
+    old_missing = pl.DataFrame({
+        "symbol": ["600000.SH"],
+        "period_end": ["2025-12-31"],
+        "roe": [9.0],
+    })
+    row = fs._merge_report_history(old_missing, revised).to_dicts()[0]
+    assert row["announce_date"] == "2026-02-01"
+    assert row["roe"] == 9.5


### PR DESCRIPTION
## 1. 问题与复现

`financial_sync._merge_report_history` 承诺的语义是"每列独立取 `announce_date` 最新的非空值 —— 新同步行有值则覆盖旧值"。但当同一报告期里存在**公告日未知**的行时，结论正好反过来：公告日为空的旧行会压过带公告日的新行。

```python
old = pl.DataFrame({
    "symbol": ["600000.SH"], "period_end": ["2025-12-31"],
    "announce_date": [None], "roe": [9.0],
})
revised = pl.DataFrame({
    "symbol": ["600000.SH"], "period_end": ["2025-12-31"],
    "announce_date": ["2026-02-01"], "roe": [9.5],
})
_merge_report_history(old, revised).to_dicts()
# 修复前: [{'symbol': '600000.SH', 'period_end': '2025-12-31',
#           'announce_date': '2026-02-01', 'roe': 9.0}]
#                                                  ^^^ 修正前的旧值
```

合并出来的是一条**自相矛盾**的行：`announce_date` 是新公告日，数值却还是修正前的。`backtest/fundamentals.py` 按 `announce_date` 严格门控放出因子，于是"新公告日之后"放出的是修正前的数 —— 属于错误金融口径而不是缺数据。

同样的问题也发生在**旧帧整列缺失** `announce_date` 的场景（另一数据源不提供该字段，`diagonal_relaxed` 拼接后补成 null）：文档写的是"无 announce_date 的帧按输入顺序, 后写优先"，实际同样是旧值胜出。

两个场景都可实际触达：内置 fuyao 源的 `announce_date` 来自 `_iso_of_ms(r.get("report_date_ms"))`，上游缺 `report_date_ms` 时就是 `None`；自定义源则可以完全不提供该列 —— 这个合并函数本身就是为"多数据源并集共存"写的。

## 2. 根因

`merged.sort(sort_keys, nulls_last=True)` 把 `announce_date` 为空的行排到**最后**，而聚合用的是逐列 `pl.col(c).drop_nulls().last()` —— "排在最后"在这里等于"最权威"。也就是说 `nulls_last=True` 把"公告日未知"当成了"公告日最新"。

`symbol` / `period_end` 已在上一步 `filter(...is_not_null())` 里过滤掉空值，所以这个参数实际只作用在 `announce_date` 上。

## 3. 解决方案

改为 `nulls_last=False`：公告日为空视为最旧，排在真实公告日之前，逐列 `last()` 时自然取带公告日的行。同步在 docstring 里把这条口径写清楚。

一处参数 + 注释，没有改动聚合方式、列并集语义或调用方。

## 4. 兼容性

- 两个帧的 `announce_date` **都非空**时行为完全不变（含"旧公告不覆盖新公告"的倒序场景，既有测试 `test_merge_fills_missing_cells_from_old_rows` 覆盖）。
- 所有帧都**没有** `announce_date` 列时，`sort_keys` 本就不含该键，行为不变（仍是输入顺序、后写优先）。
- 只有"部分行/部分帧缺公告日"这一路的结果改变，且改成文档所述的方向。
- 不动 Parquet schema、API、配置；历史 `financials/*/part.parquet` 无需迁移 —— 下一次同步合并即按新口径产出。

## 5. 性能

排序参数变化，无额外扫描或计算；不在实时或列表热路径（财务同步为手动/每周任务）。

## 6. 验证结果

补测放在 `backend/tests/test_fundamental_factors.py`（`test_financial_sync_merges_history` 的同一节）。

**修复前（源码为未修改的 main，仅加测试）：**

```
$ python -m pytest tests/test_fundamental_factors.py::test_financial_sync_merge_unknown_announce_date_does_not_win -q
        row = fs._merge_report_history(old_null, revised).to_dicts()[0]
        assert row["announce_date"] == "2026-02-01"
>       assert row["roe"] == 9.5
E       assert 9.0 == 9.5

FAILED tests/test_fundamental_factors.py::test_financial_sync_merge_unknown_announce_date_does_not_win
1 failed in 2.11s
```

注意 `announce_date == "2026-02-01"` 这一行是通过的 —— 说明产出的正是"新公告日 + 旧数值"的矛盾行。

**修复后：**

```
$ python -m pytest tests/test_fundamental_factors.py::test_financial_sync_merge_unknown_announce_date_does_not_win -q
1 passed in 1.19s

$ python -m pytest tests/test_fundamental_factors.py tests/test_fuyao_financial.py \
    tests/test_financial_shares.py tests/test_factor_attribution.py tests/test_factor_store.py -q
36 passed in 3.91s

$ python -m pytest tests -q --ignore=tests/test_watchdog.py
1 failed, 1790 passed, 100 warnings in 131.77s
```

全量里的 1 个失败是 `tests/test_mining_manager.py` 的取消竞态用例，与本 PR 无关：在**未修改的 main** 上连跑 5 次该文件，2 次失败、3 次通过（且每次失败的用例名不同 —— `test_cancel_running_job_wins_over_worker_success` / `test_cancel_while_waiting_for_capacity_never_calls_runner`），单独执行则稳定通过。`tests/test_watchdog.py` 在本地未修改的 main 上同样挂起，故排除。

```
$ python -m ruff check app/services/financial_sync.py tests/test_fundamental_factors.py --statistics
Found 10 errors.     # 与修改前逐条相同, 本 PR 未新增告警
$ git diff --check   # 通过
```

## 7. 界面证据

无界面变化。

## 8. 风险与回滚

- 若某个数据源把 `announce_date` 留空当作"这是最权威的一版"（例如人工补录的覆盖行），本 PR 会让它不再覆盖带公告日的行。从"公告日未知不能算最新"的角度看这是期望行为，但如果确有依赖该写法的用法，需要显式给这类行填公告日。
- 历史已落盘的合并结果不会被本 PR 改写，需等下一次财务同步重新合并才收敛。
- 回滚：还原本 PR 两个文件即可，无数据迁移。
