### PR TITLE
fix(screener): run_all 的 as_of 与 /custom、/preset 同口径校验 (数字 as_of 会写坏策略缓存)

### DIFF
--- a/backend/app/api/screener.py
+++ b/backend/app/api/screener.py
@@ -613,7 +613,15 @@ def run_all(request: Request, body: Optional[dict] = None):
     # 解析日期
     raw_date = body.get("as_of")
     if raw_date:
-        as_of = date_type.fromisoformat(str(raw_date)) if isinstance(raw_date, str) else raw_date
+        # 与 /custom、/preset 的 `as_of: date` 同口径: 只收 ISO 日期字符串。
+        # 非字符串原样透传会让 str(as_of) 把 "20260904" 之类写进 strategy_cache.json,
+        # 与其它入口写的 "2026-09-04" 不是同一格式, 后续按 as_of 比对缓存永远失配。
+        if not isinstance(raw_date, str):
+            raise HTTPException(status_code=400, detail="as_of 必须是 YYYY-MM-DD 日期字符串")
+        try:
+            as_of = date_type.fromisoformat(raw_date)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=f"日期格式错误: {e}") from e
     else:
         as_of = svc.latest_date()
     if not as_of:

--- a/backend/tests/test_screener_run_all_as_of.py
+++ b/backend/tests/test_screener_run_all_as_of.py
@@ -1,0 +1,103 @@
+"""run_all 的 as_of 入参口径 — 与 /custom、/preset 的 `as_of: date` 契约对齐。
+
+/api/screener/custom 与 /api/screener/preset 走 Pydantic 模型 (`as_of: Optional[date]`),
+非法日期在入口被拦下; run_all 收的是无类型 dict, 同样的入参会漏进业务层。
+本文件锁住三条: 非法字符串被拦、非日期类型被拦、合法日期照常放行。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.api import screener as screener_api
+from app.services import strategy_cache
+
+AS_OF = "2026-09-04"
+
+
+@dataclass
+class _FakeResult:
+    total: int = 1
+    rows: list = field(default_factory=lambda: [{"symbol": "000001.SZ", "close": 1.0}])
+    as_of: str = AS_OF
+
+
+class _FakeEngine:
+    def has(self, sid: str) -> bool:
+        return sid == "s1"
+
+    def get(self, sid: str):
+        return SimpleNamespace(meta={})
+
+    def run_all(self, context, params_map=None, overrides_map=None, *, strategy_ids=None, parallel=True):
+        return {sid: _FakeResult() for sid in (strategy_ids or [])}
+
+
+class _FakeService:
+    def __init__(self, repo, asset_type="stock"):
+        pass
+
+    def latest_date(self):
+        return date.fromisoformat(AS_OF)
+
+    def build_strategy_context(self, *args, **kwargs):
+        return SimpleNamespace()
+
+
+def _request(tmp_path):
+    repo = SimpleNamespace(store=SimpleNamespace(data_dir=tmp_path))
+    state = SimpleNamespace(repo=repo, strategy_engine=_FakeEngine(), monitor_engine=None)
+    return SimpleNamespace(app=SimpleNamespace(state=state))
+
+
+def _body(as_of):
+    return {
+        "as_of": as_of,
+        "strategy_ids": ["s1"],
+        "asset_type": "stock",
+        "timeframe": "1d",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _fake_service(monkeypatch):
+    monkeypatch.setattr(screener_api, "ScreenerService", _FakeService)
+
+
+@pytest.mark.parametrize("bad", ["not-a-date", "2026-13-01", "2026/09/04"])
+def test_malformed_as_of_string_is_rejected(tmp_path, bad):
+    with pytest.raises(HTTPException) as excinfo:
+        screener_api.run_all(_request(tmp_path), _body(bad))
+    assert excinfo.value.status_code == 400
+
+
+@pytest.mark.parametrize("bad", [20260904, 2026, 1.5, True, ["2026-09-04"]])
+def test_non_string_as_of_is_rejected_and_never_reaches_cache(tmp_path, bad):
+    """JSON 数字等非字符串 as_of 不得被当成日期用作缓存键。
+
+    /preset 的 `as_of: date` 对 int 报 422 (date_from_datetime_inexact),
+    run_all 必须同样拦下, 否则 str(as_of) 会把 "20260904" 之类写进 strategy_cache.json,
+    与其它入口写的 "2026-09-04" 不是同一口径, 缓存按 as_of 比对时永远失配。
+    """
+    with pytest.raises(HTTPException) as excinfo:
+        screener_api.run_all(_request(tmp_path), _body(bad))
+    assert excinfo.value.status_code == 400
+    assert strategy_cache.read_cache(tmp_path) in (None, {}) or not (
+        strategy_cache.read_cache(tmp_path) or {}
+    ).get("results")
+
+
+def test_valid_as_of_still_runs_and_writes_iso_cache(tmp_path):
+    resp = screener_api.run_all(_request(tmp_path), _body(AS_OF))
+    assert resp["as_of"] == AS_OF
+    assert resp["results"]["s1"]["total"] == 1
+    assert (strategy_cache.read_cache(tmp_path) or {}).get("as_of") == AS_OF
+
+
+def test_missing_as_of_falls_back_to_latest_date(tmp_path):
+    resp = screener_api.run_all(_request(tmp_path), _body(None))
+    assert resp["as_of"] == AS_OF


### PR DESCRIPTION
## 问题

`POST /api/screener/run_all` 收的是无类型 dict（`body: Optional[dict] = None`），`as_of` 只在 `isinstance(raw_date, str)` 成立时才走 `date.fromisoformat`，其余类型原样透传：

```python
raw_date = body.get("as_of")
if raw_date:
    as_of = date_type.fromisoformat(str(raw_date)) if isinstance(raw_date, str) else raw_date
```

由此有两个后果。用 `tests/test_screener_run_all_progressive.py` 里同款的假 engine / 假 service 在 unmodified main 上实测：

```
'not-a-date' -> raised ValueError: Invalid isoformat string: 'not-a-date'
20260904     -> HTTP 200, resp as_of= '20260904' | cache as_of= '20260904'
2026         -> HTTP 200, resp as_of= '2026'     | cache as_of= '2026'
```

1. **非法字符串 → 500。** `ValueError` 没人接，客户端只拿到 Internal Server Error。
2. **JSON 数字 → 200，但写进缓存的 as_of 格式是错的。** `{"as_of": 2026}` 不进解析分支，`as_of` 一路当日期用下去，`str(as_of)` 把 `"2026"` 写进 `strategy_cache.json`（`{"as_of": 20260904}` 则写入 `"20260904"`）。

第 2 点是真正会留下痕迹的那个：`strategy_cache.json` 是各入口共享的同一份盘后缓存，其它写入方（`_update_cache_strategy`、`/preset` 单跑路径）写的都是 `"2026-09-04"` 这种 ISO 串，而 `cached-summary` / `cached-result` 全部按 `as_of` 字符串比对（`screener.py` 里的 `cached.get("as_of") == as_of`、`result.get("as_of") != cached_as_of`）。格式不一致的缓存条目写进去之后既命不中、也不会被当天的正常写入覆盖掉整份 as_of 口径。

## 这是一处兄弟端点漏网

同一个 `as_of` 在本仓库的另外两个 screener 入口上是有契约的，走 Pydantic 模型：

- `backend/app/api/screener.py:34` — `CustomRequest.as_of: Optional[date]`
- `backend/app/api/screener.py:42` — `PresetRequest.as_of: Optional[date]`

这两个入口对非法值都是 422。实测 Pydantic v2 对数字型 `as_of` 的报错：

```
20260904 -> ValidationError: Datetimes provided to dates should have zero time - e.g. be exact dates
            [type=date_from_datetime_inexact, input_value=20260904, input_type=int]
'not-a-date' -> ValidationError: Input should be a valid date or datetime, invalid character in year
            [type=date_from_datetime_parsing, ...]
```

只有 `run_all` 这一处没有类型契约。

## 改动

只改 `run_all` 里解析 `as_of` 的那几行，补齐到和 `/custom`、`/preset` 同一口径：非字符串直接 400，非法字符串 400「日期格式错误」。没有把 body 改成 Pydantic 模型（那会牵动 `strategy_ids` / `summary_only` / `ext_columns` 等一整组字段，超出本次范围），也没有动 `_run_all_progressive`、缓存写入或其它端点。

前端 `api.ts` 的 `screenerRunAll` 传的是 `as_of: asOf ?? null`（字符串或 null），后端也没有别的调用方直接调这个函数，改动不影响现有调用。

## 验证

新增 `backend/tests/test_screener_run_all_as_of.py`。

**修复前（unmodified main）：**

```
$ python -m pytest tests/test_screener_run_all_as_of.py -q
FAILED tests/test_screener_run_all_as_of.py::test_malformed_as_of_string_is_rejected[not-a-date]
FAILED tests/test_screener_run_all_as_of.py::test_malformed_as_of_string_is_rejected[2026-13-01]
FAILED tests/test_screener_run_all_as_of.py::test_malformed_as_of_string_is_rejected[2026/09/04]
FAILED tests/test_screener_run_all_as_of.py::test_non_string_as_of_is_rejected_and_never_reaches_cache[20260904]
FAILED tests/test_screener_run_all_as_of.py::test_non_string_as_of_is_rejected_and_never_reaches_cache[2026]
FAILED tests/test_screener_run_all_as_of.py::test_non_string_as_of_is_rejected_and_never_reaches_cache[1.5]
FAILED tests/test_screener_run_all_as_of.py::test_non_string_as_of_is_rejected_and_never_reaches_cache[True]
FAILED tests/test_screener_run_all_as_of.py::test_non_string_as_of_is_rejected_and_never_reaches_cache[bad4]
8 failed, 2 passed in 0.97s
```

那 2 个 passed 是 `test_valid_as_of_still_runs_and_writes_iso_cache` 和 `test_missing_as_of_falls_back_to_latest_date`——**它们在修复前就通过**，锁住的是合法 `as_of` 照常执行、缓存照常写 ISO 日期、不传 `as_of` 时仍回退到 `latest_date()`。这条说明本次不是把入口收窄成「什么都不收」。

**修复后：**

```
$ python -m pytest tests/test_screener_run_all_as_of.py -q
10 passed in 0.64s
```

**screener 模块回归：**

```
$ python -m pytest tests/test_screener_builtin_params.py tests/test_screener_cache_api.py \
    tests/test_screener_etf.py tests/test_screener_external_access.py \
    tests/test_screener_jit_turnover.py tests/test_screener_run_all_progressive.py \
    tests/test_screener_run_all_as_of.py -q
39 passed, 2 warnings in 6.99s
```

**全量**（`tests/test_watchdog.py` 在本机 unmodified main 上也会挂住，故 ignore）：

```
$ python -m pytest tests -q --ignore=tests/test_watchdog.py
1 failed, 1799 passed, 100 warnings in 105.47s
FAILED tests/test_mining_manager.py::test_start_records_states_events_progress_and_worker_payload
```

该失败与本次改动无关（`test_mining_manager.py` 在本机满负载跑全量时会计时抖动，两次全量分别挂在该文件的不同用例上），单独跑通过：

```
$ python -m pytest tests/test_mining_manager.py -q
11 passed in 10.81s
```

**Ruff**（`app/api/screener.py` 修改前后同为 33 条历史告警，本次未新增；新增测试文件 0 条）：

```
$ ruff check app/api/screener.py
Found 33 errors.       # main 与本分支一致
$ ruff check tests/test_screener_run_all_as_of.py
All checks passed!
```

`git diff --check` 无输出。
