### PR TITLE
fix(rotation): AI 轮动分析的大盘背景不再把指数涨跌幅放大 100 倍

### DIFF
--- a/backend/app/services/concept_rotation_analyzer.py
+++ b/backend/app/services/concept_rotation_analyzer.py
@@ -206,9 +206,22 @@ def _compute_rotation_signals(dates: list[str], columns: dict) -> dict:
 # ================================================================
 
 def _fmt_pct(v) -> str:
+    """概念/行业涨幅: 小数口径 (0.0522 = +5.22%), 展示前乘 100。"""
     if v is None:
         return "—"
     return f"{v*100:+.2f}%"
+
+
+def _fmt_index_pct(v) -> str:
+    """指数涨跌幅: 百分数口径 (CONTRIBUTING §3.1), 直接展示, 不能再乘一次 100。
+
+    build_market_overview 的 indices[].change_pct 在数据边界已转成百分数
+    (quote_service._build_index_quotes 与 _index_quotes 的 DB 兜底都已乘过 100),
+    与 market_recap._build_indices_block 的展示口径一致。
+    """
+    if v is None:
+        return "—"
+    return f"{v:+.2f}%"
 
 
 def _build_market_block(overview: dict) -> str:
@@ -222,7 +235,7 @@ def _build_market_block(overview: dict) -> str:
     for idx in indices[:4]:
         name = idx.get("name") or idx.get("symbol") or "?"
         chg = idx.get("change_pct")
-        idx_lines.append(f"{name} {_fmt_pct(chg)}")
+        idx_lines.append(f"{name} {_fmt_index_pct(chg)}")
     idx_str = " / ".join(idx_lines) or "指数缺失"
 
     total_amount = (amt.get("total") or 0) / 1e8  # 元 → 亿

--- a/backend/tests/test_rotation_prompt_index_pct.py
+++ b/backend/tests/test_rotation_prompt_index_pct.py
@@ -1,0 +1,56 @@
+"""AI 轮动分析提示词里的「大盘背景」指数涨跌幅必须按百分数口径。
+
+CONTRIBUTING §3.1: build_market_overview 的 indices[].change_pct 是百分数
+(quote_service._build_index_quotes 在数据边界已乘过 100, DB 兜底路径同样乘过 100)。
+概念/行业涨幅则是小数。两者共用一个 _fmt_pct 会把指数再放大 100 倍,
+喂给 LLM 的大盘背景变成「上证指数 +123.00%」。
+"""
+from __future__ import annotations
+
+from app.services.concept_rotation_analyzer import (
+    _build_market_block,
+    _build_signal_block,
+)
+
+
+def _overview() -> dict:
+    """与 build_market_overview 返回结构一致的最小切片。"""
+    return {
+        "indices": [
+            {"symbol": "000001.SH", "name": "上证指数", "change_pct": 1.23},
+            {"symbol": "399001.SZ", "name": "深证成指", "change_pct": -0.45},
+        ],
+        "emotion": {"score": 62, "label": "偏暖"},
+        "limit": {"limit_up": 68, "broken": 20, "limit_down": 3, "max_boards": 5},
+        "amount": {"total": 1.2e12},
+    }
+
+
+def test_index_change_pct_is_not_scaled_again():
+    block = _build_market_block(_overview())
+
+    assert "上证指数 +1.23%" in block
+    assert "深证成指 -0.45%" in block
+    assert "123.00%" not in block
+
+
+def test_missing_index_change_pct_renders_placeholder():
+    overview = _overview()
+    overview["indices"][0]["change_pct"] = None
+
+    assert "上证指数 —" in _build_market_block(overview)
+
+
+def test_dimension_pct_is_still_scaled_from_decimal():
+    """概念/行业涨幅仍是小数口径, 必须乘 100 后展示 (不能被一起改掉)。"""
+    items = [{
+        "concept": "人工智能",
+        "ranks": [3, 1],
+        "pcts": [0.05, 0.07],
+        "avg_rank": 2.0,
+        "rank_std": 1.0,
+    }]
+
+    block = _build_signal_block("主线", items)
+
+    assert "区间均涨 +6.00%" in block


### PR DESCRIPTION
## 1. 问题与复现

在「概念分析」或「行业分析」页点 **AI 轮动分析**，生成的报告里大盘部分是这样的：

> 上证指数上涨 **123%**，深证成指下跌 **45%**……

第 5 节「结合大盘」整节都建立在这个数上，AI 会顺着写出「指数暴涨、题材普涨」之类的判断。同一天在「大盘复盘」（`market_recap`）里看到的却是正常的 +1.23% / -0.45%。

把 prompt 打出来就能直接看到：

```
- 指数: 上证指数 +123.00% / 深证成指 -45.00%
- 情绪: 62 (偏暖)
- 涨停/炸板/跌停: 68 / 20 / 3  (最高连板 5)
- 两市成交额: 12000 亿元
```

## 2. 根因

单位混用。`concept_rotation_analyzer._build_market_block` 用 `_fmt_pct` 渲染指数涨跌幅：

```python
def _fmt_pct(v) -> str:
    if v is None:
        return "—"
    return f"{v*100:+.2f}%"      # ← 小数口径专用
...
    chg = idx.get("change_pct")
    idx_lines.append(f"{name} {_fmt_pct(chg)}")
```

`_fmt_pct` 是给概念/行业涨幅写的——那是小数口径（`0.0522 = +5.22%`），乘 100 正确。但同一个块里的指数涨跌幅是**百分数**口径，CONTRIBUTING §3.1 就把这条列为「不可混用的数据契约」：

> 指数实时展示缓存的涨跌幅｜存在百分数口径｜使用前必须显式转换，不得直接复用到股票监控

两条来源都已经在数据边界转好了：

- `quote_service._build_index_quotes` 的 docstring：「API 返回的 change_pct/amplitude 是小数 (0.0366 = 3.66%)，**统一转成百分比输出**，与 `_fallback_index_quotes_from_daily` 口径一致（前端指数侧不 x100，直接 toFixed(2)% 展示）」
- `market_overview_builder._index_quotes` 的 DB 兜底：`change_pct = change_amount / pc * 100`

所以 1.23 又被乘了一次 100。

仓库里另外两个消费同一份 `overview["indices"]` 的地方都是对的：

- `market_recap._build_indices_block`（大盘复盘的同类提示词块）用的是 `f"{v:+.2f}%"`，不乘。
- `abnormal_moves._bench_rt_pct` 消费 `get_index_quotes()` 时显式 `/100.0`，注释还标了 issue #232。

漏的是轮动分析这一处。

## 3. 解决方案

加一个口径明确的 `_fmt_index_pct`，只给指数用：

```python
def _fmt_index_pct(v) -> str:
    """指数涨跌幅: 百分数口径 (CONTRIBUTING §3.1), 直接展示, 不能再乘一次 100。"""
    if v is None:
        return "—"
    return f"{v:+.2f}%"
```

`_build_market_block` 的指数行改用它；`_fmt_pct` 的行为一字未动，概念/行业涨幅（`_build_signal_block` 的「区间均涨」）仍按小数口径乘 100。顺手给 `_fmt_pct` 补了一行 docstring 说明它是小数口径，免得下一个人再踩。

没有改数据来源、聚合口径或提示词模板本身。

## 4. 兼容性

- 只影响送给 LLM 的提示词文本，不改 API 响应、不改前端、不改任何持久化数据。
- 历史已生成并保存的复盘/分析报告不受影响（它们是纯文本快照）。
- 两条指数来源（实时缓存 / `kline_index_daily` 兜底）都是百分数口径，新格式化函数对两者一致。

## 5. 性能

无影响，纯字符串格式化。

## 6. 验证结果

新增 `backend/tests/test_rotation_prompt_index_pct.py`（3 个用例）。

**修复前**（`origin/main` d0a14b5 + 仅加测试文件）：

```
$ python -m pytest tests/test_rotation_prompt_index_pct.py -q
F..                                                                      [100%]
    def test_index_change_pct_is_not_scaled_again():
        block = _build_market_block(_overview())

>       assert "上证指数 +1.23%" in block
E       AssertionError: assert '上证指数 +1.23%' in '- 指数: 上证指数 +123.00% / 深证成指 -45.00%\n- 情绪: 62 (偏暖)\n- 涨停/炸板/跌停: 68 / 20 / 3  (最高连板 5)\n- 两市成交额: 12000 亿元'

1 failed, 2 passed in 0.66s
```

另外两个用例修复前就通过，用来钉住不能回退的行为：`change_pct` 为 `None` 时仍渲染 `—`；概念涨幅仍按小数乘 100（`0.05 / 0.07` → `区间均涨 +6.00%`）。

**修复后**：

```
$ python -m pytest tests/test_rotation_prompt_index_pct.py tests/test_concept_rotation_signals.py -q
.....                                                                    [100%]
5 passed in 0.18s

$ python -m pytest tests -q --ignore=tests/test_watchdog.py
1899 passed, 2 failed, 6 skipped, 162 warnings in 168.05s (0:02:48)
```

那 2 个失败都在 `tests/test_mining_manager.py`，每次跑挂的还不是同一批，且**在未修改的 d0a14b5 上同样会挂**：

```
# git stash 掉本 PR 的改动, 即 origin/main 原样
$ python -m pytest tests/test_mining_manager.py -q
FAILED tests/test_mining_manager.py::test_cancel_while_waiting_for_capacity_never_calls_runner
1 failed, 10 passed in 2.53s

# 单独跑(机器不忙时)则全绿
$ python -m pytest tests/test_mining_manager.py -q
11 passed in 11.41s
```

是我这台机器满负载时的时序抖动，与本改动无关（本 PR 只动了一个字符串格式化函数）。排除该文件后：

```
$ python -m pytest tests -q --ignore=tests/test_watchdog.py --ignore=tests/test_mining_manager.py
1889 passed, 1 failed, 6 skipped in 121.07s
# 唯一失败: tests/backtest/test_worker_process.py::test_spawn_walkforward_reuses_shared_matrix_across_folds
# 同样是并发跑时的时序抖动, 单独跑通过
```

（`tests/test_watchdog.py` 在我这台机器上未修改的 main 上也会挂住，故 `--ignore`。）

Ruff：

```
$ ruff check app/services/concept_rotation_analyzer.py --statistics
2  I001 / 2  RUF100 / 1  RUF002        Found 5 errors.    # 与 main 逐项一致, 未新增
$ ruff check tests/test_rotation_prompt_index_pct.py
All checks passed!
```

## 7. 界面证据

无界面改动。可见变化在 AI 轮动分析报告正文里：大盘那句从「上证指数上涨 123%」变回「上证指数 +1.23%」。

## 8. 风险与回滚

风险很小：新增一个函数，只在指数那一行替换调用点，概念/行业涨幅路径没碰。回滚即还原本 commit。
