### PR TITLE
fix(backtest): 财务因子矩阵路径不再沿用上一期的过期值

### DIFF
--- a/backend/app/backtest/fundamentals.py
+++ b/backend/app/backtest/fundamentals.py
@@ -181,9 +181,11 @@ def build_fundamental_matrices(
             continue
         for column, target in raw_columns.items():
             value = snapshot[column][row_index]
-            if value is None or not np.isfinite(float(value)):
-                continue
-            target[start:, column_index] = float(value)
+            numeric = float("nan") if value is None else float(value)
+            # 新一期该指标为空时必须覆盖旧值为 NaN: 跳过写入会让同一行混用两期
+            # 报告 (bps 取新期、roe 停在上一期), 与 polars 侧 join_asof 只认
+            # 最新一期整行的口径不一致。
+            target[start:, column_index] = numeric if np.isfinite(numeric) else np.nan
 
     for name in requested:
         spec = FUNDAMENTAL_FACTORS[name]

--- a/backend/tests/test_fundamental_factors.py
+++ b/backend/tests/test_fundamental_factors.py
@@ -140,6 +140,36 @@ def test_matrix_field_matches_polars_attach_across_two_announcements():
             np.testing.assert_allclose(actual, value, rtol=1e-6)
 
 
+def test_matrix_field_clears_value_when_newer_report_lacks_metric():
+    """新一期财报缺该指标时不得继续沿用上一期值, 否则同一行混用两期报告。
+
+    矩阵路径逐列前向填充, 若跳过空值写入, 4-16 起 pb 已换到新期 bps=6,
+    roe 却仍停在上一期的 20 —— polars 侧 join_asof 只认最新一期整行 (roe 为
+    null), 两条路径给出不同的因子值。
+    """
+    panel = _daily_panel(date(2026, 4, 1), 20, ("600000.SH",))
+    snapshot = _snapshot_frame([
+        {"symbol": "600000.SH", "announce": "2026-04-05", "roe": 20.0, "bps": 4.0},
+        {"symbol": "600000.SH", "announce": "2026-04-15", "roe": None, "bps": 6.0},
+    ])
+    attached = attach_fundamental_factors(panel, snapshot, ["roe_latest", "pb_latest"]).sort("date")
+    market = build_market_data_matrix(panel)
+    matrices = build_fundamental_matrices(market, snapshot, ["roe_latest", "pb_latest"])
+    column = market.symbols.index("600000.SH")
+
+    # polars 口径: 新公告生效 (4-16) 后 roe 无值, pb 走新一期 bps
+    assert attached["roe_latest"].to_list()[15:] == [None] * 5
+    assert all(value is not None for value in attached["pb_latest"].to_list()[15:])
+
+    for name in ("roe_latest", "pb_latest"):
+        for row_index, value in enumerate(attached[name].to_list()):
+            actual = matrices[name][row_index, column]
+            if value is None:
+                assert np.isnan(actual), (name, row_index, actual)
+            else:
+                np.testing.assert_allclose(actual, value, rtol=1e-6)
+
+
 def test_bps_nonpositive_gives_null_pb():
     panel = _daily_panel(date(2026, 4, 1), 8, ("000001.SZ",))
     snapshot = _snapshot_frame([


### PR DESCRIPTION
## 现象

一只票新一期财报里某个指标缺失（多数据源并集共存时很常见 —— 见 `financial_sync._merge_report_history` 的「新行缺的列由旧行补齐」语义，某期确实可能整列为空），走矩阵路径的因子回测/挖掘里，这只票在新公告生效后会出现**同一行混用两期报告**的取值：

- `pb_latest` 已经换成新一期的净资产（bps=6）
- `roe_latest` 却还停在**上一期**的 20.0

而 polars 面板路径（`attach_fundamental_factors`）对同一份数据给出的是 `roe_latest = null`（`join_asof` 只认最新一期整行）。同一份配置、同一天、同一只票，两条路径两个因子值 —— 正是本模块 docstring 声明要避免的。

## 原因

`backend/app/backtest/fundamentals.py` `build_fundamental_matrices()` 逐列前向填充时跳过了空值写入：

```python
for column, target in raw_columns.items():
    value = snapshot[column][row_index]
    if value is None or not np.isfinite(float(value)):
        continue                      # ← 新一期为空就不写, 旧值原地保留
    target[start:, column_index] = float(value)
```

`continue` 让每一列**各自保留自己最后一个非空的报告期**，于是不同列可以来自不同期。polars 侧不是这样：`join_asof` 选中最新一期那一行，整行的列一起生效，缺的列就是 null。

`build_fundamental_matrices` 的 docstring 明写「与 attach_fundamental_factors 同一口径」，模块 docstring 也写「无财务数据的标的/日期一律为 null，绝不填 0（填 0 会污染截面排名）」—— 沿用上一期的过期值同样污染截面，而且更隐蔽（看起来是个合理数值）。

## 修复

空值同样写入 NaN，让新一期整行生效：

```python
numeric = float("nan") if value is None else float(value)
target[start:, column_index] = numeric if np.isfinite(numeric) else np.nan
```

## 复现与验证

在既有的 `backend/tests/test_fundamental_factors.py` 里新增 `test_matrix_field_clears_value_when_newer_report_lacks_metric`（紧邻已有的两条双路径一致性用例）：两期公告，新一期 `roe` 为空、`bps` 有值。

**修复前（origin/main，`d0a14b5`）**

```
$ python -m pytest tests/test_fundamental_factors.py -q
FAILED tests/test_fundamental_factors.py::test_matrix_field_clears_value_when_newer_report_lacks_metric
1 failed, 11 passed in 8.57s
```

失败细节：

```
E  AssertionError: ('roe_latest', 15, np.float32(20.0))
E  assert np.False_
E   +  where np.False_ = <ufunc 'isnan'>(np.float32(20.0))
```

第 15 行（新公告生效首日 2026-04-16）polars 侧是 `None`，矩阵侧却是上一期的 `20.0`；同一行的 `pb_latest` 两边都已经换成新一期。

**修复后**

```
$ python -m pytest tests/test_fundamental_factors.py -q
12 passed in 1.76s
```

**必须保持不变的部分**（同文件原有 11 条用例，修复前后都通过）：公告日严格门控（`date > announce`）、换报告期时前向填充不断档（`test_matrix_field_matches_polars_attach_across_two_announcements`）、无快照全 null、bps <= 0 给 null、历史累积同步合并语义。

**回归**

```
$ python -m pytest tests -q --ignore=tests/test_watchdog.py
main:  1898 passed, 6 skipped in 166.70s
本分支: 1899 passed, 6 skipped in 164.59s
```

（`tests/test_watchdog.py` 在本机 origin/main 上也会挂起，两次都用 `--ignore` 排除。）

`ruff check .`：main 与本分支同为 `Found 1583 errors`；改动文件与测试文件均 `All checks passed!`。
