### PR TITLE
fix(screener): 涨停梯队按分区找前一交易日, 不再按固定自然日回看

### DIFF
--- a/backend/app/services/screener.py
+++ b/backend/app/services/screener.py
@@ -23,6 +23,9 @@ logger = logging.getLogger(__name__)
 _history_cache: dict[tuple[str, date, int], tuple[float, pl.DataFrame]] = {}
 _HISTORY_CACHE_TTL = 120.0  # 秒
 
+# load_prior_consecutive 最多回看多少个已存在的日分区 (缺列时继续往前找的上限)
+_PRIOR_PARTITION_SCAN = 10
+
 
 @dataclass
 class ScreenerResult:
@@ -109,15 +112,14 @@ class ScreenerService:
         可直接从 parquet 读取, 无需 _load_enriched_for_date 的全量指标重算
         (历史日期该慢路径最坏会触发 9 次全市场 compute_enriched_full)。
 
-        选取逻辑与旧循环等价: 在 as_of 前 1~9 天内找到第一个存在的日分区
-        (即前一交易日), 读取其 symbol + consec_col。存储列的值与重算值逐位一致
-        (连板计数为 run-length, 150 天 warmup 完全覆盖 A 股最长连板, 二者相等)。
+        由近到远取 as_of 之前已存在的日分区 (即前一交易日), 读取其
+        symbol + consec_col。存储列的值与重算值逐位一致 (连板计数为 run-length,
+        150 天 warmup 完全覆盖 A 股最长连板, 二者相等)。
 
         返回列: symbol, prev_consec。找不到前一交易日时返回空 DataFrame。
         """
         enriched_dir = self.repo.store.data_dir / self._enriched_dirname
-        for delta in range(1, 10):
-            candidate = as_of - timedelta(days=delta)
+        for candidate in self._prior_partition_dates(as_of, _PRIOR_PARTITION_SCAN):
             target_parquet = enriched_dir / f"date={candidate.isoformat()}" / "part.parquet"
             if not target_parquet.exists():
                 continue
@@ -139,6 +141,32 @@ class ScreenerService:
                 logger.warning("load_prior_consecutive read failed for %s: %s", candidate, e)
                 return pl.DataFrame()
         return pl.DataFrame()
+
+    def _prior_partition_dates(self, as_of: date, limit: int) -> list[date]:
+        """enriched 目录里早于 as_of 的分区日期, 由近到远最多 limit 个。
+
+        枚举分区目录而不是按自然日回看固定天数: 春节长假连着调休周末,
+        相邻两个交易日能隔 10~11 个自然日 (如 2024-02-08 → 2024-02-19),
+        固定窗口会整段落空。与 auction_benchmark._prev_trading_day
+        「本地日K分区日期 = 已知交易日集合」同口径。
+        """
+        enriched_dir = self.repo.store.data_dir / self._enriched_dirname
+        days: list[date] = []
+        try:
+            entries = list(enriched_dir.iterdir())
+        except OSError:
+            return []
+        for part in entries:
+            if not part.name.startswith("date="):
+                continue
+            try:
+                day = date.fromisoformat(part.name[5:])
+            except ValueError:
+                continue
+            if day < as_of:
+                days.append(day)
+        days.sort(reverse=True)
+        return days[:limit]
 
     def _compute_enriched_full(self, df_target: pl.DataFrame, target_date: date) -> pl.DataFrame:
         """从 14 列基础数据即时计算完整 enriched (含全部指标和信号)。

--- a/backend/tests/test_limit_ladder_prior_trading_day.py
+++ b/backend/tests/test_limit_ladder_prior_trading_day.py
@@ -1,0 +1,88 @@
+"""涨停梯队的「昨日连板数」不能按固定自然日窗口回看。
+
+load_prior_consecutive 原本在 as_of 前 1~9 个自然日里找分区。春节长假连着
+调休周末, 相邻两个交易日能隔 10~11 个自然日 (如 2024-02-08 到 2024-02-19),
+窗口整段落空, prev_consec 全被填 0: 断板(晋级失败)一栏空掉, 炸板股的板数
+从「昨日 N 板 + 1」退回 1 板。
+"""
+from __future__ import annotations
+
+import types
+from datetime import date
+
+import polars as pl
+import pytest
+
+from app.services.screener import ScreenerService
+
+_CONSEC_COL = "consecutive_limit_ups"
+
+
+def _write_partition(data_dir, day: date, rows: dict) -> None:
+    part = data_dir / "kline_daily_enriched" / f"date={day.isoformat()}"
+    part.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame(rows).write_parquet(part / "part.parquet")
+
+
+def _service(data_dir) -> ScreenerService:
+    repo = types.SimpleNamespace(store=types.SimpleNamespace(data_dir=data_dir))
+    return ScreenerService(repo)
+
+
+@pytest.mark.parametrize(
+    ("prev_day", "as_of", "label"),
+    [
+        (date(2024, 2, 8), date(2024, 2, 19), "春节长假(11 个自然日)"),
+        (date(2023, 1, 20), date(2023, 1, 30), "春节长假(10 个自然日)"),
+        (date(2026, 6, 26), date(2026, 6, 29), "周末(3 个自然日)"),
+        (date(2026, 6, 29), date(2026, 6, 30), "相邻交易日"),
+    ],
+)
+def test_prior_consecutive_spans_any_holiday_gap(tmp_path, prev_day, as_of, label):
+    _write_partition(tmp_path, prev_day, {"symbol": ["600000.SH"], _CONSEC_COL: [3]})
+    _write_partition(tmp_path, as_of, {"symbol": ["600000.SH"], _CONSEC_COL: [0]})
+
+    got = _service(tmp_path).load_prior_consecutive(as_of, _CONSEC_COL)
+
+    assert not got.is_empty(), f"{label}: 没找到前一交易日分区"
+    assert got.to_dicts() == [{"symbol": "600000.SH", "prev_consec": 3}]
+
+
+def test_prior_consecutive_picks_the_nearest_earlier_partition(tmp_path):
+    """多个更早分区时取最近的一个, 不是最早的。"""
+    _write_partition(tmp_path, date(2024, 2, 6), {"symbol": ["600000.SH"], _CONSEC_COL: [1]})
+    _write_partition(tmp_path, date(2024, 2, 7), {"symbol": ["600000.SH"], _CONSEC_COL: [2]})
+    _write_partition(tmp_path, date(2024, 2, 8), {"symbol": ["600000.SH"], _CONSEC_COL: [3]})
+    _write_partition(tmp_path, date(2024, 2, 19), {"symbol": ["600000.SH"], _CONSEC_COL: [0]})
+
+    got = _service(tmp_path).load_prior_consecutive(date(2024, 2, 19), _CONSEC_COL)
+
+    assert got.to_dicts() == [{"symbol": "600000.SH", "prev_consec": 3}]
+
+
+def test_prior_consecutive_ignores_as_of_and_future_partitions(tmp_path):
+    """只看严格早于 as_of 的分区; 当日和更晚的分区不能被当成「昨日」。"""
+    _write_partition(tmp_path, date(2026, 6, 30), {"symbol": ["600000.SH"], _CONSEC_COL: [5]})
+    _write_partition(tmp_path, date(2026, 7, 1), {"symbol": ["600000.SH"], _CONSEC_COL: [6]})
+
+    got = _service(tmp_path).load_prior_consecutive(date(2026, 6, 30), _CONSEC_COL)
+
+    assert got.is_empty()
+
+
+def test_prior_consecutive_skips_partition_missing_the_column(tmp_path):
+    """前一天分区缺列时继续往前找 (保持旧循环行为)。"""
+    _write_partition(tmp_path, date(2026, 6, 26), {"symbol": ["600000.SH"], _CONSEC_COL: [4]})
+    _write_partition(tmp_path, date(2026, 6, 29), {"symbol": ["600000.SH"], "close": [10.0]})
+    _write_partition(tmp_path, date(2026, 6, 30), {"symbol": ["600000.SH"], _CONSEC_COL: [0]})
+
+    got = _service(tmp_path).load_prior_consecutive(date(2026, 6, 30), _CONSEC_COL)
+
+    assert got.to_dicts() == [{"symbol": "600000.SH", "prev_consec": 4}]
+
+
+def test_prior_consecutive_returns_empty_without_any_partition(tmp_path):
+    """本地没有 enriched 目录时返回空表, 不抛异常。"""
+    got = _service(tmp_path).load_prior_consecutive(date(2026, 6, 30), _CONSEC_COL)
+
+    assert got.is_empty()


### PR DESCRIPTION
## 1. 问题与复现

春节后第一个交易日打开「涨停梯队」（`GET /api/screener/limit-ladder`）：

- **断板（晋级失败）一栏是空的** —— 前一天封住的票今天没封，本该出现在这一栏。
- **炸板股的板数退回 1 板** —— 本该是「昨日 N 板 + 1」。

节前最后一个交易日和节后第一个交易日之间隔了 **10~11 个自然日**（春节长假 + 前后调休周末），例如 2024-02-08 → 2024-02-19（11 天）、2023-01-20 → 2023-01-30（10 天）。平时（相邻交易日、周末、清明/端午这类三天小长假）都在窗口内，所以只有春节后那一天会这样，很容易被当成「今天就是没有断板」。

## 2. 根因

`ScreenerService.load_prior_consecutive` 按**自然日**回看找前一交易日的 enriched 分区：

```python
for delta in range(1, 10):
    candidate = as_of - timedelta(days=delta)
    target_parquet = enriched_dir / f"date={candidate.isoformat()}" / "part.parquet"
```

窗口只有 9 个自然日。间隔超过 9 天时一个分区都命中不到，函数返回空表，调用方 `app/api/screener.py:840` 就把整列填 0：

```python
if not prev_consec.is_empty():
    df = df.join(prev_consec, on="symbol", how="left")
else:
    df = df.with_columns(pl.lit(0).cast(pl.UInt32).alias("prev_consec"))
```

`prev_c` 恒为 0 之后：

```python
is_failed = ~is_limit & ~is_broken & (prev_c > 0)      # 恒假 → 断板一栏空
... .when(is_broken | is_failed).then(prev_c + 1)      # 恒为 1 → 炸板股显示 1 板
```

CONTRIBUTING §3.3 写的就是这条：「窗口、前 N 日和批次回算均按实际交易日，不得用自然日直接替代」。仓库里已经有做对了的同类函数——`auction_benchmark._prev_trading_day` 把本地分区目录当作已知交易日集合，直接取 `max(d for d in days if d < target)`，不假设任何自然日间隔；`data_integrity.scan_recent_integrity` 也是枚举 `date=*` 目录。

## 3. 解决方案

新增 `_prior_partition_dates(as_of, limit)`：枚举 enriched 目录下的 `date=` 分区，取早于 `as_of` 的日期、由近到远排序，最多 `limit` 个。`load_prior_consecutive` 改成遍历它。

保留的行为：

- 回看上限仍是 10 个候选（原来是 9 个自然日候选），「该分区缺 `consec_col` 就继续往前找」的逻辑一字未动。
- 仍然是窄读（`scan_parquet` + 两列），没有回到被它替换掉的全量重算慢路径。
- 只取严格早于 `as_of` 的分区，当日/未来分区不会被当成「昨日」。

目录不存在时 `iterdir()` 抛的 `OSError` 就地吞掉返回空列表，与原来 `exists()` 全部落空的结果一致。

## 4. 兼容性

- 只改前一交易日的**选取方式**，读的列、返回的列（`symbol` / `prev_consec`）、空表语义都不变。
- 对 ETF（`kline_etf_enriched`）同样生效，走的是同一个 `self._enriched_dirname`。
- 不涉及 Parquet schema、API 契约、配置或数据源。

## 5. 性能

一次 `iterdir()` 换掉最多 9 次 `Path.exists()`，同一目录、一次目录列举，都是元数据操作。这个函数每次「涨停梯队」请求调用一次，不在实时行情热路径上。

## 6. 验证结果

新增 `backend/tests/test_limit_ladder_prior_trading_day.py`（8 个用例）。

**修复前**（`origin/main` d0a14b5 + 仅加测试文件）：

```
$ python -m pytest tests/test_limit_ladder_prior_trading_day.py -q
...
        got = _service(tmp_path).load_prior_consecutive(as_of, _CONSEC_COL)

>       assert not got.is_empty(), f"{label}: 没找到前一交易日分区"
E       AssertionError: 春节长假(10 个自然日): 没找到前一交易日分区
E       assert not True
E        +  where True = is_empty()

3 failed, 5 passed in 1.01s
```

3 个失败的是：春节长假 11 天、春节长假 10 天、以及「多个更早分区时取最近的一个」。

**修复前就通过、用来钉住不能回退的 5 个**：相邻交易日、周末 3 天间隔、只看早于 `as_of` 的分区、缺列时继续往前找、本地无分区返回空表。

**修复后**：

```
$ python -m pytest tests/test_limit_ladder_prior_trading_day.py -q
........                                                                 [100%]
8 passed in 0.94s

$ python -m pytest tests -q --ignore=tests/test_watchdog.py
1906 passed, 6 skipped, 162 warnings in 111.00s (0:01:51)
```

（`tests/test_watchdog.py` 在我这台机器上未修改的 main 上也会挂住，故 `--ignore`。）

Ruff：

```
$ ruff check app/services/screener.py --statistics
8  RUF100 / 1  RUF002 / 1  SIM105        Found 10 errors.    # 与 main 逐项一致, 未新增
$ ruff check tests/test_limit_ladder_prior_trading_day.py
All checks passed!
```

## 7. 界面证据

无界面改动。可见变化是春节后首个交易日的「涨停梯队」里断板一栏不再是空的、炸板股的板数不再一律显示 1 板。

## 8. 风险与回滚

风险集中在「取到了不该取的分区」。三个用例把边界钉住了：不取 `as_of` 当天、不取更晚的分区、多个更早分区时取最近的那个。回滚即还原本 commit，回到自然日窗口。
