### PR TITLE
fix(backtest): SSE 端点非法 start/end 返回 400 而不是 500

### DIFF
--- a/backend/app/api/backtest.py
+++ b/backend/app/api/backtest.py
@@ -527,10 +527,12 @@ async def strategy_stream(
     from app.backtest.strategy import StrategyBacktestConfig
     from app.backtest.worker import make_worker_task, run_worker_task
 
-    end_date = date.fromisoformat(end) if end else date.today()
-    if start:
-        start_date = date.fromisoformat(start)
-    else:
+    try:
+        end_date = date.fromisoformat(end) if end else date.today()
+        start_date = date.fromisoformat(start) if start else None
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"日期格式错误: {e}") from e
+    if start_date is None:
         # 空 start = 全部历史: 用本地最早日K日期, 查不到再回退到默认窗口
         earliest = request.app.state.repo.earliest_daily_date()
         start_date = earliest or (end_date - timedelta(days=FACTOR_DEFAULT_DAYS))
@@ -830,10 +832,12 @@ async def optimize_stream(
     from app.backtest.optimizer import OptimizeConfig
     from app.backtest.worker import make_worker_task, run_worker_task
 
-    end_date = date.fromisoformat(end) if end else date.today()
-    if start:
-        start_date = date.fromisoformat(start)
-    else:
+    try:
+        end_date = date.fromisoformat(end) if end else date.today()
+        start_date = date.fromisoformat(start) if start else None
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"日期格式错误: {e}") from e
+    if start_date is None:
         earliest = request.app.state.repo.earliest_daily_date()
         start_date = earliest or (end_date - timedelta(days=FACTOR_DEFAULT_DAYS))
 
@@ -1052,10 +1056,12 @@ async def walkforward_stream(
 
     direction = direction or None
 
-    end_date = date.fromisoformat(end) if end else date.today()
-    if start:
-        start_date = date.fromisoformat(start)
-    else:
+    try:
+        end_date = date.fromisoformat(end) if end else date.today()
+        start_date = date.fromisoformat(start) if start else None
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"日期格式错误: {e}") from e
+    if start_date is None:
         earliest = request.app.state.repo.earliest_daily_date()
         start_date = earliest or (end_date - timedelta(days=STRATEGY_DEFAULT_DAYS))
 

--- a/backend/tests/test_backtest_stream_date_guard.py
+++ b/backend/tests/test_backtest_stream_date_guard.py
@@ -1,0 +1,69 @@
+"""回测 SSE 端点的 start/end 入参校验 — 非法日期返回 400 而不是 500。
+
+signals.py 的 `/intraday/replay` 与 mining.py 的 `MiningRunRequest` 都把
+`date.fromisoformat` 包在校验里, 非法日期给出 400/422; backtest 的三个 SSE
+端点直接裸调 `date.fromisoformat`, 同样的入参会抛未捕获 ValueError。
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.backtest import router
+from app.config import settings
+
+# (路径, 该端点的必填参数)
+STREAMS = [
+    ("/api/backtest/strategy/stream", {"strategy_id": "ma_cross"}),
+    ("/api/backtest/optimize/stream", {"strategy_id": "ma_cross", "param_grid": '{"n": [5]}'}),
+    ("/api/backtest/walkforward/stream", {"strategy_id": "ma_cross", "param_grid": '{"n": [5]}'}),
+]
+STREAM_IDS = [path.rsplit("/", 2)[1] for path, _ in STREAMS]
+
+BAD_DATES = ["not-a-date", "2026-13-01", "2026/09/04", ""]
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    # raise_server_exceptions=False: 未捕获异常表现为 500 响应, 与线上行为一致
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize("path,extra", STREAMS, ids=STREAM_IDS)
+@pytest.mark.parametrize("bad", BAD_DATES)
+def test_malformed_end_returns_400(client, path, extra, bad):
+    if not bad:
+        pytest.skip("空串走默认值分支, 不属于非法日期")
+    resp = client.get(path, params={**extra, "end": bad})
+    assert resp.status_code == 400, resp.text
+    assert "日期" in resp.json()["detail"]
+
+
+@pytest.mark.parametrize("path,extra", STREAMS, ids=STREAM_IDS)
+@pytest.mark.parametrize("bad", BAD_DATES)
+def test_malformed_start_returns_400(client, path, extra, bad):
+    if not bad:
+        pytest.skip("空串走默认值分支, 不属于非法日期")
+    resp = client.get(path, params={**extra, "start": bad, "end": "2026-09-04"})
+    assert resp.status_code == 400, resp.text
+    assert "日期" in resp.json()["detail"]
+
+
+@pytest.mark.parametrize("path,extra", STREAMS, ids=STREAM_IDS)
+def test_valid_dates_still_accepted(client, monkeypatch, path, extra):
+    """合法日期必须照旧进入事件流, 证明这不是把入口收窄成"什么都不收"。
+
+    打开服务端范围保护并给一个超阈值的窗口, 事件流会立刻以 error 事件收尾,
+    既不触发真实回测, 又能证明日期解析已经放行。
+    """
+    monkeypatch.setattr(settings, "backtest_range_guard", True)
+    params = {**extra, "start": "2020-01-01", "end": "2026-09-04"}
+    if "walkforward" in path:
+        # walkforward 的 guard 作用于单折窗口, 不是总区间
+        params.update({"train_days": 400, "test_days": 400})
+    resp = client.get(path, params=params)
+    assert resp.status_code == 200, resp.text
+    assert "event: error" in resp.text


### PR DESCRIPTION
## 问题

`backend/app/api/backtest.py` 的三个 SSE 端点直接裸调 `date.fromisoformat` 解析查询参数 `start` / `end`：

- `/api/backtest/strategy/stream`（`backtest.py:530`）
- `/api/backtest/optimize/stream`（`backtest.py:833`）
- `/api/backtest/walkforward/stream`（`backtest.py:1055`）

```python
end_date = date.fromisoformat(end) if end else date.today()
if start:
    start_date = date.fromisoformat(start)
```

传入 `"not-a-date"`、`"2026-13-01"`、`"2026/09/04"` 之类的值时 `ValueError` 没人接，客户端拿到的是 500 + Internal Server Error，看不到是哪个参数不合法。

## 这是一处兄弟端点漏网

同样的 `date.fromisoformat` 在本仓库别处都是包好的：

- `backend/app/api/signals.py:249-253` — `/intraday/replay` 用 `try / except ValueError` → `HTTPException(400, f"日期格式错误: {e}")`
- `backend/app/api/mining.py:71-79` — `MiningRunRequest` 用 `field_validator("start", "end", mode="before")` 包住 `date.fromisoformat` → 422

本次把 backtest 这三处补齐到 `signals.py` 的同一写法（400 +「日期格式错误」），不新增别的校验，不改区间大小、start > end 之类的既有行为。

## 改动

三处结构一致：把 `end` / `start` 的解析一起放进 `try`，`start` 为空时保持原来的「取本地最早日K，查不到回退默认窗口」分支不变。

```python
try:
    end_date = date.fromisoformat(end) if end else date.today()
    start_date = date.fromisoformat(start) if start else None
except ValueError as e:
    raise HTTPException(status_code=400, detail=f"日期格式错误: {e}") from e
if start_date is None:
    earliest = request.app.state.repo.earliest_daily_date()
    start_date = earliest or (end_date - timedelta(days=...))
```

`git diff --stat`：`backend/app/api/backtest.py | 30 ++++++-----`（18 插入 / 12 删除）。

## 验证

新增 `backend/tests/test_backtest_stream_date_guard.py`：三个端点 × 3 个非法日期 × `start` / `end` 两个位置。TestClient 用 `raise_server_exceptions=False`，让未捕获异常表现为 500 响应，与线上一致。

**修复前（unmodified main）：**

```
$ python -m pytest tests/test_backtest_stream_date_guard.py -q
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_end_returns_400[not-a-date-strategy]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_end_returns_400[not-a-date-optimize]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_end_returns_400[not-a-date-walkforward]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_end_returns_400[2026-13-01-strategy]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_end_returns_400[2026-13-01-optimize]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_end_returns_400[2026-13-01-walkforward]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_end_returns_400[2026/09/04-strategy]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_end_returns_400[2026/09/04-optimize]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_end_returns_400[2026/09/04-walkforward]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_start_returns_400[not-a-date-strategy]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_start_returns_400[not-a-date-optimize]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_start_returns_400[not-a-date-walkforward]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_start_returns_400[2026-13-01-strategy]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_start_returns_400[2026-13-01-optimize]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_start_returns_400[2026-13-01-walkforward]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_start_returns_400[2026/09/04-strategy]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_start_returns_400[2026/09/04-optimize]
FAILED tests/test_backtest_stream_date_guard.py::test_malformed_start_returns_400[2026/09/04-walkforward]
18 failed, 3 passed, 6 skipped in 2.25s
```

失败长这样：

```
        resp = client.get(path, params={**extra, "start": bad, "end": "2026-09-04"})
>       assert resp.status_code == 400, resp.text
E       AssertionError: Internal Server Error
E       assert 500 == 400
```

那 3 个 passed 是 `test_valid_dates_still_accepted`（三个端点各一）——**它们在修复前就通过**。这个用例打开 `settings.backtest_range_guard` 并给一个超阈值的窗口，事件流会立刻以 `event: error` 收尾（既不触发真实回测，又证明日期解析已经放行），断言 200 + 事件流里有 error 事件。这条说明本次不是把入口收窄成「什么都不收」。

**修复后：**

```
$ python -m pytest tests/test_backtest_stream_date_guard.py -q
21 passed, 6 skipped in 2.47s
```

（6 skipped 是空串参数——空串走的是默认值分支，不属于非法日期，用例里显式 skip。）

**回测相关模块回归：**

```
$ python -m pytest tests/backtest tests/test_backtest_etf.py tests/test_backtest_warmup.py \
    tests/test_job_stall_and_cancel.py tests/test_backtest_stream_date_guard.py -q
323 passed, 6 skipped, 24 warnings in 36.35s
```

**全量**（`tests/test_watchdog.py` 在本机 unmodified main 上也会挂住，故 ignore）：

```
$ python -m pytest tests -q --ignore=tests/test_watchdog.py
3 failed, 1808 passed, 6 skipped, 100 warnings in 92.38s
FAILED tests/backtest/test_worker_process.py::test_spawn_worker_returns_compact_result_and_memory_metrics
FAILED tests/test_mining_manager.py::test_cancel_running_job_wins_over_worker_success
FAILED tests/test_mining_manager.py::test_runner_exception_marks_failed_and_appends_error_event
```

这 3 个与本次改动无关：`test_worker_process.py` 和 `test_mining_manager.py` 在本机满负载跑全量时会计时抖动（多次全量分别挂在这两个文件的不同用例上），单独跑通过：

```
$ python -m pytest tests/backtest/test_worker_process.py tests/test_mining_manager.py -q
22 passed, 5 warnings in 28.99s
```

**Ruff**（`app/api/backtest.py` 修改前后同为 13 条历史告警，本次未新增；新增测试文件 0 条）：

```
$ ruff check app/api/backtest.py
Found 13 errors.       # main 与本分支一致
$ ruff check tests/test_backtest_stream_date_guard.py
All checks passed!
```

`git diff --check` 无输出。
