### PR TITLE
fix(indicators): 维表涨跌停价为 0 时不再把全部标的判成涨停

### DIFF
--- a/backend/app/indicators/pipeline.py
+++ b/backend/app/indicators/pipeline.py
@@ -803,9 +803,13 @@ def compute_limit_signals(
     else:
         authoritative_date = pl.col("date") == pl.col("date").max()
     if "limit_up" in df.columns:
+        # >0 与实时路径 (_compute_limit_signals_today) 同守卫: 维表 limit_up 为 0
+        # (数据源未提供该字段的占位值) 不是权威价, 直接采用会让 raw_close >= -0.005
+        # 恒成立, 全部标的被判涨停。
         effective_limit_up = pl.when(
             authoritative_date
             & pl.col("limit_up").is_not_null()
+            & (pl.col("limit_up") > 0)
             & (pl.col("limit_up") < _SENTINEL)
         ).then(pl.col("limit_up")).otherwise(pl.col("_theoretical_limit_up"))
     else:
@@ -814,6 +818,7 @@ def compute_limit_signals(
         effective_limit_down = pl.when(
             authoritative_date
             & pl.col("limit_down").is_not_null()
+            & (pl.col("limit_down") > 0)
             & (pl.col("limit_down") < _SENTINEL)
         ).then(pl.col("limit_down")).otherwise(pl.col("_theoretical_limit_down"))
     else:

--- a/backend/tests/test_price_limits.py
+++ b/backend/tests/test_price_limits.py
@@ -189,6 +189,68 @@ def test_daily_limit_prices_require_matching_instrument_date(instrument_as_of, e
     assert "_instrument_as_of" not in result.columns
 
 
+def test_daily_limit_prices_ignore_zero_placeholder_and_match_realtime():
+    """维表涨跌停价为 0 (数据源未提供该字段的占位值) 时必须回退理论价。
+
+    直接采用 0 会让「raw_close >= 0 - 0.005」恒成立, 当日所有标的被判涨停,
+    连板数一路累加; 跌停侧反过来永远判不出跌停。实时路径
+    (_compute_limit_signals_today) 已有 >0 守卫, 冷路径必须同口径。
+    """
+    instruments = pl.DataFrame({
+        "symbol": ["600001.SH"],
+        "name": ["普通股"],
+        "limit_up": [0.0],
+        "limit_down": [0.0],
+        "as_of": [date(2026, 7, 20)],
+    })
+
+    # 只涨 0.5%: 不是涨停
+    mild = pipeline.compute_limit_signals(
+        _daily_limit_rows(10.05),
+        instruments,
+        needed={"signal_limit_up", "consecutive_limit_ups"},
+    )
+    assert mild["signal_limit_up"][-1] is False
+    assert mild["consecutive_limit_ups"][-1] == 0
+
+    # 真涨停 11.00 = 10.00 x 1.1: 理论价兜底后仍须判出
+    sealed = pipeline.compute_limit_signals(
+        _daily_limit_rows(11.00),
+        instruments,
+        needed={"signal_limit_up", "consecutive_limit_ups"},
+    )
+    assert sealed["signal_limit_up"][-1] is True
+    assert sealed["consecutive_limit_ups"][-1] == 1
+
+    # 真跌停 9.00 = 10.00 x 0.9: 占位 0 不得让跌停漏判
+    floored = pipeline.compute_limit_signals(
+        _daily_limit_rows(9.00),
+        instruments,
+        needed={"signal_limit_down"},
+    )
+    assert floored["signal_limit_down"][-1] is True
+
+    # 与实时路径同一份维表同一结论
+    realtime = pipeline._compute_limit_signals_today(
+        pl.DataFrame({
+            "symbol": ["600001.SH"],
+            "date": [date(2026, 7, 20)],
+            "open": [10.05],
+            "high": [10.05],
+            "low": [10.05],
+            "close": [10.05],
+            "raw_close": [10.05],
+            "raw_high": [10.05],
+            "raw_low": [10.05],
+            "_prev_close_raw": [10.0],
+            "volume": [1000.0],
+        }),
+        instruments,
+    )
+    assert realtime["signal_limit_up"][0] is False
+    assert mild["signal_limit_up"][-1] is realtime["signal_limit_up"][0]
+
+
 def test_realtime_limit_prices_ignore_stale_instrument_date():
     today = date(2026, 7, 20)
     rows = pl.DataFrame({


### PR DESCRIPTION
## 现象

数据源没提供涨跌停价、维表里 `limit_up` / `limit_down` 落成占位值 `0` 时（`instrument_sync._flatten_instruments` 是 `ext.get("limit_up")` 原样透传，自定义数据源填 0 表示「无此字段」很常见），当天全市场的票都会被判成**涨停**：涨停名单被撑爆、连板数从 1 开始一路累加，enriched 里存下来的 `signal_limit_up` 也是错的。

反过来跌停侧是漏判：真正跌到跌停价的票被判成没跌停，`signal_limit_down_recovery`（跌停翘板）也跟着失效。

同一份维表走实时路径（`_compute_limit_signals_today`）结论是对的 —— 冷热两条路径对同一天同一只票给出相反答案。

## 原因

`backend/app/indicators/pipeline.py` `compute_limit_signals()` 里判定「维表价是否权威」时只校验了非空和哨兵上界：

```python
effective_limit_up = pl.when(
    authoritative_date
    & pl.col("limit_up").is_not_null()
    & (pl.col("limit_up") < _SENTINEL)
).then(pl.col("limit_up")).otherwise(pl.col("_theoretical_limit_up"))
```

`limit_up = 0` 满足这三条，于是 `_effective_limit_up = 0`，下面的判定

```python
pl.col("raw_close") >= (pl.col("_effective_limit_up") - 0.005)
```

变成 `raw_close >= -0.005`，对任何正收盘价**恒成立**。跌停侧对称地变成 `raw_close <= 0.005`，对任何正收盘价恒不成立。

同文件的实时路径 `_compute_limit_signals_today()` 已经有这个守卫：

```python
has_authoritative_up = (
    authoritative_date
    & pl.col("limit_up").is_not_null()
    & (pl.col("limit_up") > 0)          # ← 冷路径缺的就是这一条
    & (pl.col("limit_up") < _SENTINEL)
)
```

## 修复

冷路径补上同样的 `> 0` 守卫（涨停、跌停各一条），占位 0 时回退到理论价（`prev_close × (1 ± limit_pct)`，整数分算术），与实时路径同口径。

## 复现与验证

在既有的 `backend/tests/test_price_limits.py` 里新增 `test_daily_limit_prices_ignore_zero_placeholder_and_match_realtime`，复用文件里已有的 `_daily_limit_rows()` 夹具（昨收 10.00）。

**修复前（origin/main，`d0a14b5`）**

```
$ python -m pytest tests/test_price_limits.py -q
FAILED tests/test_price_limits.py::test_daily_limit_prices_ignore_zero_placeholder_and_match_realtime
1 failed, 16 passed, 1 warning in 24.39s
```

失败细节：

```
E  assert True is False
tests\test_price_limits.py:213: AssertionError
```

即收盘 10.05（只涨 0.5%）被判成涨停，`consecutive_limit_ups` 记成 1。

**修复后**

```
$ python -m pytest tests/test_price_limits.py -q
17 passed, 1 warning in 10.35s
```

用例覆盖四条：

1. 只涨 0.5%（10.05）→ 不是涨停，连板数 0；
2. 真涨停 11.00 = 10.00 × 1.1 → 理论价兜底后仍判出，连板数 1；
3. 真跌停 9.00 = 10.00 × 0.9 → 占位 0 不再让跌停漏判；
4. 同一份维表交给 `_compute_limit_signals_today`，冷热两条路径结论一致。

**必须保持不变的部分**（同文件原有 16 条用例，修复前后都通过）：维表日期不匹配时回退理论价（`test_daily_limit_prices_require_matching_instrument_date` 的三种 `as_of`）、实时路径忽略过期维表、ST 涨跌停比例按交易日切换、polars/numpy 半入取整一致、除权后翘板用原始价判定。另外 `tests/test_st_limit_and_sharpe.py` 与 `tests/test_limit_ladder_one_word.py` 也一并跑过（合计 26 passed）。

**回归**

```
$ python -m pytest tests -q --ignore=tests/test_watchdog.py
main:  1898 passed, 6 skipped in 166.70s
本分支: 1899 passed, 6 skipped in 98.33s
```

（`tests/test_watchdog.py` 在本机 origin/main 上也会挂起，两次都用 `--ignore` 排除。）

`ruff check .`：main 与本分支同为 `Found 1583 errors`；`app/indicators/pipeline.py` 前后同为 46 条，`tests/test_price_limits.py` 为 `All checks passed!`。

## 说明

本 PR 只补 `> 0` 这一条守卫，不动实时路径已有的 `no_price_limit`（`limit_up >= 哨兵 10000` 视为无涨跌停限制）分支 —— 那是另一个口径差异，保持改动最小。
