### PR TITLE
fix(overview): 板块领涨股不再把 0.00% 当成缺失涨跌幅

### DIFF
--- a/backend/app/services/market_overview_builder.py
+++ b/backend/app/services/market_overview_builder.py
@@ -237,6 +237,16 @@ def _symbol_keys(row: dict, config: ExtConfig) -> list[str]:
     return keys
 
 
+def _leader_sort_key(row: dict) -> float:
+    """领涨股排序键: 缺涨跌幅的成分股排最后。
+
+    0.00% 是有效涨跌幅, 不能与"无行情"合并成同一个哨兵值 —— 板块整体下跌时
+    平盘股就是领涨股。
+    """
+    value = _finite(row.get("change_pct"))
+    return value if value is not None else float("-inf")
+
+
 def _dimension_rank(rows: list[dict], repo, kind: str, limit: int = 5, level: int | None = None) -> dict:
     if not rows:
         return {"leading": [], "lagging": []}
@@ -281,7 +291,7 @@ def _dimension_rank(rows: list[dict], repo, kind: str, limit: int = 5, level: in
         changes = [v for v in changes if v is not None]
         if not changes:
             continue
-        leader = max(stocks, key=lambda s: _finite(s.get("change_pct")) or -999)
+        leader = max(stocks, key=_leader_sort_key)
         items.append({
             "name": name,
             "count": len(stocks),

--- a/backend/tests/test_overview_dimension_leader.py
+++ b/backend/tests/test_overview_dimension_leader.py
@@ -1,0 +1,89 @@
+"""市场总览「领涨股」选取: 涨跌幅 0.00% 是有效值, 不能被当成缺失值。"""
+from __future__ import annotations
+
+import json
+
+import polars as pl
+
+from app.services.market_overview_builder import _dimension_rank
+
+
+def _fake_repo(tmp_path):
+    import types
+
+    return types.SimpleNamespace(store=types.SimpleNamespace(data_dir=tmp_path))
+
+
+def _write_concept_ext(tmp_path, mapping: dict[str, str]) -> None:
+    """写一张 snapshot 模式的概念扩展表 (symbol → 所属概念)。"""
+    cfg_dir = tmp_path / "ext_data" / "concept_tbl"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    cfg_dir.joinpath("config.json").write_text(
+        json.dumps({
+            "id": "concept_tbl",
+            "label": "概念表",
+            "mode": "snapshot",
+            "fields": [{"name": "所属概念", "dtype": "string", "label": "所属概念"}],
+        }, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    pl.DataFrame({
+        "symbol": list(mapping.keys()),
+        "所属概念": list(mapping.values()),
+    }).write_parquet(cfg_dir / "part.parquet")
+
+
+def test_flat_stock_can_be_leader_of_a_falling_concept(tmp_path):
+    """全概念下跌、最强的一只恰好平盘(0.00%)时, 领涨股必须是那只平盘股。"""
+    _write_concept_ext(tmp_path, {
+        "000001.SZ": "人工智能",
+        "000002.SZ": "人工智能",
+        "000003.SZ": "人工智能",
+    })
+    rows = [
+        {"symbol": "000001.SZ", "name": "跌一", "change_pct": -0.01, "amount": 1e8},
+        {"symbol": "000002.SZ", "name": "平盘", "change_pct": 0.0, "amount": 2e8},
+        {"symbol": "000003.SZ", "name": "跌三", "change_pct": -0.03, "amount": 3e8},
+    ]
+
+    result = _dimension_rank(rows, _fake_repo(tmp_path), "concept")
+
+    items = {item["name"]: item for item in result["lagging"]}
+    assert "人工智能" in items
+    leader = items["人工智能"]["leader"]
+    assert leader["name"] == "平盘"
+    assert leader["change_pct"] == 0.0
+
+
+def test_leader_falls_back_to_none_pct_last(tmp_path):
+    """change_pct 缺失(None)的成分股仍排在所有有值的成分股之后。"""
+    _write_concept_ext(tmp_path, {
+        "000001.SZ": "芯片",
+        "000002.SZ": "芯片",
+    })
+    rows = [
+        {"symbol": "000001.SZ", "name": "无行情", "change_pct": None, "amount": 1e8},
+        {"symbol": "000002.SZ", "name": "微跌", "change_pct": -0.02, "amount": 1e8},
+    ]
+
+    result = _dimension_rank(rows, _fake_repo(tmp_path), "concept")
+
+    items = {item["name"]: item for item in result["lagging"]}
+    assert items["芯片"]["leader"]["name"] == "微跌"
+
+
+def test_leader_still_picks_max_when_all_positive(tmp_path):
+    """普通情形不受影响: 全部上涨时仍取涨幅最大的一只。"""
+    _write_concept_ext(tmp_path, {
+        "000001.SZ": "光伏",
+        "000002.SZ": "光伏",
+    })
+    rows = [
+        {"symbol": "000001.SZ", "name": "涨多", "change_pct": 0.05, "amount": 1e8},
+        {"symbol": "000002.SZ", "name": "涨少", "change_pct": 0.01, "amount": 1e8},
+    ]
+
+    result = _dimension_rank(rows, _fake_repo(tmp_path), "concept")
+
+    items = {item["name"]: item for item in result["leading"]}
+    assert items["光伏"]["leader"]["name"] == "涨多"


### PR DESCRIPTION
## 1. 问题与复现

打开「市场总览」(或 AI 大盘复盘的「概念板块排名 / 行业板块排名」段), 某个概念/行业整体下跌、成分股里最强的一只恰好收平盘 (0.00%) 时, 「领涨」显示的是跌幅最小的那只**下跌股**, 而不是那只平盘股。

复现: 概念「人工智能」当日三只成分股 —— A −1.00%、B 0.00%、C −3.00%。
- 期望领涨: B (0.00%)
- 实际领涨: A (−1.00%)

受影响面: `GET /api/overview/market` 的 `concept_rank` / `industry_rank` 的 `leading[].leader` 与 `lagging[].leader`, 以及复用同一装配的 AI 大盘复盘 prompt (`market_recap._build_sector_block` 会把 `leader.name` 写进复盘正文)。

## 2. 根因

`backend/app/services/market_overview_builder.py` 的 `_dimension_rank`:

```python
leader = max(stocks, key=lambda s: _finite(s.get("change_pct")) or -999)
```

`or` 判的是**假值**不是 `None`。`_finite(0.0)` 返回 `0.0`, 是假值, 于是被替换成哨兵 `-999`, 排到所有下跌股之后。哨兵本意只用于 `change_pct` 缺失 (`None`) 的成分股, 但 0.00% 是有效涨跌幅, 被和「无行情」混为一谈。

同仓库的板块监控快照 `app/services/sector_monitor.py:_dimension_snapshot` 对同一件事写的是:

```python
leader = max(valid_rows, key=lambda row: row["change_pct"])
```

先过滤掉 `change_pct is None` 的行再取 `max`, 不存在这个问题 —— 两处口径本应一致。

## 3. 解决方案

新增一个显式排序键, 只把 `None` 映射到 `-inf`, 保留 0.0:

```python
def _leader_sort_key(row: dict) -> float:
    value = _finite(row.get("change_pct"))
    return value if value is not None else float("-inf")
```

只改 `_dimension_rank` 一处调用点, 不动分组、排序、字段结构。

`app/api/overview.py` 里有一份同名的历史副本 (`_dimension_rank`, 第 122 行), 但 `_build_overview` 已完全委托给 `services.market_overview_builder`, 该副本没有任何调用方 —— 本 PR 不动它, 避免把「删无用代码」夹带进 bug 修复。

## 4. 兼容性

- API 字段结构不变, 只是 `leader` 在上述边界场景下选中正确的成分股。
- 不涉及持久化、缓存键、Parquet schema 和数据源能力。
- 无前端改动 (前端直接渲染后端给的 `leader`)。

## 5. 性能

`_dimension_rank` 每次 `/api/overview/market` 未命中 5s TTL 缓存时执行一次; 改动只是把 lambda 换成同复杂度的具名函数, 无额外遍历。

## 6. 验证结果

新增 `backend/tests/test_overview_dimension_leader.py` (3 例: 平盘领涨 / `None` 排最后 / 全涨时仍取最大值)。

先在未修改的 `origin/main` 上跑, 复现失败:

```
$ python -m pytest tests/test_overview_dimension_leader.py -q
        items = {item["name"]: item for item in result["lagging"]}
        assert "人工智能" in items
        leader = items["人工智能"]["leader"]
>       assert leader["name"] == "平盘"
E       AssertionError: assert '跌一' == '平盘'
E
E         - 平盘
E         + 跌一

tests\test_overview_dimension_leader.py:54: AssertionError
=========================== short test summary info ===========================
FAILED tests/test_overview_dimension_leader.py::test_flat_stock_can_be_leader_of_a_falling_concept
1 failed, 2 passed in 0.86s
```

(同文件另外 2 例在 main 上就通过 —— 失败只来自「最强成分股恰好平盘」这一种截面。)

打上修复后:

```
$ python -m pytest tests/test_overview_dimension_leader.py -q
3 passed in 0.53s
```

相关模块定向测试 (总览/主线/轮动/扩展维度):

```
$ python -m pytest tests/test_rotation_prompt_index_pct.py tests/test_ext_preset_dimension_values.py \
    tests/test_market_mainline.py tests/test_dimension_intraday.py \
    tests/test_rps_rotation_days_cache.py tests/test_rps_rotation_map_cache.py -q
29 passed in 2.20s
```

全量 (`tests/test_watchdog.py` 在本机会挂起, 已 --ignore):

- `origin/main`: `1 failed, 1926 passed, 6 skipped in 157.46s` (唯一失败 `tests/test_mining_manager.py::test_shutdown_sets_cancel_uses_bounded_join_and_keeps_history`, 是本机既有的偶发用例 —— 在未修改的 `origin/main` 上单独连跑 3 次也有 1 次失败, 且每次挂的用例不同)
- 本分支: `1930 passed, 6 skipped in 143.11s` (= 1926 + 上面那例偶发用例这次通过 + 本 PR 新增 3 例)

Ruff (未引入新告警):

```
$ ruff check app/services/market_overview_builder.py
origin/main: Found 10 errors.   本分支: Found 10 errors.     # 均为存量
$ ruff check tests/test_overview_dimension_leader.py
All checks passed!
```

`git diff --check` 无输出。

## 7. 界面证据

改动只影响「领涨」这一个名字, 复现需要真实行情里出现「板块整体下跌 + 最强成分股恰好平盘」的截面, 本机没有可稳定构造该截面的实盘数据, 因此以单元测试替代截图 —— 测试直接断言 `_dimension_rank` 返回的 `leader`, 即前端渲染的同一个字段。

## 8. 风险与回滚

风险极低: 单函数、无状态、无持久化。行为差异只出现在「成分股最高涨跌幅 = 0.00%」这一种截面; 其余场景 `max` 结果与修复前逐位一致 (第三个测试用例即回归保护)。回滚 = revert 本 commit。
