### PR TITLE
fix(trading-day): 「未知」结论也按 TTL 缓存, 不再每拍重打探测

### DIFF
--- a/backend/app/services/trading_day.py
+++ b/backend/app/services/trading_day.py
@@ -113,9 +113,11 @@ def is_trading_day(now: datetime | None = None) -> bool | None:
         return False
 
     with _CACHE_LOCK:
+        # 「未知」(None) 也是一个结论, 同样按 TTL 缓存 —— 它正是 _TTL_UNKNOWN_S 要
+        # 挡住的场景 (未配 fuyao 且 tickflow 不可用时, 轮询每拍都会重打一次探测)。
+        # _CACHE.day 只在探测写回时设置, 因此「当天已探过」用它判定即可。
         if (
             _CACHE.day == now.date()
-            and _CACHE.verdict is not None
             and (time.monotonic() - _CACHE.probed_at) < _ttl_of(_CACHE.verdict)
         ):
             return _CACHE.verdict

--- a/backend/tests/test_trading_day.py
+++ b/backend/tests/test_trading_day.py
@@ -254,3 +254,25 @@ def test_fuyao_provider_trading_days_conversion(monkeypatch):
     monkeypatch.setattr(fp, "get_api_key", lambda: "test-key")
     days = FuyaoProvider().trading_days()
     assert days == {date(2026, 9, 4), date(2026, 9, 7)}
+
+
+def test_unknown_verdict_is_cached_within_short_ttl(monkeypatch):
+    """未知结论也要按 _TTL_UNKNOWN_S 缓存: 轮询每拍重探会重复打 tickflow 请求。"""
+    monday = datetime(2026, 9, 7, 10, 0, tzinfo=CN)
+    calls = {"fuyao": 0, "tickflow": 0}
+
+    def _fuyao(now):
+        calls["fuyao"] += 1
+        return None
+
+    def _tickflow(now):
+        calls["tickflow"] += 1
+        return None
+
+    monkeypatch.setattr(trading_day, "_probe_fuyao", _fuyao)
+    monkeypatch.setattr(trading_day, "_probe_tickflow", _tickflow)
+
+    assert is_trading_day(monday) is None
+    assert is_trading_day(monday) is None
+    assert is_trading_day(monday) is None
+    assert calls == {"fuyao": 1, "tickflow": 1}


### PR DESCRIPTION
## 1. 问题与复现

没配 fuyao、且 TickFlow 无实时行情权限 (或网络暂时不可达) 的部署上, 只要开着实时行情轮询或盘中分钟增量, 后端就会**每一拍**多打一次 `quotes.get()` 探测请求 —— 交易日探针的「未知」结论从来没被缓存住, 说好的 5 分钟 TTL 完全不生效。

复现 (纯函数, 不依赖网络):

```python
# 工作日 + 两个探测都返回 None (未知)
is_trading_day(datetime(2026, 9, 7, 10, 0, tzinfo=CN))   # → None
is_trading_day(datetime(2026, 9, 7, 10, 0, tzinfo=CN))   # → None
is_trading_day(datetime(2026, 9, 7, 10, 0, tzinfo=CN))   # → None
# 期望: 探测各执行 1 次 (TTL 内命中缓存)
# 实际: 各执行 3 次
```

用户侧表现: 白白消耗数据源限流额度、每拍多一次网络往返, 日志里探测异常反复刷屏。

## 2. 根因

`backend/app/services/trading_day.py:is_trading_day` 的缓存命中条件带了 `verdict is not None`:

```python
with _CACHE_LOCK:
    if (
        _CACHE.day == now.date()
        and _CACHE.verdict is not None
        and (time.monotonic() - _CACHE.probed_at) < _ttl_of(_CACHE.verdict)
    ):
        return _CACHE.verdict
```

而「未知」这个结论**就是** `None`。于是写回的 `None` 永远读不出来, `_ttl_of(None)` 返回的 `_TTL_UNKNOWN_S = 300.0` 是一条读不到的分支。模块 docstring 里对它的定位写得很清楚:

> 未知结论短 TTL (5 分钟) 防止轮询循环每拍重打失败的探测。

消费方都在轮询循环里逐拍调用:

- `app/services/quote_service.py:_holiday_gate` ← `_should_poll_for_phase` ← `_poll_loop` 每拍
- `app/services/minute_refresh.py:_gate_reason` ← `_loop` 每拍 (等待期内也每 `_LOOP_STEP_S` 再判一次)

未知路径上每次调用都会重跑整条探测链, 其中 `_probe_tickflow` 会真的发一次 `get_client().quotes.get(symbols=[...5 只...])`。

## 3. 解决方案

去掉多余的 `verdict is not None`。`_CACHE.day` 只在探测写回时被赋值 (`reset_cache()` 把它置回 `None`), 所以「当天已经探过」用 `_CACHE.day == now.date()` 判定就够, 不需要再借 verdict 判空:

```python
if (
    _CACHE.day == now.date()
    and (time.monotonic() - _CACHE.probed_at) < _ttl_of(_CACHE.verdict)
):
    return _CACHE.verdict
```

三档 TTL 的语义至此完整: 交易日 3600s / 确定休市 1800s / 未知 300s。

## 4. 兼容性

- 对外行为不变: 同样的输入仍然返回 True / False / None, 只是未知结论在 300s 内直接返回缓存值而不是重探。
- 周末仍然零成本直判 False (在缓存之前)。
- 误判自愈窗口不变 —— 未知结论 300s 后照常重探, 已有的 `test_unknown_verdict_retries_after_short_ttl` 就是这条, 修复后仍通过。
- 不涉及持久化、API 契约、数据源能力。

## 5. 性能

进入实时轮询热路径。修复前, 未知状态下每拍一次探测链 (含一次 `quotes.get` 网络请求); 修复后 300s 内 0 次。以默认轮询间隔计, 5 分钟窗口内的探测请求数从「窗口内的拍数」降到 1。本 PR 不附基准数据 (探测是否发生取决于用户的数据源配置), 测试直接断言探测函数的调用次数。

## 6. 验证结果

在 `backend/tests/test_trading_day.py` 已有的「TTL 缓存」一节补一例 `test_unknown_verdict_is_cached_within_short_ttl` (两个探测函数都替换成计数器)。

先在未修改的 `origin/main` 上跑, 复现失败:

```
$ python -m pytest tests/test_trading_day.py -q
        assert is_trading_day(monday) is None
        assert is_trading_day(monday) is None
        assert is_trading_day(monday) is None
>       assert calls == {"fuyao": 1, "tickflow": 1}
E       AssertionError: assert {'fuyao': 3, 'tickflow': 3} == {'fuyao': 1, 'tickflow': 1}
E
E         Differing items:
E         {'tickflow': 3} != {'tickflow': 1}
E         {'fuyao': 3} != {'fuyao': 1}
E         Use -v to get more diff

tests\test_trading_day.py:278: AssertionError
=========================== short test summary info ===========================
FAILED tests/test_trading_day.py::test_unknown_verdict_is_cached_within_short_ttl
1 failed, 15 passed in 1.16s
```

3 次调用 = 3 次探测, TTL 完全没生效。

打上修复后 (含既有的 15 例, 特别是 `test_unknown_verdict_retries_after_short_ttl` 与 `test_verdict_cached_within_ttl`):

```
$ python -m pytest tests/test_trading_day.py -q
16 passed in 0.54s
```

两个消费方及相邻模块的定向测试:

```
$ python -m pytest tests/test_realtime_mode.py tests/test_minute_refresh.py \
    tests/test_quote_interval_min.py tests/test_final_sync_confirmation.py \
    tests/test_minute_timezone_contract.py -q
45 passed in 6.26s
```

全量 (`tests/test_watchdog.py` 在本机会挂起, 已 --ignore):

- `origin/main`: `1 failed, 1926 passed, 6 skipped in 157.46s` (唯一失败 `tests/test_mining_manager.py::test_shutdown_sets_cancel_uses_bounded_join_and_keeps_history`, 是本机既有的偶发用例 —— 在未修改的 `origin/main` 上单独连跑 3 次也有 1 次失败, 且每次挂的用例不同)
- 本分支: `1928 passed, 6 skipped in 116.50s` (= 1926 + 上面那例偶发用例这次通过 + 本 PR 新增 1 例)

Ruff (未引入新告警):

```
$ ruff check app/services/trading_day.py tests/test_trading_day.py
origin/main: Found 7 errors.   本分支: Found 7 errors.     # 均为存量 (3 + 4)
```

`git diff --check` 无输出。

## 7. 界面证据

无界面变化 —— 改动只影响后台轮询线程发起的探测次数。

## 8. 风险与回滚

- 唯一的行为变化是「未知」结论现在也吃 300s TTL。极端情形: 探针原本可用但短暂失败 (如网络抖动), 修复后最多晚 300s 才拿到确定结论; 这正是 `_TTL_UNKNOWN_S` 设计时的取舍, 且未知本身是「维持现状」(继续按周几近似轮询), 不会导致漏轮询。
- 缓存 day 与写回同步设置, 首次调用 (`_CACHE.day is None`) 不会命中。
- 回滚 = revert 本 commit。
