### PR TITLE
fix(alerts): 触发记录查询的 days/limit 补上范围约束 (limit=-1 静默丢记录)

### DIFF
--- a/backend/app/api/alerts.py
+++ b/backend/app/api/alerts.py
@@ -5,7 +5,7 @@ import random
 import time
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 
 from app.services import alert_store
 
@@ -19,8 +19,10 @@ def _data_dir(request: Request) -> Path:
 @router.get("")
 def list_alerts(
     request: Request,
-    days: int = 7,
-    limit: int = 5000,
+    # 上限取存储侧保留策略 (alert_store.MAX_DAYS / MAX_RECORDS): 超出也没有可返回的记录。
+    # 无下限时 days=-1 会把 cutoff 推到未来直接返回空, limit=-1 会走负数切片静默丢掉最旧一条。
+    days: int = Query(alert_store.MAX_DAYS, ge=1, le=alert_store.MAX_DAYS),
+    limit: int = Query(alert_store.MAX_RECORDS, ge=1, le=alert_store.MAX_RECORDS),
     source: str | None = None,
     type: str | None = None,
     ext_columns: str | None = None,

--- a/backend/tests/test_alerts_query_bounds.py
+++ b/backend/tests/test_alerts_query_bounds.py
@@ -1,0 +1,69 @@
+"""告警记录查询入参边界 — days/limit 越界应被拦下, 合法值照常返回。
+
+同类列表端点 (abnormal.py 的 limit、rps.py 的 days) 已用 Query(ge=..., le=...)
+约束同名参数; 本文件锁住 /api/alerts 的同一口径。
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.alerts import router
+from app.services import alert_store
+
+
+def _client(tmp_path) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.state.repo = SimpleNamespace(store=SimpleNamespace(data_dir=tmp_path))
+    return TestClient(app)
+
+
+def _seed(tmp_path, count: int = 3) -> None:
+    now_ms = int(time.time() * 1000)
+    alert_store.append_many(
+        tmp_path,
+        [
+            {"ts": now_ms - i * 1000, "rule_id": f"r{i}", "source": "monitor", "type": "price"}
+            for i in range(count)
+        ],
+    )
+
+
+@pytest.mark.parametrize("params", [{"days": -1}, {"days": 0}, {"limit": -1}, {"limit": 0}])
+def test_out_of_range_params_are_rejected(tmp_path, params):
+    _seed(tmp_path)
+    resp = _client(tmp_path).get("/api/alerts", params=params)
+    assert resp.status_code == 422, resp.text
+
+
+def test_days_and_limit_above_store_retention_are_rejected(tmp_path):
+    _seed(tmp_path)
+    client = _client(tmp_path)
+    # 存储侧只保留 MAX_DAYS 天 / MAX_RECORDS 条, 超出上限的请求没有可返回的数据
+    assert client.get("/api/alerts", params={"days": alert_store.MAX_DAYS + 1}).status_code == 422
+    assert client.get(
+        "/api/alerts", params={"limit": alert_store.MAX_RECORDS + 1}
+    ).status_code == 422
+
+
+def test_valid_params_still_return_all_records(tmp_path):
+    _seed(tmp_path, 3)
+    client = _client(tmp_path)
+    # 默认值
+    body = client.get("/api/alerts").json()
+    assert len(body["alerts"]) == 3
+    assert body["total"] == 3
+    # 显式边界值 (前端实际用的 days=7 / limit=1、10、500 均在内)
+    for params in (
+        {"days": 1, "limit": 1},
+        {"days": 7, "limit": 500},
+        {"days": alert_store.MAX_DAYS, "limit": alert_store.MAX_RECORDS},
+    ):
+        resp = client.get("/api/alerts", params=params)
+        assert resp.status_code == 200, resp.text
+        assert len(resp.json()["alerts"]) == min(3, params["limit"])


### PR DESCRIPTION
## 问题

`GET /api/alerts` 的 `days`、`limit` 是裸 `int`，没有任何范围约束。越界值不会报错，而是静默返回错误结果。

在临时 data_dir 里写入 3 条触发记录后实测（unmodified main）：

```
GET /api/alerts              200 alerts= 3 total= 3
GET /api/alerts?days=-1      200 alerts= 0 total= 3
GET /api/alerts?limit=-1     200 alerts= 2 total= 3
GET /api/alerts?limit=0      200 alerts= 0 total= 3
GET /api/alerts?days=99999   200 alerts= 3 total= 3
GET /api/alerts?limit=999999 200 alerts= 3 total= 3
```

- `days=-1`：`alert_store.list_recent` 的 `cutoff = (time.time() - days * 86400) * 1000` 被推到未来，所有记录都被过滤掉，返回 200 + 空列表，但 `total` 仍是 3；
- `limit=-1`：`return out[:limit]` 变成负数切片，3 条只返回 2 条，**静默丢掉最旧一条**，调用方无从察觉。这是三者里最坏的一个：不是空结果，而是看起来正常的、少了一条的结果。

## 这是一处兄弟端点漏网

同类列表端点在本仓库里已经是正确写法，约束的还是同名参数：

- `backend/app/api/abnormal.py:18` — `limit: int = Query(500, ge=1, le=2000)`
- `backend/app/api/rps.py:21` — `days: int = Query(12, ge=7, le=30, description="最近 N 个交易日(7-30)")`

越界值在这些端点上直接 422。只有 `/api/alerts` 这一处漏了。

## 改动

`backend/app/api/alerts.py` 把 `days` / `limit` 换成 `Query(..., ge=1, le=...)`，上下限直接取存储侧的保留策略常量 `alert_store.MAX_DAYS` / `alert_store.MAX_RECORDS`，不新增第二套常量——`alert_store._prune_locked` 本来就只保留这个窗口，超出上限的请求没有可返回的数据。

只动了这一个函数签名，没有改 `list_recent` 的实现，也没有改其它端点。

## 验证

新增 `backend/tests/test_alerts_query_bounds.py`。

**修复前（unmodified main）：**

```
$ python -m pytest tests/test_alerts_query_bounds.py -q
FAILED tests/test_alerts_query_bounds.py::test_out_of_range_params_are_rejected[params0]
FAILED tests/test_alerts_query_bounds.py::test_out_of_range_params_are_rejected[params1]
FAILED tests/test_alerts_query_bounds.py::test_out_of_range_params_are_rejected[params2]
FAILED tests/test_alerts_query_bounds.py::test_out_of_range_params_are_rejected[params3]
FAILED tests/test_alerts_query_bounds.py::test_days_and_limit_above_store_retention_are_rejected
5 failed, 1 passed in 0.56s
```

失败详情里 `limit=-1` 的实际响应体（3 条只回 2 条）：

```
E       AssertionError: {"alerts":[{"ts":1788906721343,"rule_id":"r0","source":"monitor","type":"price"},{"ts":1788906720343,"rule_id":"r1","source":"monitor","type":"price"}],"total":3}
E       assert 200 == 422
```

注意那 1 个 passed 是 `test_valid_params_still_return_all_records`——**它在修复前就通过**，锁住的是「合法取值不受影响」。前端 `alertsList` 实际只传 `days=7`、`limit=1/10/500`（`Layout.tsx:534`、`Dashboard.tsx:108`、`Monitor.tsx:159`），全部落在新区间内，该用例把这些取值和默认值都覆盖了。这条说明本次不是把入口收窄成「什么都不收」。

**修复后：**

```
$ python -m pytest tests/test_alerts_query_bounds.py -q
6 passed in 2.46s
```

**相关模块回归**（所有引用 alerts / alert_store 的测试）：

```
$ python -m pytest tests/test_alerts_query_bounds.py tests/test_data_clear_generation.py \
    tests/test_date_rule.py tests/test_notification_settings.py \
    tests/test_pipeline_and_monitor_fixes.py tests/test_preferences_cache.py \
    tests/test_strategy_detail_signals.py tests/test_strategy_monitor_events.py \
    tests/test_strategy_registry.py tests/test_webhook_test.py -q
75 passed, 3 warnings in 4.08s
```

**全量**（`tests/test_watchdog.py` 在本机 unmodified main 上也会挂住，故 ignore）：

```
$ python -m pytest tests -q --ignore=tests/test_watchdog.py
1 failed, 1795 passed, 100 warnings in 104.76s
FAILED tests/test_mining_manager.py::test_budget_exhausted_result_uses_distinct_success_status
```

该失败与本次改动无关，是机器负载下的计时抖动，单独跑通过：

```
$ python -m pytest tests/test_mining_manager.py -q
11 passed in 1.31s
```

**Ruff**（`app/api/alerts.py` 修改前后同为 6 条历史告警，本次未新增；新增测试文件 0 条）：

```
$ ruff check app/api/alerts.py
Found 6 errors.        # main 与本分支一致
$ ruff check tests/test_alerts_query_bounds.py
All checks passed!
```

`git diff --check` 无输出。
