### PR TITLE
fix(rps): 轮动矩阵缓存按覆盖天数复用, 切到更长窗口不再少列

### DIFF
--- a/backend/app/services/rps_rotation.py
+++ b/backend/app/services/rps_rotation.py
@@ -35,12 +35,16 @@ logger = logging.getLogger(__name__)
 _CACHE_TTL = 120.0
 _cache: dict[str, dict] = {}
 _cache_ts: dict[str, float] = {}
+# 该条目实际覆盖的天数: enriched 只读 days 换算出的日历窗口, 缓存的"全量"因此
+# 以写入时的 days 为上限, 请求更长窗口时不能复用 (见 build_rps_rotation)。
+_cache_days: dict[str, int] = {}
 
 
 def invalidate_cache() -> None:
     """清空轮动矩阵结果缓存(数据管道完成后调用, 避免返回旧数据)。"""
     _cache.clear()
     _cache_ts.clear()
+    _cache_days.clear()
 
 
 def _latest_enriched_date(repo) -> date | None:
@@ -138,7 +142,11 @@ def build_rps_rotation(repo, days: int = 12, kind: str = "concept", level: int |
     cache_key = f"{kind}|{level}|{latest.isoformat()}"
     now = time.time()
     cached = _cache.get(cache_key)
-    if cached and (now - _cache_ts.get(cache_key, 0)) < _CACHE_TTL:
+    if (
+        cached
+        and _cache_days.get(cache_key, 0) >= days
+        and (now - _cache_ts.get(cache_key, 0)) < _CACHE_TTL
+    ):
         return _slice_cached(cached, days)
 
     # 1. 维度映射(symbol → 维度成员), 已按 kind 缓存为 (map_df, count) 元组 (#186)。
@@ -201,9 +209,10 @@ def build_rps_rotation(repo, days: int = 12, kind: str = "concept", level: int |
         "concept_count": member_count,
     }
 
-    # 写缓存(存全量, 按需 slice)
+    # 写缓存(存本次窗口的全量, 按需 slice; 覆盖天数一并记下)
     _cache[cache_key] = full
     _cache_ts[cache_key] = now
+    _cache_days[cache_key] = days
 
     return _slice_cached(full, days)
 

--- a/backend/tests/test_rps_rotation_days_cache.py
+++ b/backend/tests/test_rps_rotation_days_cache.py
@@ -1,0 +1,102 @@
+"""涨幅轮动矩阵结果缓存必须按 days 区分。
+
+build_rps_rotation 只按 days 换算出的日历窗口读 enriched (days=7 只读 24 个
+自然日), 但结果缓存键是 "{kind}|{level}|{latest}" —— 不含 days。先看 7 日
+再切到 30 日, 120s TTL 内会命中那份按 7 日窗口算出来的矩阵, 前端拿到的列数
+比请求的少。
+"""
+from __future__ import annotations
+
+import types
+from datetime import date, timedelta
+
+import polars as pl
+import pytest
+
+from app.services import rps_rotation
+
+_LATEST = date(2026, 6, 30)
+_HISTORY_DAYS = 80
+_MEMBERS = ("人工智能", "芯片")
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    rps_rotation.invalidate_cache()
+    rps_rotation._map_cache.clear()
+    rps_rotation._map_ts.clear()
+    yield
+    rps_rotation.invalidate_cache()
+    rps_rotation._map_cache.clear()
+    rps_rotation._map_ts.clear()
+
+
+def _history() -> pl.DataFrame:
+    """两只票在 80 个连续自然日上的 change_pct(小数制)。"""
+    rows = []
+    for offset in range(_HISTORY_DAYS):
+        day = _LATEST - timedelta(days=offset)
+        rows.append({"symbol": "S1.SH", "date": day, "change_pct": 0.01})
+        rows.append({"symbol": "S2.SH", "date": day, "change_pct": -0.01})
+    return pl.DataFrame(rows)
+
+
+def _fake_repo() -> types.SimpleNamespace:
+    history = _history()
+
+    def get_enriched_range(start, end, columns=None):
+        df = history.filter((pl.col("date") >= start) & (pl.col("date") <= end))
+        return df.select(columns) if columns else df
+
+    return types.SimpleNamespace(
+        _enriched_history_cache=history,
+        get_enriched_range=get_enriched_range,
+        store=types.SimpleNamespace(data_dir=None),
+    )
+
+
+@pytest.fixture
+def repo(monkeypatch) -> types.SimpleNamespace:
+    map_df = pl.DataFrame(
+        {"_sym_up": ["S1.SH", "S2.SH"], "concept": list(_MEMBERS)},
+        schema={"_sym_up": pl.Utf8, "concept": pl.Utf8},
+    )
+    monkeypatch.setattr(
+        rps_rotation, "_load_concept_map_df", lambda _repo, kind: (map_df, len(_MEMBERS))
+    )
+    return _fake_repo()
+
+
+def test_widening_days_after_a_narrow_request_returns_all_days(repo):
+    """先请求 7 日再请求 30 日, 第二次必须拿到 30 列。
+
+    旧实现: 缓存键不含 days, 第二次命中第一次那份只有 25 列的矩阵。
+    """
+    narrow = rps_rotation.build_rps_rotation(repo, days=7)
+    assert len(narrow["dates"]) == 7
+
+    wide = rps_rotation.build_rps_rotation(repo, days=30)
+    assert len(wide["dates"]) == 30
+    assert len(wide["columns"]) == 30
+
+
+def test_narrowing_days_after_a_wide_request_still_slices(repo):
+    """反方向仍要按请求截断 (宽窗缓存可以复用, 但只返回请求的天数)。"""
+    wide = rps_rotation.build_rps_rotation(repo, days=30)
+    assert len(wide["dates"]) == 30
+
+    narrow = rps_rotation.build_rps_rotation(repo, days=7)
+    assert len(narrow["dates"]) == 7
+    assert narrow["dates"] == wide["dates"][:7]
+
+
+def test_same_days_request_hits_cache(repo, monkeypatch):
+    """同一 days 的重复请求仍走缓存, 不重新读 enriched。"""
+    rps_rotation.build_rps_rotation(repo, days=12)
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("缓存未命中: 又读了一次 enriched")
+
+    monkeypatch.setattr(repo, "get_enriched_range", _boom)
+    again = rps_rotation.build_rps_rotation(repo, days=12)
+    assert len(again["dates"]) == 12


### PR DESCRIPTION
## 1. 问题与复现

打开「概念分析 → 涨幅RPS轮动」对话框，天数先选 **7 日**，再切到 **30 日**，矩阵只有 **25 列**，不是 30 列。等 2 分钟（缓存 TTL）再切一次就正常了。行业分析页、以及「AI 轮动分析」（`POST /api/rps/rotation-analyze`，同样先经过 `build_rps_rotation`）都是同一条路径。

对 AI 轮动分析的影响更实际：`_compute_rotation_signals` 的「新晋 / 退潮」判据是拿 `ranks[0]`（区间最早日）和 `ranks[-1]`（最新日）比。区间被悄悄缩短后，起点整体右移，同一天的数据会得出不一样的轮动结论。

## 2. 根因

`build_rps_rotation` 读 enriched 的窗口是按 `days` 换算的日历天：

```python
start = latest - timedelta(days=days * 2 + 10)   # days=7 → 只读 24 个自然日
df = repo.get_enriched_range(start, latest, columns=[...])
```

但结果缓存键不含 `days`：

```python
cache_key = f"{kind}|{level}|{latest.isoformat()}"
```

于是第二次（days=30）请求在 120s TTL 内命中了第一次（days=7）那份按 24 个自然日算出来的矩阵。`_slice_cached` 的注释写的是「存全量，按需 slice」，可缓存里那份并不是全量，而是被写入时的 `days` 框住的；它又恰好走 `len(dates_all) <= days` 这条早返回分支原样返回，所以少列这件事一点提示都没有：

```python
def _slice_cached(full: dict, days: int) -> dict:
    dates_all = full["dates"]
    if len(dates_all) <= days:
        return full          # ← 请求 30 列, 这里把 25 列原样交出去
```

## 3. 解决方案

沿用本模块已有的「并列字典」写法（`_cache` / `_cache_ts`，`_map_cache` / `_map_ts`），再加一个 `_cache_days` 记下每个条目实际覆盖的天数，只在 **覆盖天数 ≥ 请求天数** 时复用：

- 窄 → 宽（7 日后切 30 日）：不复用，重算，拿到完整 30 列。
- 宽 → 窄（30 日后切 7 日）：照旧复用并 `_slice_cached` 截断，缓存收益不变。
- 同一 `days` 重复请求：照旧命中缓存，不重读 enriched。

`invalidate_cache()` 一并清空新字典。没有动矩阵计算、聚合口径和返回结构。

## 4. 兼容性

- 返回结构（`dates` / `columns` / `concept_count`）不变，前端不用改。
- 只影响进程内缓存的复用条件，不涉及 Parquet、配置、API 契约或数据源。
- 最坏情况是用户把天数调大时多算一次矩阵（模块 docstring 记的是 387 概念 × 30 天 < 50ms）——这正是原本被跳过的那次计算。

## 5. 性能

不进实时/列表热路径。命中率只在「同一 kind+level 下把天数调大」这一种操作上下降，其余场景（同天数刷新、调小天数）复用行为与改动前完全一致。

## 6. 验证结果

新增 `backend/tests/test_rps_rotation_days_cache.py`（3 个用例：窄→宽、宽→窄、同天数命中缓存）。

**修复前**（`origin/main` d0a14b5 + 仅加测试文件）：

```
$ python -m pytest tests/test_rps_rotation_days_cache.py -q
F..                                                                      [100%]
        narrow = rps_rotation.build_rps_rotation(repo, days=7)
        assert len(narrow["dates"]) == 7

        wide = rps_rotation.build_rps_rotation(repo, days=30)
>       assert len(wide["dates"]) == 30
E       AssertionError: assert 25 == 30
E        +  where 25 = len(['2026-06-30', '2026-06-29', '2026-06-28', '2026-06-27', '2026-06-26', '2026-06-25', ...])

1 failed, 2 passed in 0.73s
```

另外两个用例（宽→窄仍截断、同天数仍命中缓存）在修复前就通过，用来钉住不能回退的行为。

**修复后**：

```
$ python -m pytest tests/test_rps_rotation_days_cache.py -q
...                                                                      [100%]
3 passed in 0.42s

$ python -m pytest tests/test_rps_rotation_days_cache.py tests/test_rps_rotation_map_cache.py tests/test_concept_rotation_signals.py tests/test_market_mainline.py -q
18 passed in 1.43s

$ python -m pytest tests -q --ignore=tests/test_watchdog.py
1901 passed, 6 skipped, 163 warnings in 117.06s (0:01:57)
```

（`tests/test_watchdog.py` 在我这台机器上未修改的 main 上也会挂住，故 `--ignore`。）

Ruff：

```
$ ruff check app/services/rps_rotation.py --statistics
1  RUF002 / 1  I001 / 1  RUF100 / 1  B905      Found 4 errors.     # 与 main 逐项一致, 未新增
$ ruff check tests/test_rps_rotation_days_cache.py
All checks passed!
```

## 7. 界面证据

无界面改动：同一个对话框，同一个请求，只是 30 日档位现在真的返回 30 列。

## 8. 风险与回滚

风险很小：只多了一个进程内字典和一个复用条件判断。回滚即还原本 commit，缓存回到「按 kind|level|latest 无条件复用」的旧行为。
