### PR TITLE
fix(preferences): 轮询间隔写入走 save(), 不再覆盖并发写入的其它偏好

### DIFF
--- a/backend/app/services/preferences.py
+++ b/backend/app/services/preferences.py
@@ -88,13 +88,12 @@ def get_realtime_quote_interval() -> float:
 
 
 def set_realtime_quote_interval(interval: float) -> float:
-    """保存行情轮询间隔（不在此做 min/max 校验，由调用方按档位限制）。"""
-    current = load()
-    current["realtime_quote_interval"] = interval
-    _path().write_text(
-        json.dumps(current, indent=2, ensure_ascii=False), encoding="utf-8",
-    )
-    _invalidate_cache()
+    """保存行情轮询间隔（不在此做 min/max 校验，由调用方按档位限制）。
+
+    走 save() 而不是自己 load + write_text: 锁外的 read-modify-write 会用旧快照
+    整体覆盖文件, 把并发写入的另一个偏好丢掉 (见 save 的 docstring)。
+    """
+    save({"realtime_quote_interval": interval})
     return interval
 
 

--- a/backend/tests/test_preferences_concurrent_write.py
+++ b/backend/tests/test_preferences_concurrent_write.py
@@ -1,0 +1,104 @@
+"""并发写 preferences.json 不得互相覆盖。
+
+preferences.save 的 docstring 记着这个坑: "FastAPI 同步端点跑线程池, 并行 PUT
+各自基于旧快照写盘会互相覆盖", 所以 save 的 read-modify-write 整段在 _SAVE_LOCK
+里。set_realtime_quote_interval 是唯一一个绕开该锁、自己 load + write_text 的
+setter —— PUT /api/settings/preferences/quote-interval 与任意另一个偏好 PUT
+同时在飞时, 后者会被前者用旧快照整体覆盖掉。
+"""
+from __future__ import annotations
+
+import json
+import threading
+
+import pytest
+
+from app.services import preferences
+
+_OTHER_KEY = "realtime_quotes_enabled"
+
+
+@pytest.fixture
+def prefs_path(tmp_path, monkeypatch):
+    path = tmp_path / "preferences.json"
+    monkeypatch.setattr(preferences, "_path", lambda: path)
+    preferences._invalidate_cache()
+    yield path
+    preferences._invalidate_cache()
+
+
+def _read(path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_interval_setter_does_not_clobber_a_concurrent_save(prefs_path, monkeypatch):
+    """轮询间隔写入与另一个偏好写入并发时, 两个键都要留下。
+
+    用一个会在第一次调用时挂起的 load 替身制造交错: 间隔 setter 拿到快照后
+    停住, 另一个 save 完整跑完, 然后间隔 setter 继续写盘。
+    """
+    preferences.save({_OTHER_KEY: False})
+
+    first_load_entered = threading.Event()
+    release_first_load = threading.Event()
+    other_save_done = threading.Event()
+    load_calls = []
+    real_load = preferences.load
+
+    def _load_pausing_on_first_call() -> dict:
+        snapshot = real_load()
+        load_calls.append(1)
+        if len(load_calls) == 1:
+            first_load_entered.set()
+            release_first_load.wait(10)
+        return snapshot
+
+    monkeypatch.setattr(preferences, "load", _load_pausing_on_first_call)
+
+    def _set_interval() -> None:
+        preferences.set_realtime_quote_interval(9.0)
+
+    def _save_other() -> None:
+        preferences.save({_OTHER_KEY: True})
+        other_save_done.set()
+
+    interval_thread = threading.Thread(target=_set_interval, name="set-interval")
+    interval_thread.start()
+    assert first_load_entered.wait(10), "间隔 setter 没有进入 load"
+
+    other_thread = threading.Thread(target=_save_other, name="save-other")
+    other_thread.start()
+    # 有锁时另一个 save 会一直等到间隔 setter 写完 (这里超时是预期的);
+    # 无锁时它会立刻写完, 随后被间隔 setter 的旧快照覆盖。
+    other_save_done.wait(0.5)
+    release_first_load.set()
+
+    interval_thread.join(10)
+    other_thread.join(10)
+    assert not interval_thread.is_alive() and not other_thread.is_alive()
+
+    monkeypatch.setattr(preferences, "load", real_load)
+    preferences._invalidate_cache()
+    stored = _read(prefs_path)
+    assert stored["realtime_quote_interval"] == 9.0
+    assert stored[_OTHER_KEY] is True, "并发的偏好写入被间隔 setter 的旧快照覆盖了"
+
+
+def test_interval_setter_keeps_existing_keys(prefs_path):
+    """顺序场景: 写间隔不能丢掉文件里已有的其它偏好。"""
+    preferences.save({_OTHER_KEY: True, "minute_sync_enabled": True})
+
+    preferences.set_realtime_quote_interval(3.0)
+
+    stored = _read(prefs_path)
+    assert stored == {
+        _OTHER_KEY: True,
+        "minute_sync_enabled": True,
+        "realtime_quote_interval": 3.0,
+    }
+
+
+def test_interval_setter_returns_value_and_refreshes_cache(prefs_path):
+    """返回值与缓存失效行为保持不变。"""
+    assert preferences.set_realtime_quote_interval(12.5) == 12.5
+    assert preferences.get_realtime_quote_interval() == 12.5


### PR DESCRIPTION
## 1. 问题与复现

在设置里拖动「行情轮询间隔」的同时改另一项偏好（比如实时行情总开关、分时刷新开关），刷新页面后**另一项又变回原样**。间隔本身保存成功了，被吞掉的是那一项。

复现条件是两个 PUT 同时在飞：

- `PUT /api/settings/preferences/quote-interval`（Data 页的间隔编辑器）
- 任意另一个 `PUT /api/settings/preferences/*`（走 `preferences.save`）

FastAPI 的同步端点跑在线程池里，两个请求真并行。间隔那条把整个 `preferences.json` 用自己进来时的旧快照写回去，另一条刚落盘的键就没了。

## 2. 根因

这个坑仓库里已经踩过一次并修好了——`preferences.save` 的 docstring 就是那次修复留下的：

```python
def save(updates: dict) -> dict:
    """合并写入。返回新内容。

    锁内 read-modify-write: FastAPI 同步端点跑线程池, 并行 PUT 各自基于旧快照
    写盘会互相覆盖 (实测: 压缩总开关并行写分时/日K两键, 后写者把先写者覆盖)。
    """
    with _SAVE_LOCK:
        current = load()
        current.update(updates)
        _path().write_text(...)
```

`set_realtime_quote_interval` 是本模块里唯一没跟上的 setter，它自己 load + 全量 write_text，全程不持 `_SAVE_LOCK`：

```python
def set_realtime_quote_interval(interval: float) -> float:
    current = load()                    # ← 快照
    current["realtime_quote_interval"] = interval
    _path().write_text(                 # ← 锁外全量写回, 覆盖这期间别人写的键
        json.dumps(current, indent=2, ensure_ascii=False), encoding="utf-8",
    )
    _invalidate_cache()
    return interval
```

`grep -n "_path().write_text" app/services/preferences.py` 全文件只有两处：`save` 里那处（持锁）和这一处（不持锁）。其余 setter（`set_sentiment_exclude_st` / `set_pipeline_pull_types` / `set_review_schedule` / `set_mining_schedule` / …）都是 `save({...})`。

调用链：`PUT /api/settings/preferences/quote-interval` → `QuoteService.set_interval` → `preferences.set_realtime_quote_interval`。

## 3. 解决方案

把它改成和其它 setter 一样委托给 `save`：

```python
save({"realtime_quote_interval": interval})
return interval
```

`save` 已经负责持锁、合并、写盘、失效缓存，所以返回值、落盘格式（`indent=2, ensure_ascii=False`）和 `_invalidate_cache()` 的时机都不变。净减 7 行、增 6 行（含 docstring 里补的一句为什么）。

## 4. 兼容性

- `preferences.json` 的内容与格式不变；返回值仍是传入的 `interval`（**不做 clamp**——档位 clamp 在 `QuoteService._clamp_interval`，本函数的 docstring 明确写了不在这里校验，这一点没动）。
- 缓存失效时机不变（`save` 在锁内写完后调 `_invalidate_cache`）。
- 无 API 契约、schema、数据源变化。

## 5. 性能

写偏好不是热路径。唯一变化是这条写入现在也要排 `_SAVE_LOCK`——锁内只有一次读文件 + 一次写文件，与其它所有偏好写入同级。

## 6. 验证结果

新增 `backend/tests/test_preferences_concurrent_write.py`（3 个用例）。并发用例用一个「第一次调用时挂起」的 `load` 替身制造确定的交错：间隔 setter 拿到快照后停住 → 另一个 `save` 跑完 → 间隔 setter 继续写盘。

**修复前**（`origin/main` d0a14b5 + 仅加测试文件）：

```
$ python -m pytest tests/test_preferences_concurrent_write.py -q
        stored = _read(prefs_path)
        assert stored["realtime_quote_interval"] == 9.0
>       assert stored[_OTHER_KEY] is True, "并发的偏好写入被间隔 setter 的旧快照覆盖了"
E       AssertionError: 并发的偏好写入被间隔 setter 的旧快照覆盖了
E       assert False is True

tests\test_preferences_concurrent_write.py:84: AssertionError
1 failed, 2 passed in 0.80s
```

另两个用例修复前就通过，用来钉住不能回退的行为：顺序写间隔不能丢已有键；返回值与缓存刷新行为不变。

**修复后**：

```
$ python -m pytest tests/test_preferences_concurrent_write.py tests/test_preferences_cache.py tests/test_quote_interval_min.py tests/test_quote_interval_settings.py tests/test_notification_settings.py -q
.........................                                                [100%]
25 passed in 24.99s

$ python -m pytest tests -q --ignore=tests/test_watchdog.py
1901 passed, 6 skipped, 162 warnings in 150.78s (0:02:30)
```

（`tests/test_watchdog.py` 在我这台机器上未修改的 main 上也会挂住，故 `--ignore`。）

Ruff：

```
$ ruff check app/services/preferences.py --statistics
9  RUF002 / 2  RUF003 / 1  RUF100        Found 12 errors.   # 与 main 逐项一致, 未新增
$ ruff check tests/test_preferences_concurrent_write.py
All checks passed!
```

## 7. 界面证据

无界面改动。可见变化是「改间隔的同时改另一项设置」不再把后者打回原值。

## 8. 风险与回滚

主要风险是 `set_realtime_quote_interval` 现在会阻塞在 `_SAVE_LOCK` 上——锁内只有一次文件读写，且不再有任何一处写偏好时持有它做慢操作。回滚即还原本 commit。
