### PR TITLE
fix(indicators): KDJ 零分母不再永久污染后续递推

### DIFF
--- a/backend/app/indicators/pipeline.py
+++ b/backend/app/indicators/pipeline.py
@@ -467,16 +467,21 @@ def compute_indicators(
 
     # Pass 3: KDJ
     if "kdj_k" in want:
-        _kdj_rsv = (
-            100 * (pl.col("close") - pl.col("_kdj_ln"))
-            / (pl.col("_kdj_hn") - pl.col("_kdj_ln")).fill_null(1e-12)
+        # 9 日内最高价=最低价 (场内货币 ETF、长期无成交标的) 时分母是 0 而不是空值,
+        # fill_null 拦不住: 0/0 得到 NaN, 再被 ewm 递推永久传染。与矩阵路径口径一致 ——
+        # 该日 RSV 置空, EWM 跳过空值后继续递推。
+        _kdj_range = pl.col("_kdj_hn") - pl.col("_kdj_ln")
+        _kdj_rsv = pl.when(_kdj_range > 0).then(
+            100 * (pl.col("close") - pl.col("_kdj_ln")) / _kdj_range
         )
         df = df.with_columns([
-            _kdj_rsv.ewm_mean(alpha=1.0 / 3, adjust=False).over("symbol").alias("kdj_k"),
+            _kdj_rsv.ewm_mean(alpha=1.0 / 3, adjust=False, ignore_nulls=True)
+            .over("symbol").alias("kdj_k"),
         ])
     if "kdj_d" in want:
         df = df.with_columns([
-            pl.col("kdj_k").ewm_mean(alpha=1.0 / 3, adjust=False).over("symbol").alias("kdj_d"),
+            pl.col("kdj_k").ewm_mean(alpha=1.0 / 3, adjust=False, ignore_nulls=True)
+            .over("symbol").alias("kdj_d"),
         ])
     if "kdj_j" in want:
         df = df.with_columns([

--- a/backend/tests/test_kdj_flat_range.py
+++ b/backend/tests/test_kdj_flat_range.py
@@ -1,0 +1,94 @@
+"""KDJ 零分母回归: 9 日内最高价=最低价时 RSV 无定义, 不得污染后续递推。
+
+场内货币 ETF (511990/511880 等) 与长期无成交的冷门标的会连续多日
+最高价=最低价, 此时 rolling_max(9)-rolling_min(9) 恰好为 0。旧实现用
+fill_null(1e-12) 守卫, 但零分母不是空值, 0/0 得到 NaN 并被 ewm_mean
+递推永久传染, 该标的此后所有交易日的 KDJ 都是 NaN。
+
+矩阵路径 (backtest/matrix.matrix_feature) 对同一份数据只把该日置空、
+之后继续递推, 两条路径必须给出同一套值。
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import numpy as np
+import polars as pl
+
+from app.backtest.matrix import build_market_data_matrix, matrix_feature
+from app.indicators.pipeline import compute_indicators
+
+FLAT_START = 12
+FLAT_STOP = 21  # 12..20 共 9 个交易日 最高价=最低价
+N_DAYS = 40
+
+
+def _flat_window_panel() -> pl.DataFrame:
+    rows: list[dict] = []
+    start = date(2024, 1, 1)
+    close = 10.0
+    for offset in range(N_DAYS):
+        if FLAT_START <= offset < FLAT_STOP:
+            high = low = current = close
+        else:
+            close = close * (1.0 + 0.01 * np.sin(offset / 3.0))
+            current = close
+            high = close * 1.02
+            low = close * 0.98
+        rows.append({
+            "symbol": "511990.SH",
+            "date": start + timedelta(days=offset),
+            "open": current,
+            "high": high,
+            "low": low,
+            "close": current,
+            "volume": 1000.0,
+        })
+    return pl.DataFrame(rows)
+
+
+def test_kdj_recovers_after_flat_high_low_window():
+    panel = _flat_window_panel()
+    enriched = compute_indicators(panel, needed={"kdj_k", "kdj_d", "kdj_j"})
+
+    for name in ("kdj_k", "kdj_d", "kdj_j"):
+        values = enriched[name].to_numpy().astype(float)
+        # 前 8 个交易日仍是预热空值, 第 9 个平盘日 (index 20) RSV 无定义。
+        assert np.isnan(values[:8]).all(), name
+        assert np.isnan(values[FLAT_STOP - 1]), name
+        # 平盘窗口滚出后必须恢复, 而不是永久 NaN。
+        assert np.isfinite(values[FLAT_STOP:]).all(), (
+            f"{name} 在平盘窗口之后仍为 NaN: {values[FLAT_STOP:]}"
+        )
+        assert int(np.isnan(values).sum()) == 9, name
+
+
+def test_kdj_cold_path_matches_matrix_on_flat_window():
+    panel = _flat_window_panel()
+    enriched = compute_indicators(panel, needed={"kdj_k", "kdj_d", "kdj_j"})
+    market = build_market_data_matrix(panel)
+
+    for name in ("kdj_k", "kdj_d", "kdj_j"):
+        np.testing.assert_allclose(
+            enriched[name].to_numpy().astype(float),
+            np.asarray(matrix_feature(market, name)[:, 0], dtype=float),
+            rtol=2e-4,
+            atol=2e-4,
+            equal_nan=True,
+            err_msg=name,
+        )
+
+
+def test_kdj_before_flat_window_is_unchanged():
+    """平盘窗口之前的取值不受本次修复影响 (锁定既有口径)。"""
+    panel = _flat_window_panel()
+    enriched = compute_indicators(panel, needed={"kdj_k", "kdj_d"})
+    np.testing.assert_allclose(
+        enriched["kdj_k"].to_numpy().astype(float)[8:20],
+        [
+            79.038803, 78.910706, 77.639870, 73.898865, 69.964340, 65.401917,
+            59.955997, 54.126106, 50.239616, 47.648457, 46.534885, 47.689919,
+        ],
+        rtol=1e-5,
+        atol=1e-5,
+    )


### PR DESCRIPTION
## 现象

把一只「连续 9 个交易日 最高价 = 最低价」的标的加进来（场内货币 ETF 如 511990/511880 长期钉在 100.000，或长期无成交的冷门标的、退市整理期个股），它的 KDJ 三条线从第 9 个平盘日起**永远是 NaN**，副图直接空掉，后面恢复正常交易也回不来。

同一份数据走回测矩阵路径（`backtest/matrix.matrix_feature`）算出来的 KDJ 却是正常的：只有那一天没值，之后继续递推。同一份行情两套 KDJ。

## 原因

`backend/app/indicators/pipeline.py` Pass 3：

```python
_kdj_rsv = (
    100 * (pl.col("close") - pl.col("_kdj_ln"))
    / (pl.col("_kdj_hn") - pl.col("_kdj_ln")).fill_null(1e-12)
)
```

`_kdj_hn - _kdj_ln` = `high.rolling_max(9) - low.rolling_min(9)`。9 日内最高价等于最低价时它是 **0**，不是空值 —— `fill_null(1e-12)` 拦不住。此时分子 `close - _kdj_ln` 同样是 0，`0 / 0` 在 Polars 浮点除法里得到 **NaN**（不是 null）。

NaN 与 null 的区别正是问题所在：`ewm_mean` 会跳过 null 继续递推，但 NaN 会参与 `k_t = α·x_t + (1-α)·k_{t-1}` 的算术，**一旦进入递推就永久传染**。`kdj_d` 再从 `kdj_k` 递推、`kdj_j = 3K - 2D`，三条线一起废掉。

同文件下方 RSI 的零分母守卫写法是对的，可以对照：

```python
pl.when(pl.col(f"_rsi_avg_loss_{n}") == 0).then(1e-12).otherwise(...)
```

即 KDJ 这里本该是零值守卫，却写成了空值守卫。

## 修复

零分母时把当日 RSV 置空，并让 EWM 跳过空值继续递推（`ignore_nulls=True`）—— 这与矩阵路径 `_matrix_ratio`（分母为 0 → NaN）+ `valid_ewm_adjust_false`（无效 bar 跳过、状态保留）完全同口径。预热期分母为空的行为不变（分子也为空，结果仍是 null）。

## 复现与验证

新增 `backend/tests/test_kdj_flat_range.py`：40 个交易日，第 13~21 天（9 天）最高价 = 最低价 = 收盘价，之后恢复正常。

**修复前（origin/main，`d0a14b5`）**

```
$ python -m pytest tests/test_kdj_flat_range.py -q
FAILED tests/test_kdj_flat_range.py::test_kdj_recovers_after_flat_high_low_window
FAILED tests/test_kdj_flat_range.py::test_kdj_cold_path_matches_matrix_on_flat_window
2 failed, 1 passed in 1.35s
```

失败细节：

```
E  assert np.isfinite(values[FLAT_STOP:]).all()
E    +  where <ufunc 'isfinite'>(array([nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan, nan,
E                                       nan, nan, nan, nan, nan, nan]))

E  Not equal to tolerance rtol=0.0002, atol=0.0002
E  kdj_k
E  nan location mismatch:
```

平盘窗口滚出之后 19 个交易日全是 NaN；矩阵路径同一列在 2024-01-22 就恢复到 48.46。

**修复后**

```
$ python -m pytest tests/test_kdj_flat_range.py -q
3 passed in 1.32s
```

冷路径与矩阵路径逐值相等，kdj_k/kdj_d/kdj_j 的 NaN 天数从 **28/40** 降到 **9/40**（8 天预热 + 1 天分母为零），与矩阵路径的 9/40 一致。

**必须保持不变的部分**（第三个用例 `test_kdj_before_flat_window_is_unchanged`，在修复前后都通过）：平盘窗口之前的 12 个 kdj_k 取值逐一锁定，未受本次改动影响。

**回归**

```
$ python -m pytest tests -q --ignore=tests/test_watchdog.py
main:  1898 passed, 6 skipped in 166.70s
本分支: 1901 passed, 6 skipped in 106.82s
```

（`tests/test_watchdog.py` 在本机 origin/main 上也会挂起，两次都用 `--ignore` 排除。）

`ruff check .`：main 与本分支同为 `Found 1583 errors`；改动的 `app/indicators/pipeline.py` 前后同为 46 条，新增测试文件 `All checks passed!`。
