### PR TITLE
fix(screener): 涨停梯队的时序扩展列只取最新分区, 不再放大行数

### DIFF
--- a/backend/app/api/screener.py
+++ b/backend/app/api/screener.py
@@ -933,32 +933,48 @@ def limit_ladder(
     if ext_specs:
         db = repo.store.db
         data_dir = repo.store.data_dir
+        from app.api.ext_data import _read_ext_dataframe
         from app.services.ext_data import ExtConfigStore
 
         ext_store = ExtConfigStore(data_dir)
         configs = {c.id: c for c in ext_store.load_all()}
 
+        def _dedup_ext(frame: pl.DataFrame, field: str, out_col: str) -> pl.DataFrame | None:
+            """(symbol, 字段) 两列并按 symbol 去重; 缺列时返回 None。"""
+            if frame.is_empty() or "symbol" not in frame.columns or field not in frame.columns:
+                return None
+            return (
+                frame
+                .select(["symbol", field])
+                .unique(subset=["symbol"], keep="last")
+                .rename({field: out_col})
+            )
+
         for config_id, field_name in ext_specs:
             view_name = f"ext_{config_id}"
             ext_col_name = f"{config_id}__{field_name}"
             try:
-                ext_df = pl.from_arrow(db.query(
-                    f"SELECT symbol, {quote_ident(field_name)} FROM {view_name}"
-                ).arrow())
-                if not ext_df.is_empty() and "symbol" in ext_df.columns:
-                    ext_df = ext_df.rename({field_name: ext_col_name})
-                    df = df.join(ext_df.select(["symbol", ext_col_name]), on="symbol", how="left")
+                # 扩展时序数据必须只取最新分区; 否则一个 symbol 会按历史分区数被 JOIN 放大
+                # (ext_{id} 视图覆盖 timeseries/**), 与自选股列表同口径。
+                cfg = configs.get(config_id)
+                if cfg:
+                    ext_df, _ = _read_ext_dataframe(cfg, data_dir)
+                else:
+                    ext_df = pl.from_arrow(db.query(
+                        f"SELECT symbol, {quote_ident(field_name)} FROM {view_name}"
+                    ).arrow())
+                joined = _dedup_ext(ext_df, field_name, ext_col_name)
+                if joined is not None:
+                    df = df.join(joined, on="symbol", how="left")
                     ext_col_names.append(ext_col_name)
             except Exception:
                 cfg = configs.get(config_id)
                 if cfg:
                     try:
-                        from app.api.ext_data import _parquet_glob
-                        glob = _parquet_glob(cfg, data_dir)
-                        ext_df = pl.read_parquet(glob)
-                        if not ext_df.is_empty() and "symbol" in ext_df.columns and field_name in ext_df.columns:
-                            ext_df = ext_df.select(["symbol", field_name]).rename({field_name: ext_col_name})
-                            df = df.join(ext_df, on="symbol", how="left")
+                        ext_df, _ = _read_ext_dataframe(cfg, data_dir)
+                        joined = _dedup_ext(ext_df, field_name, ext_col_name)
+                        if joined is not None:
+                            df = df.join(joined, on="symbol", how="left")
                             ext_col_names.append(ext_col_name)
                     except Exception:
                         pass

--- a/backend/tests/test_limit_ladder_ext_timeseries.py
+++ b/backend/tests/test_limit_ladder_ext_timeseries.py
@@ -1,0 +1,151 @@
+"""涨停梯队挂时序扩展列时, 一只票不能按历史分区数被 JOIN 放大。
+
+ext_{config_id} DuckDB 视图对 timeseries 模式覆盖 timeseries/**/*.parquet 全部
+分区 (见 app/api/ext_data._refresh_views), 一只票在 N 天快照里就有 N 行。
+自选股列表 (app/api/watchlist) 对同一场景先走 _read_ext_dataframe 取最新分区
+再按 symbol 去重, 梯队这边直接查视图, 于是同一只涨停股在梯队里出现 N 次、
+档位 count 被放大 N 倍。
+"""
+from __future__ import annotations
+
+import json
+from datetime import date
+from types import SimpleNamespace
+
+import polars as pl
+import pytest
+
+from app.api import screener as screener_api
+from app.services.screener import ScreenerService
+
+_AS_OF = date(2026, 9, 10)
+
+
+class _FakeQuery:
+    def __init__(self, df: pl.DataFrame) -> None:
+        self._df = df
+
+    def arrow(self):
+        return self._df.to_arrow()
+
+
+class _FakeDB:
+    """模拟 ext_{id} 视图: timeseries 模式下返回全部分区的行。"""
+
+    def __init__(self, df: pl.DataFrame) -> None:
+        self._df = df
+
+    def query(self, sql: str) -> _FakeQuery:
+        return _FakeQuery(self._df)
+
+
+class _NoDepth:
+    def get_sealed_map(self, _as_of, is_down: bool = False) -> dict:
+        return {}
+
+    def is_sealed_ready(self, _as_of) -> bool:
+        return False
+
+    def get_sealed_age(self, _as_of):
+        return None
+
+
+def _write_timeseries_ext(data_dir, partitions: dict[str, pl.DataFrame]) -> pl.DataFrame:
+    """写 timeseries 扩展表; 返回视图口径 (全部分区拼接) 的 DataFrame。"""
+    cfg_dir = data_dir / "ext_data" / "concept_ts"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    cfg_dir.joinpath("config.json").write_text(
+        json.dumps({
+            "id": "concept_ts",
+            "label": "概念时序",
+            "mode": "timeseries",
+            "fields": [{"name": "concept", "dtype": "string", "label": "概念"}],
+        }, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    for day, frame in partitions.items():
+        part = cfg_dir / "timeseries" / f"date={day}"
+        part.mkdir(parents=True, exist_ok=True)
+        frame.write_parquet(part / "part.parquet")
+    return pl.concat([partitions[d] for d in sorted(partitions)])
+
+
+def _request(data_dir, view_df: pl.DataFrame):
+    repo = SimpleNamespace(
+        store=SimpleNamespace(data_dir=data_dir, db=_FakeDB(view_df)),
+    )
+    state = SimpleNamespace(repo=repo, depth_service=_NoDepth())
+    return SimpleNamespace(app=SimpleNamespace(state=state))
+
+
+@pytest.fixture
+def _stub_enriched(monkeypatch):
+    """单只涨停股的 enriched 快照 + 空的昨日连板表。"""
+    snapshot = pl.DataFrame({
+        "symbol": ["600000.SH"],
+        "name": ["示例"],
+        "close": [11.0],
+        "change_pct": [0.1],
+        "signal_limit_up": [True],
+        "signal_limit_down": [False],
+        "signal_broken_limit_up": [False],
+        "consecutive_limit_ups": [2],
+    })
+    monkeypatch.setattr(
+        ScreenerService, "_load_enriched_for_date", lambda self, d: snapshot
+    )
+    monkeypatch.setattr(
+        ScreenerService, "load_prior_consecutive", lambda self, d, c: pl.DataFrame()
+    )
+    return snapshot
+
+
+def test_timeseries_ext_column_does_not_duplicate_ladder_rows(tmp_path, _stub_enriched):
+    view_df = _write_timeseries_ext(tmp_path, {
+        "2026-09-08": pl.DataFrame({"symbol": ["600000.SH"], "concept": ["旧概念"]}),
+        "2026-09-09": pl.DataFrame({"symbol": ["600000.SH"], "concept": ["次新概念"]}),
+        "2026-09-10": pl.DataFrame({"symbol": ["600000.SH"], "concept": ["最新概念"]}),
+    })
+
+    payload = screener_api.limit_ladder(
+        _request(tmp_path, view_df),
+        as_of=_AS_OF,
+        direction="up",
+        ext_columns="concept_ts.concept",
+    )
+
+    tiers = payload["tiers"]
+    assert len(tiers) == 1
+    stocks = tiers[0]["stocks"]
+    assert [s["symbol"] for s in stocks] == ["600000.SH"], "同一只票被历史分区放大了"
+    assert tiers[0]["count"] == 1
+    # 取最新分区的值, 不是任意一期的历史值
+    assert stocks[0]["concept_ts__concept"] == "最新概念"
+
+
+def test_snapshot_ext_column_still_joins(tmp_path, _stub_enriched):
+    """snapshot 模式扩展表照常挂列 (回归保护)。"""
+    cfg_dir = tmp_path / "ext_data" / "concept_snap"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    cfg_dir.joinpath("config.json").write_text(
+        json.dumps({
+            "id": "concept_snap",
+            "label": "概念快照",
+            "mode": "snapshot",
+            "fields": [{"name": "concept", "dtype": "string", "label": "概念"}],
+        }, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    snap = pl.DataFrame({"symbol": ["600000.SH"], "concept": ["人工智能"]})
+    snap.write_parquet(cfg_dir / "part.parquet")
+
+    payload = screener_api.limit_ladder(
+        _request(tmp_path, snap),
+        as_of=_AS_OF,
+        direction="up",
+        ext_columns="concept_snap.concept",
+    )
+
+    stocks = payload["tiers"][0]["stocks"]
+    assert len(stocks) == 1
+    assert stocks[0]["concept_snap__concept"] == "人工智能"


### PR DESCRIPTION
## 1. 问题与复现

在「涨停梯队」里挂一列**时序模式 (timeseries)** 的扩展数据 (`ext_columns=<config_id>.<field>`) 之后, 同一只涨停股在梯队里重复出现 N 次, 对应档位的 `count` 也被放大 N 倍 —— N = 这张扩展表已落盘的历史分区数。分区每天一份, 用得越久重复得越多。

复现: 扩展表 `concept_ts` 为 timeseries 模式, 有 `date=2026-09-08 / 09-09 / 09-10` 三个分区, 每个分区里 `600000.SH` 各一行。当日 `600000.SH` 二板涨停。

```
GET /api/screener/limit-ladder?direction=up&ext_columns=concept_ts.concept
→ tiers[0].count == 3, stocks 里 600000.SH 出现 3 次
```

不挂扩展列, 或扩展表是 snapshot 模式时不复现。

## 2. 根因

`backend/app/api/ext_data.py:_refresh_views` 给每张扩展表注册的视图, timeseries 模式覆盖的是**全部分区**:

```python
glob_pattern = f"{cfg_dir.as_posix()}/timeseries/**/*.parquet"
sql = f"CREATE OR REPLACE VIEW {view_name} AS SELECT * FROM read_parquet('{glob_pattern}', union_by_name=true)"
```

`backend/app/api/screener.py:limit_ladder` 直接 LEFT JOIN 这个视图, 右表里一只票有 N 行 (每个快照日一行), JOIN 后左表被扇出成 N 行:

```python
ext_df = pl.from_arrow(db.query(f"SELECT symbol, {quote_ident(field_name)} FROM {view_name}").arrow())
if not ext_df.is_empty() and "symbol" in ext_df.columns:
    ext_df = ext_df.rename({field_name: ext_col_name})
    df = df.join(ext_df.select(["symbol", ext_col_name]), on="symbol", how="left")
```

同一件事在自选股列表 `backend/app/api/watchlist.py` 里已经处理过, 代码里还留着注释:

```python
# 扩展时序数据必须只取最新分区；否则一个 symbol 会按历史分区数被 JOIN 放大。
cfg = configs.get(config_id)
if cfg:
    ext_df, _ = _read_ext_dataframe(cfg, data_dir)
...
ext_df = ext_df.select(["symbol", field_name]).unique(subset=["symbol"], keep="last")...
```

同一个文件里的策略结果扩展列 (`app/api/screener.py:_load_ext_value_maps`) 也走的是 `_read_ext_dataframe` + `unique(subset=["symbol"])`。只有梯队这一处漏了。

## 3. 解决方案

把梯队的扩展列 JOIN 改成与自选股列表同口径:

- 有配置时走 `_read_ext_dataframe(cfg, data_dir)` —— timeseries 只读最新分区, snapshot 读 `part.parquet` (这是全仓统一的「扩展表当前值」读法);
- 无配置时保留原来的视图查询兜底;
- 两条路径统一经 `_dedup_ext()` 做 `select(["symbol", field]) → unique(subset=["symbol"], keep="last") → rename`, 保证右表 symbol 唯一;
- `except` 兜底分支原本用 `_parquet_glob` 读**全部** parquet 且不去重 (同样会放大), 一并换成 `_read_ext_dataframe`, 与自选股的兜底一致。

不改梯队的档位划分、状态判定、封单叠加和排序。

## 4. 兼容性

- API 字段与结构不变; 挂扩展列时每只票仍是一行, 值取最新分区。
- snapshot 模式扩展表行为不变 (`_read_ext_dataframe` 读的还是同一个 `part.parquet`), 已加回归用例。
- 无配置但视图存在的历史场景 (视图由旧版本注册、config.json 已删) 仍走视图查询, 只是多了一层按 symbol 去重。
- 不涉及持久化、缓存键、Parquet schema。

## 5. 性能

从「DuckDB 扫全部时序分区」变成「直接读最新一个分区的 parquet」, 读取量随历史分区数下降而不是上升; 少了一次 DuckDB 查询, 多了一次 `unique`(单列去重, 全市场量级毫秒)。梯队不是实时热路径 (点击/轮询触发的单次请求)。本 PR 不作性能主张, 这里只说明不会退化。

## 6. 验证结果

新增 `backend/tests/test_limit_ladder_ext_timeseries.py`, 直接调 `screener_api.limit_ladder`, 用真实落盘的 timeseries 扩展表 + 模拟「视图返回全部分区」的假 DuckDB。

先在未修改的 `origin/main` 上跑, 复现失败:

```
$ python -m pytest tests/test_limit_ladder_ext_timeseries.py -q
        tiers = payload["tiers"]
        assert len(tiers) == 1
        stocks = tiers[0]["stocks"]
>       assert [s["symbol"] for s in stocks] == ["600000.SH"], "同一只票被历史分区放大了"
E       AssertionError: 同一只票被历史分区放大了
E       assert ['600000.SH',..., '600000.SH'] == ['600000.SH']
E
E         Left contains 2 more items, first extra item: '600000.SH'
E         Use -v to get more diff

tests\test_limit_ladder_ext_timeseries.py:120: AssertionError
=========================== short test summary info ===========================
FAILED tests/test_limit_ladder_ext_timeseries.py::test_timeseries_ext_column_does_not_duplicate_ladder_rows
1 failed, 1 passed in 1.67s
```

3 个分区 → 3 行, 与「N 个分区放大 N 倍」一致。同一个文件里的 snapshot 用例在 main 上就是通过的, 说明失败确实来自 timeseries 分区扇出。

打上修复后:

```
$ python -m pytest tests/test_limit_ladder_ext_timeseries.py -q
2 passed in 1.51s
```

相关模块定向测试 (梯队 / 筛选 / 自选扩展列 / 扩展维度):

```
$ python -m pytest tests/test_limit_ladder_one_word.py tests/test_limit_ladder_prior_trading_day.py \
    tests/test_screener_cache_api.py tests/test_screener_etf.py tests/test_screener_jit_turnover.py \
    tests/test_screener_external_access.py tests/test_screener_builtin_params.py \
    tests/test_watchlist_enriched_join.py tests/test_ext_data_dimension_members.py -q
44 passed, 2 warnings in 6.81s
```

全量 (`tests/test_watchdog.py` 在本机会挂起, 已 --ignore):

- `origin/main`: `1 failed, 1926 passed, 6 skipped in 157.46s`
- 本分支: `1 failed, 1928 passed, 6 skipped in 118.34s` (= 1926 + 本 PR 新增 2 例)

两边唯一的失败都来自 `tests/test_mining_manager.py` —— 它在本机是既有的偶发用例, 在**未修改的** `origin/main` 上单独连跑 3 次也有 1 次失败, 且每次挂的用例不同 (main 上挂 `test_shutdown_sets_cancel_...`, 本分支挂 `test_start_records_states_...`)。与本 PR 无关: 本 PR 只动 `app/api/screener.py` 的扩展列 JOIN。

Ruff (未引入新告警):

```
$ ruff check app/api/screener.py
origin/main: Found 33 errors.   本分支: Found 33 errors.     # 均为存量
$ ruff check tests/test_limit_ladder_ext_timeseries.py
All checks passed!
```

`git diff --check` 无输出。

## 7. 界面证据

可见变化是「梯队里不再出现重复行、档位家数回到真实值」。复现需要一张已积累多个日期分区的时序扩展表 + 当日有涨停票, 本机没有可用于截图的实盘扩展数据, 因此以直接调用端点的测试替代截图 —— 测试断言的 `tiers[*].count` / `tiers[*].stocks` 就是前端渲染的字段。

## 8. 风险与回滚

- 主要行为差异: 挂时序扩展列时取值从「视图里任意一期 (实际由 JOIN 顺序决定)」变成「最新分区」。这与自选股列表、策略结果扩展列已有的口径一致, 也是扩展表「当前值」的既定语义。
- `_dedup_ext` 的 `keep="last"` 与自选股一致: 同一分区内若同一 symbol 有多行, 取最后一行。
- 回滚 = revert 本 commit, 无数据迁移。
