### PR TITLE
fix(ext-data): 卡片「最新」时间按北京墙钟, 不再随服务端时区漂移

### DIFF
--- a/backend/app/api/ext_data.py
+++ b/backend/app/api/ext_data.py
@@ -16,6 +16,7 @@ import polars as pl
 from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
 from pydantic import BaseModel, Field
 
+from app.market_time import CN_TZ
 from app.services.ext_data import (
     ExtConfig,
     ExtConfigStore,
@@ -255,10 +256,14 @@ def _with_instrument_name(df: pl.DataFrame, data_dir: Path) -> pl.DataFrame:
 
 
 def _latest_sync_date(config: ExtConfig, data_dir: Path) -> str | None:
-    """扫描数据文件，返回该扩展配置的最新同步时间（含时分秒）。
+    """扫描数据文件，返回该扩展配置的最新同步时间（北京墙钟, 含时分秒）。
 
     - snapshot: 直接取 ext_data/{id}/part.parquet 的 mtime
     - timeseries: 扫描 ext_data/{id}/timeseries/date=xxx 分区目录
+
+    用北京时间而非宿主机时钟: 前端 ExtDataStatCard 原样展示这串裸时间,
+    容器默认 UTC 时会比同一页拉取面板里的 pull.last_run(带时区 ISO,
+    浏览器按本地时区渲染)整整差一个时区。
     """
     from datetime import datetime
 
@@ -266,7 +271,7 @@ def _latest_sync_date(config: ExtConfig, data_dir: Path) -> str | None:
         # 快照: part.parquet 与 config.json 同级
         p = data_dir / "ext_data" / config.id / "part.parquet"
         if p.exists():
-            ts = datetime.fromtimestamp(p.stat().st_mtime).strftime("%Y-%m-%d %H:%M:%S")
+            ts = datetime.fromtimestamp(p.stat().st_mtime, tz=CN_TZ).strftime("%Y-%m-%d %H:%M:%S")
             return ts
         # 兼容旧路径
         old = data_dir / "instruments_ext"
@@ -285,7 +290,7 @@ def _latest_sync_date(config: ExtConfig, data_dir: Path) -> str | None:
 
 
 def _latest_sync_from_partitions(base: Path) -> str | None:
-    """从 date=xxx 分区目录中找到最新分区的修改时间。"""
+    """从 date=xxx 分区目录中找到最新分区的修改时间 (北京墙钟)。"""
     from datetime import datetime
     latest_ts: float = 0
     latest_date: str | None = None
@@ -297,7 +302,7 @@ def _latest_sync_from_partitions(base: Path) -> str | None:
                     latest_ts = mtime
                     latest_date = d.name[5:]
     if latest_date and latest_ts > 0:
-        ts = datetime.fromtimestamp(latest_ts).strftime("%H:%M:%S")
+        ts = datetime.fromtimestamp(latest_ts, tz=CN_TZ).strftime("%H:%M:%S")
         return f"{latest_date} {ts}"
     return latest_date
 

--- a/backend/tests/test_ext_data_latest_sync_timezone.py
+++ b/backend/tests/test_ext_data_latest_sync_timezone.py
@@ -1,0 +1,62 @@
+"""扩展数据卡片的「最新」时间必须是北京墙钟, 不随服务端时区漂移。
+
+latest_sync_date 由 parquet 的 mtime 格式化而来, 前端 ExtDataStatCard 原样
+展示这串裸时间。用宿主机时钟格式化, 容器默认 UTC 时同一次同步在卡片上显示
+成 8 小时前, 而同一页拉取面板里的 pull.last_run(带时区的 ISO, 前端按浏览器
+时区渲染)显示的是正确时间 —— 一个页面两个时间对不上。
+"""
+from __future__ import annotations
+
+import os
+import types
+from datetime import datetime
+
+import pytest
+
+from app.api.ext_data import _latest_sync_date
+from app.market_time import CN_TZ
+
+# 固定 epoch 秒 = 北京时间 2026-09-04 22:13:20
+_MTIME = 1_788_531_200
+
+
+def _beijing(fmt: str) -> str:
+    return datetime.fromtimestamp(_MTIME, tz=CN_TZ).strftime(fmt)
+
+
+def _touch(path, mtime: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"")
+    os.utime(path, (mtime, mtime))
+
+
+@pytest.fixture
+def snapshot_config():
+    return types.SimpleNamespace(id="ext_gn_ths", mode="snapshot")
+
+
+@pytest.fixture
+def timeseries_config():
+    return types.SimpleNamespace(id="ext_ts_demo", mode="timeseries")
+
+
+def test_snapshot_latest_sync_is_beijing_wall_clock(tmp_path, snapshot_config):
+    _touch(tmp_path / "ext_data" / snapshot_config.id / "part.parquet", _MTIME)
+
+    got = _latest_sync_date(snapshot_config, tmp_path)
+
+    assert got == _beijing("%Y-%m-%d %H:%M:%S")
+
+
+def test_timeseries_latest_sync_is_beijing_wall_clock(tmp_path, timeseries_config):
+    base = tmp_path / "ext_data" / timeseries_config.id / "timeseries"
+    _touch(base / "date=2026-09-03" / "part.parquet", _MTIME - 86400)
+    _touch(base / "date=2026-09-04" / "part.parquet", _MTIME)
+
+    got = _latest_sync_date(timeseries_config, tmp_path)
+
+    assert got == f"2026-09-04 {_beijing('%H:%M:%S')}"
+
+
+def test_latest_sync_is_none_without_any_data(tmp_path, snapshot_config):
+    assert _latest_sync_date(snapshot_config, tmp_path) is None


### PR DESCRIPTION
## 1. 问题与复现

扩展数据页上，**同一次同步在同一个页面里显示成两个时间**：

- 卡片底部「最新」：`2026-09-04 10:30:00`
- 同一个配置的设置 → 拉取面板 → 「上次」：`09-04 18:30`

差的正好是一个时区。Docker 镜像默认 UTC（`app/market_time.py` 开篇就写着「服务器/容器本地时区不可靠 (python:slim 镜像默认 UTC)」），所以国内用户跑容器时卡片上的「最新」永远早 8 小时，看上去像今天还没同步过。

不是只有 00:00–08:00 那个窗口——这串时间**一天 24 小时都偏一个时区**。

## 2. 根因

`_latest_sync_date` 用宿主机时钟把 mtime 格式化成一串**不带时区**的裸字符串：

```python
ts = datetime.fromtimestamp(p.stat().st_mtime).strftime("%Y-%m-%d %H:%M:%S")
```

```python
ts = datetime.fromtimestamp(latest_ts).strftime("%H:%M:%S")   # _latest_sync_from_partitions
```

前端 `ExtDataStatCard.tsx:141` 原样渲染，没有任何换算余地：

```tsx
<span className="text-secondary">{config.latest_sync_date ?? '—'}</span>
```

而同一页拉取面板里的时间是对的，因为那一侧写的是**带偏移的 ISO**：

```python
fresh.pull.last_run = datetime.now(timezone.utc).isoformat()          # ext_pull.py
latest.pull.next_run = datetime.fromtimestamp(next_dt, tz=UTC).isoformat()
```

前端 `ExtDataPullPanel.fmtTime` 用 `new Date(iso)` 解析，浏览器按本地时区渲染 → 正确。

同一个坑仓库里已经修过一次，`json_report_store._now_iso` 的 docstring 就是那次留下的：

> 用北京墙钟而非宿主机时钟: 容器默认 UTC 时, 前端把这串 naive 时间按浏览器本地时区解析, 刚生成的报告会显示成「8 小时前」。

`_latest_sync_date` 是同一类里漏掉的那个。

## 3. 解决方案

两条路径（snapshot 的 `part.parquet`、timeseries 的 `date=xxx` 分区）都改成用 `app.market_time.CN_TZ` 格式化：

```python
datetime.fromtimestamp(p.stat().st_mtime, tz=CN_TZ).strftime("%Y-%m-%d %H:%M:%S")
datetime.fromtimestamp(latest_ts, tz=CN_TZ).strftime("%H:%M:%S")
```

`CN_TZ` 是本仓库里北京时间的单一权威（`market_time.py`），已被 `kline_sync` / `data_integrity` / `trading_day` / `json_report_store` 共用。

输出**格式**一字未改（还是 `YYYY-MM-DD HH:MM:SS` / `YYYY-MM-DD HH:MM:SS` 的裸串），只是数值变对了，前端不用改。

## 4. 兼容性

- API 字段 `latest_sync_date` 的类型和格式不变，前端零改动。
- 不落盘、不入库，只影响这一处展示字符串。
- 宿主机时区本来就是 UTC+8 的部署：行为完全不变（`fromtimestamp(ts, tz=CN_TZ)` 与 `fromtimestamp(ts)` 结果相同）。
- 其它时区的部署：显示的时间从「宿主机墙钟」变成「北京墙钟」，与页面上其它时间一致。

## 5. 性能

无影响，只是给同一个 `fromtimestamp` 加了 `tz=` 参数。

## 6. 验证结果

新增 `backend/tests/test_ext_data_latest_sync_timezone.py`（3 个用例）。用固定 epoch（`1_788_531_200` = 北京时间 2026-09-04 22:13:20）设 mtime，断言返回值等于该时刻的北京墙钟。

**修复前**（`origin/main` d0a14b5 + 仅加测试文件）：

```
$ python -m pytest tests/test_ext_data_latest_sync_timezone.py -q
E       AssertionError: assert '2026-09-04 23:13:20' == '2026-09-04 22:13:20'
E         - 2026-09-04 22:13:20
E         ?             ^
E         + 2026-09-04 23:13:20
E         ?             ^
（snapshot 与 timeseries 两条路径各一次）
2 failed, 1 passed in 9.69s
```

> 说明：我这台开发机是 UTC+9，所以偏差显示为 1 小时；在项目自己的 Docker 镜像（UTC）上同一断言会差 8 小时。这个用例的口径与已合入的 `tests/test_json_report_store_timezone.py` 一致——都是拿「北京墙钟」当契约，在宿主机时区恰为 UTC+8 的机器上修复前后都通过。

第 3 个用例（无数据时返回 `None`）修复前就通过，用来钉住空路径行为。

**修复后**：

```
$ python -m pytest tests/test_ext_data_latest_sync_timezone.py -q
...                                                                      [100%]
3 passed in 0.64s

$ python -m pytest tests -q --ignore=tests/test_watchdog.py
1901 passed, 6 skipped, 162 warnings in 90.86s (0:01:30)
```

（`tests/test_watchdog.py` 在我这台机器上未修改的 main 上也会挂住，故 `--ignore`。）

Ruff：

```
$ ruff check app/api/ext_data.py --statistics
Found 62 errors.       # 与 main 逐项一致, 未新增
$ ruff check tests/test_ext_data_latest_sync_timezone.py
All checks passed!
```

## 7. 界面证据

扩展数据卡片底部「最新」那一行的数值。在 UTC 容器上，18:30 完成的一次同步：修复前显示 `10:30:00`，修复后显示 `18:30:00`，与同页拉取面板的「上次 09-04 18:30」对上了。没有布局/样式改动，所以没附截图；需要的话我可以补一张对照图。

## 8. 风险与回滚

风险很小：改动只在两处格式化调用。UTC+8 宿主机上行为逐位不变；其它时区上是把错的改对。回滚即还原本 commit。
