### PR TITLE
fix(strategy): 叠加策略单候选子策略改用中性分, 与回测合并同口径

### DIFF
--- a/backend/app/strategy/composite.py
+++ b/backend/app/strategy/composite.py
@@ -80,7 +80,12 @@ def merge_results(
             ordered = sorted(symbols, key=lambda s: res.scores[s], reverse=True)
             count = len(ordered)
             for rank, sym in enumerate(ordered, start=1):
-                norm[sym] = 1 - (rank - 1) / max(count - 1, 1)
+                # 单候选无法排名, 必须用中性分: 当成"最优=1"会凭空抬高融合分,
+                # 而回测合并 (merge_signal_matrices 的 n <= 1 分支) 用的是中性分,
+                # 两条路径同一天同一标的会给出不同评分与排序。
+                norm[sym] = (
+                    _NEUTRAL_NORM if count <= 1 else 1 - (rank - 1) / (count - 1)
+                )
         else:
             # 子策略未产出 score: 命中即中性分, 不奖励也不惩罚。
             for row in res.rows:

--- a/backend/tests/test_composite_strategy.py
+++ b/backend/tests/test_composite_strategy.py
@@ -399,6 +399,54 @@ def test_composite_no_scores_uses_neutral(tmp_path):
     assert all(abs(s - 50.0) < 0.01 for s in merged.scores.values())  # 中性分 0.5*100
 
 
+def test_composite_single_candidate_child_matches_backtest_merge():
+    """子策略当天只选出一只票时, 选股合并与回测合并必须给出同一套评分。
+
+    单候选无法排名, 只能用中性分 0.5; 若当成"最优=1"会凭空抬高该票的融合分,
+    与 merge_signal_matrices (n <= 1 → 中性分) 分叉 —— 同一天同一标的在选股页
+    和回测里评分与排序都不一样, 正是本模块要防的口径分裂。
+    """
+    from app.backtest.matrix import make_signal_matrix
+    from app.strategy import composite as composite_mod
+    from app.strategy.engine import StrategyResult
+
+    as_of = date(2026, 1, 2)
+    child_a = StrategyResult(as_of=as_of, strategy_id="a", scores={"X": 7.0})
+    child_b = StrategyResult(
+        as_of=as_of, strategy_id="b", scores={"X": 1.0, "Y": 3.0, "Z": 2.0}
+    )
+    merged = composite_mod.merge_results(
+        [child_a, child_b], [1.0, 1.0], "union", 0, as_of=as_of, strategy_id="blend"
+    )
+
+    shape = (1, 3)  # 一个交易日, 三只标的 X/Y/Z
+
+    def _sig(entry: list[int], score: list[float]):
+        return make_signal_matrix(
+            shape,
+            entry=np.array([entry], dtype=np.uint8),
+            exit=np.zeros(shape, dtype=np.uint8),
+            score=np.array([score], dtype=np.float32),
+        )
+
+    matrix = composite_mod.merge_signal_matrices(
+        shape,
+        [_sig([1, 0, 0], [7.0, 0.0, 0.0]), _sig([1, 1, 1], [1.0, 3.0, 2.0])],
+        [("a", 1.0), ("b", 1.0)],
+        "union",
+        0,
+        max_hold=1,
+    )
+    backtest_scores = dict(zip(("X", "Y", "Z"), matrix.score[0], strict=True))
+
+    # X 只被单候选子策略 a 命中: 中性分 0.5 与 b 的最差名 0 融合 → 25 分
+    assert abs(merged.scores["X"] - 25.0) < 0.01
+    for symbol in ("X", "Y", "Z"):
+        assert abs(merged.scores[symbol] - float(backtest_scores[symbol])) < 0.01, symbol
+    # 排序也一致: Y > Z > X
+    assert merged.scores["Y"] > merged.scores["Z"] > merged.scores["X"]
+
+
 def test_composite_empty_children_returns_empty(tmp_path):
     """空子结果列表 → 返回空 StrategyResult。"""
     from app.strategy import composite as composite_mod


### PR DESCRIPTION
## 现象

一个叠加（composite）策略里，只要某个子策略当天**只选出一只票**，选股页显示的评分和同一天回测里的评分就对不上，排序也可能不一样。

举个可手算的例子：子策略 a 当天只命中 X，子策略 b 命中 X/Y/Z（内部分数 X=1、Y=3、Z=2），两个子权重都是 1，union 模式。

| 标的 | 选股 `merge_results` | 回测 `merge_signal_matrices` |
| --- | --- | --- |
| X | **50.0** | **25.0** |
| Y | 100.0 | 100.0 |
| Z | 50.0 | 50.0 |

选股里 X 和 Z 并列 50 分，回测里 Z(50) 明显高于 X(25)。`max_positions` 卡名额时，两边买进去的票就不是同一批。

## 原因

`backend/app/strategy/composite.py` `merge_results()`：

```python
ordered = sorted(symbols, key=lambda s: res.scores[s], reverse=True)
count = len(ordered)
for rank, sym in enumerate(ordered, start=1):
    norm[sym] = 1 - (rank - 1) / max(count - 1, 1)
```

`count == 1` 时 `max(count - 1, 1)` 把分母兜到 1，结果是 `1 - 0/1 = 1.0` —— **唯一候选被当成了「最优」**。

回测那条路 `merge_signal_matrices()` 用的是中性分：

```python
n = len(valid_idx)
if n <= 1:
    norm_scores[i, t, valid_idx] = _NEUTRAL_NORM   # 0.5
```

模块里 `_NEUTRAL_NORM` 的注释就写着「子策略无 score 或**单候选**(无法排名)时的占位，不污染融合结果」，`merge_results` 自己的 docstring 也写着「单候选或无 score 时用中性分」—— 代码没做到。而这个模块之所以单独存在，正是因为「选股和回测必须共享同一套口径，否则会出现『选股与回测使用不同逻辑』的金融错误(CONTRIBUTING §5.1)」。

`merge_results` 里「子策略完全没有 score」的分支已经用的是 `_NEUTRAL_NORM`，唯独单候选这一条漏了。

## 修复

`count <= 1` 时用 `_NEUTRAL_NORM`，其余照旧（此时 `count >= 2`，分母 `count - 1` 恒正，不再需要 `max(..., 1)` 兜底）。

## 复现与验证

在既有的 `backend/tests/test_composite_strategy.py` 里新增 `test_composite_single_candidate_child_matches_backtest_merge`，把上面那张表的两条路径放在一个用例里逐值对比。

**修复前（origin/main，`d0a14b5`）**

```
$ python -m pytest tests/test_composite_strategy.py -q
FAILED tests/test_composite_strategy.py::test_composite_single_candidate_child_matches_backtest_merge
1 failed, 19 passed in 24.01s
```

失败细节：

```
E  assert 25.0 < 0.01
E   +  where 25.0 = abs((50.0 - 25.0))
tests\test_composite_strategy.py:443: AssertionError
```

**修复后**

```
$ python -m pytest tests/test_composite_strategy.py -q
20 passed in 3.60s
```

两条路径 X/Y/Z 三个值逐一相等，排序都是 Y > Z > X。

**必须保持不变的部分**（同文件原有 19 条用例，修复前后都通过）：`test_composite_weighted_score_ranking`（多候选时的权重排名）、`test_composite_no_scores_uses_neutral`（无 score 用中性分 50）、union/intersect 合并、min_confirm、退出投影窗口。另外 `tests/test_composite_override.py`、`tests/test_composite_strategy_api.py`、`tests/backtest/test_composite_backtest_e2e.py` 一并跑过（合计 38 passed）。

**回归**

```
$ python -m pytest tests -q --ignore=tests/test_watchdog.py
main:  1898 passed, 6 skipped in 166.70s
本分支: 1899 passed, 6 skipped in 95.02s
```

（`tests/test_watchdog.py` 在本机 origin/main 上也会挂起，两次都用 `--ignore` 排除。）

`ruff check .`：main 与本分支同为 `Found 1583 errors`；改动文件与测试文件均 `All checks passed!`。
