### PR TITLE
fix(optimizer): 参数网格按步长展开不再越过用户填写的上限

### DIFF
--- a/backend/app/backtest/optimizer.py
+++ b/backend/app/backtest/optimizer.py
@@ -60,7 +60,9 @@ def _candidates_for(param_id: str, spec, pmeta: dict) -> list:
             raise ValueError(f"参数 '{param_id}' 的 max < min")
         step = float(step)
         # 整数计数生成候选, 避免浮点累加误差丢端点 (如 0.1/0.1 步长)。
-        n_steps = round((hi - lo) / step)
+        # 步数向下取整: (hi-lo) 不是 step 整数倍时, 四舍五入会多造一个越过 hi 的候选
+        # (1~20 步长 7 → 22), 用户填的上限反而被越界校验拒绝。1e-9 容差保住整除端点。
+        n_steps = int((hi - lo) / step + 1e-9)
         raw = [round(lo + i * step, 10) for i in range(n_steps + 1)]
     else:
         raise ValueError(f"参数 '{param_id}' 的网格 spec 必须是列表或 {{min,max,step}} 字典")

--- a/backend/tests/backtest/test_optimizer_grid_step_bounds.py
+++ b/backend/tests/backtest/test_optimizer_grid_step_bounds.py
@@ -1,0 +1,53 @@
+"""参数网格 {min,max,step} 展开不得越过用户填写的上限。
+
+(hi-lo) 不是 step 整数倍时, 旧实现用 round() 算步数会向上取整, 多造一个
+超过 max 的候选值: 1~20 步长 7 展开成 [1,8,15,22], 22 又被参数自身的
+range 校验拒绝 —— 用户填的上限就是参数合法上限, 却直接报错扫不了。
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.backtest.optimizer import count_combinations, expand_param_grid
+
+PARAMS_META = [
+    {"id": "min_boards", "type": "int", "default": 2, "min": 1, "max": 20, "step": 1},
+    {"id": "ma_proximity", "type": "float", "default": 0.02, "min": 0.01, "max": 0.50, "step": 0.005},
+]
+
+
+def test_int_range_not_divisible_by_step_stays_within_max():
+    """1~20 步长 7: 不得造出 22, 也不得因此报「超出范围」。"""
+    combos = expand_param_grid(PARAMS_META, {"min_boards": {"min": 1, "max": 20, "step": 7}})
+    values = sorted(combo["min_boards"] for combo in combos)
+    assert values == [1, 8, 15]
+    assert count_combinations(PARAMS_META, {"min_boards": {"min": 1, "max": 20, "step": 7}}) == 3
+
+
+def test_float_range_not_divisible_by_step_stays_within_max():
+    """0.01~0.05 步长 0.015: 末候选 0.055 越过用户填的 0.05。"""
+    combos = expand_param_grid(
+        PARAMS_META, {"ma_proximity": {"min": 0.01, "max": 0.05, "step": 0.015}}
+    )
+    values = sorted(combo["ma_proximity"] for combo in combos)
+    assert values == pytest.approx([0.01, 0.025, 0.04])
+    assert max(values) <= 0.05
+
+
+def test_divisible_range_still_keeps_both_endpoints():
+    """整除区间的端点必须保留 (含浮点累加误差场景), 锁定既有行为。"""
+    int_values = sorted(
+        combo["min_boards"]
+        for combo in expand_param_grid(PARAMS_META, {"min_boards": {"min": 1, "max": 4, "step": 1}})
+    )
+    assert int_values == [1, 2, 3, 4]
+
+    float_meta = [{"id": "p", "type": "float", "default": 0.2, "min": 0.1, "max": 0.3, "step": 0.1}]
+    float_values = sorted(
+        combo["p"] for combo in expand_param_grid(float_meta, {"p": {"min": 0.1, "max": 0.3, "step": 0.1}})
+    )
+    assert float_values == [0.1, 0.2, 0.3]
+
+    assert count_combinations(
+        PARAMS_META, {"ma_proximity": {"min": 0.01, "max": 0.05, "step": 0.001}}
+    ) == 41


### PR DESCRIPTION
## 现象

在参数优化页把一个整数参数按「最小 1 / 最大 20 / 步长 7」扫描，直接报错扫不了：

```
参数 'min_boards' 的候选值 22.0 超出范围 (> max 20)
```

用户填的上限 20 就是这个参数自己的合法上限，22 是展开器凭空造出来的。

换成浮点参数则是静默多扫一档：「0.01 ~ 0.05 步长 0.015」展开成 `[0.01, 0.025, 0.04, 0.055]`，`0.055` 超过了用户填的 0.05，还会进最优参数结果。

## 原因

`backend/app/backtest/optimizer.py` `_candidates_for()`：

```python
n_steps = round((hi - lo) / step)
raw = [round(lo + i * step, 10) for i in range(n_steps + 1)]
```

`(hi - lo)` 不是 `step` 整数倍时，`round()` 会**向上取整**，于是多生成一个 `lo + n_steps*step > hi` 的候选：

- `(20-1)/7 = 2.714 → round = 3 → [1, 8, 15, 22]`，22 随后被下面的 range 校验拒绝，整个网格失败；
- `(0.05-0.01)/0.015 = 2.667 → round = 3 → [..., 0.055]`，因为参数元数据的 max 更宽松（0.50）而没被拦下，直接多扫一档。

函数注释写的是「含端点」，意思是不丢端点，不是可以越过 `max`。

## 修复

步数改为向下取整，保留 `1e-9` 容差以维持原注释里「避免浮点累加误差丢端点（如 0.1/0.1 步长）」的行为：

```python
n_steps = int((hi - lo) / step + 1e-9)
```

`hi >= lo` 已在上方校验，`int()` 对非负数即向下取整，不需要新增 import。

## 复现与验证

新增 `backend/tests/backtest/test_optimizer_grid_step_bounds.py`。

**修复前（origin/main，`d0a14b5`）**

```
$ python -m pytest tests/backtest/test_optimizer_grid_step_bounds.py -q
FAILED ...::test_int_range_not_divisible_by_step_stays_within_max
FAILED ...::test_float_range_not_divisible_by_step_stays_within_max
2 failed, 1 passed in 0.14s
```

失败细节：

```
E  ValueError: 参数 'min_boards' 的候选值 22.0 超出范围 (> max 20)

E  assert [0.01, 0.025, 0.04, 0.055] == approx([0.01 ...04 ± 4.0e-08])
E    Impossible to compare lists with different sizes.
E    Lengths: 3 and 4
```

**修复后**

```
$ python -m pytest tests/backtest/test_optimizer_grid_step_bounds.py tests/backtest/test_optimizer_grid.py -q
15 passed in 0.07s
```

（3 个新用例 + 原有 12 个用例全绿。）

**必须保持不变的部分**（第三个用例 `test_divisible_range_still_keeps_both_endpoints`，修复前后都通过，与原有 `test_range_spec_expands_by_step` / `test_range_spec_float_keeps_endpoint_despite_accumulation` / `test_combination_explosion_rejected` 重合）：

- `1~4 步长 1 → [1,2,3,4]`
- `0.1~0.3 步长 0.1 → [0.1, 0.2, 0.3]`（浮点累加不丢端点 0.3）
- `0.01~0.05 步长 0.001 → 41 个组合`

**回归**

```
$ python -m pytest tests -q --ignore=tests/test_watchdog.py
main:  1898 passed, 6 skipped in 166.70s
本分支: 1900 passed, 6 skipped, 1 failed in 273.15s
```

唯一失败是 `tests/test_pipeline_capacity.py::test_api_jobs_wait_before_computing[...repair_daily...]`，本机高负载下的计时抖动（本轮整体耗时 273s vs 平时 100~170s），与本 PR 的网格展开无关；单独重跑 `python -m pytest tests/test_pipeline_capacity.py -q` → `15 passed in 4.93s`。

（`tests/test_watchdog.py` 在本机 origin/main 上也会挂起，一律 `--ignore` 排除。）

`ruff check .`：main 与本分支同为 `Found 1583 errors`；改动文件与新增测试均 `All checks passed!`。
