### PR TITLE
fix(backtest): 信号回测统计里的 inf/NaN 不再让接口返回 500

### DIFF
--- a/backend/app/services/backtest.py
+++ b/backend/app/services/backtest.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import uuid
 from dataclasses import dataclass, field
 from datetime import date, timedelta
@@ -424,10 +425,16 @@ def _config_to_dict(c: BacktestConfig) -> dict:
 
 
 def _json_safe(v):
+    # 非有限浮点 (inf / NaN) 必须先于原生标量分支拦下: Starlette 的 JSONResponse 用
+    # json.dumps(allow_nan=False) 渲染, 漏一个就是整个响应 500。pf.stats() 经
+    # pandas Series.to_dict() 出来时 numpy 标量已被装箱成原生 float (全胜时
+    # Profit Factor = inf, 零波动时 Sharpe = NaN), 两条分支都要覆盖。
+    if isinstance(v, (float, np.floating)) and not math.isfinite(float(v)):
+        return None
     if isinstance(v, (int, float, str, bool)) or v is None:
         return v
     if isinstance(v, (np.floating, np.integer)):
-        return float(v) if not np.isnan(float(v)) else None
+        return float(v)
     if hasattr(v, "isoformat"):
         return v.isoformat()
     return str(v)

--- a/backend/tests/test_backtest_stats_json_safe.py
+++ b/backend/tests/test_backtest_stats_json_safe.py
@@ -1,0 +1,84 @@
+"""信号回测统计里的 inf/NaN 必须在出接口前清成 null。
+
+Starlette 的 JSONResponse 用 json.dumps(..., allow_nan=False) 渲染, 响应体里
+只要出现一个 inf/NaN, 整个 POST /api/backtest/run 直接 500
+(ValueError: Out of range float values are not JSON compliant)。
+
+vectorbt 的 pf.stats() 常态产出这类值: 全部交易都盈利时 Profit Factor = inf,
+零波动/无交易时 Sharpe 等为 NaN; pandas 的 Series.to_dict() 会把 numpy 标量
+装箱成原生 float, 所以 _json_safe 的 (int, float, str, bool) 分支会原样放行。
+"""
+from __future__ import annotations
+
+import json
+from datetime import date
+
+import numpy as np
+import pytest
+
+from app.services.backtest import _config_to_dict, _json_safe
+
+
+def _render_like_starlette(payload) -> str:
+    """与 starlette.responses.JSONResponse.render 同参数。"""
+    return json.dumps(payload, ensure_ascii=False, allow_nan=False, separators=(",", ":"))
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        float("inf"),          # Profit Factor: 没有亏损单
+        float("-inf"),
+        float("nan"),          # Sharpe / Sortino: 零波动
+        np.float64("inf"),
+        np.float64("nan"),
+    ],
+)
+def test_non_finite_values_become_null(value):
+    assert _json_safe(value) is None
+
+
+def test_stats_dict_survives_starlette_json_render():
+    """pf.stats() 形态的统计字典清洗后可被 allow_nan=False 渲染。"""
+    stats_dict = {
+        "Total Return [%]": 12.5,
+        "Profit Factor": float("inf"),   # 全胜 → gross_loss = 0
+        "Sharpe Ratio": float("nan"),
+        "Max Drawdown [%]": np.float64(3.25),
+        "Start": date(2026, 1, 2),
+    }
+
+    cleaned = {k: _json_safe(v) for k, v in stats_dict.items()}
+    rendered = json.loads(_render_like_starlette(cleaned))
+
+    assert rendered["Profit Factor"] is None
+    assert rendered["Sharpe Ratio"] is None
+    assert rendered["Total Return [%]"] == 12.5
+    assert rendered["Max Drawdown [%]"] == 3.25
+    assert rendered["Start"] == "2026-01-02"
+
+
+def test_finite_and_non_float_values_pass_through():
+    """回归保护: 有限数值/字符串/bool/None/日期的既有行为不变。"""
+    assert _json_safe(1.5) == 1.5
+    assert _json_safe(np.float64(2.5)) == 2.5
+    assert _json_safe(3) == 3
+    assert _json_safe(np.int64(4)) == 4
+    assert _json_safe("abc") == "abc"
+    assert _json_safe(True) is True
+    assert _json_safe(None) is None
+    assert _json_safe(date(2026, 1, 2)) == "2026-01-02"
+
+
+def test_config_payload_is_json_renderable():
+    """/api/backtest/run 的 config 段本身无非法浮点 (对照组)。"""
+    from app.services.backtest import BacktestConfig
+
+    cfg = BacktestConfig(
+        symbols=["600000.SH"],
+        start=date(2026, 1, 2),
+        end=date(2026, 2, 2),
+        entries=["signal_ma_golden_5_20"],
+        exits=[],
+    )
+    _render_like_starlette(_config_to_dict(cfg))


### PR DESCRIPTION
## 1. 问题与复现

跑「信号回测」(`POST /api/backtest/run`, 装了可选依赖 vectorbt 时) 遇到某些正常行情就直接 500, 页面拿不到任何结果:

```
ValueError: Out of range float values are not JSON compliant: inf
```

触发条件是统计里出现 inf / NaN, 这在 `pf.stats()` 里是常态而不是异常:

- 区间内**全部交易都盈利** → gross loss = 0 → `Profit Factor = inf`
- 零波动 / 交易数过少 → `Sharpe Ratio`、`Sortino Ratio` 等 = `NaN`

## 2. 根因

Starlette 的 `JSONResponse.render` 用的是 `allow_nan=False` (starlette 1.6.0):

```python
json.dumps(content, ensure_ascii=False, allow_nan=False, indent=None, separators=(",", ":"))
```

响应体里出现一个 inf/NaN 就整体抛 `ValueError`, 请求 500。

`backend/app/services/backtest.py` 有专门的清洗函数, 但两条分支都漏了:

```python
def _json_safe(v):
    if isinstance(v, (int, float, str, bool)) or v is None:
        return v                       # ← 原生 float 的 inf/NaN 原样放行
    if isinstance(v, (np.floating, np.integer)):
        return float(v) if not np.isnan(float(v)) else None   # ← 只挡 NaN, 不挡 inf
    ...
```

而且第二条分支对本调用点是够不着的: `stats_dict` 来自

```python
stats_series = pf.stats(silence_warnings=True)
stats_dict = stats_series.to_dict()          # 或 .mean(numeric_only=True).to_dict()
```

pandas 的 `Series.to_dict()` 会把 numpy 标量装箱成**原生** Python `float` (实测 pandas 2.x):

```
>>> pd.Series({'Profit Factor': np.float64('inf')}).to_dict()
{'Profit Factor': (<class 'float'>, inf)}
```

所以每个值都在第一条分支就被放行, 清洗整体落空。

同仓库 `backend/app/api/backtest.py` 里的同名函数把这件事写得很直白, 它服务的是优化器/步进优化路径:

```python
def _json_safe(obj):
    """递归把 nan/inf 置 None —— json.dumps(default=str) 处理不了它们, 会输出非法 JSON
    字面量 NaN/Infinity 让前端 JSON.parse 崩。..."""
    if isinstance(obj, float):
        return obj if math.isfinite(obj) else None
```

## 3. 解决方案

把「非有限」判定提到原生标量分支之前, 同时覆盖原生 `float` 与 `np.floating`:

```python
if isinstance(v, (float, np.floating)) and not math.isfinite(float(v)):
    return None
if isinstance(v, (int, float, str, bool)) or v is None:
    return v
if isinstance(v, (np.floating, np.integer)):
    return float(v)
```

其余分支 (日期 `isoformat`、兜底 `str`) 与 numpy 整数仍按原样 `float(v)`, 一律不动。

## 4. 兼容性

- 有限数值、字符串、bool、None、日期的返回值逐位不变 (已加回归用例)。
- `stats` 字段结构不变, 只是 inf/NaN 从「让接口 500」变成 `null` —— 与优化器/步进优化路径 (`app/api/backtest._json_safe`) 已有的表现一致, 前端本来就要处理 `null` 指标。
- `_persist` 落盘的是 `str(result.stats)`, 值从 `inf` 变成 `None` 只影响这份汇总 parquet 里的文本, 不影响任何读取路径。
- 不涉及 API 契约、缓存键、数据源能力。

## 5. 性能

不在实时或列表热路径; 只在一次回测结束后对 `stats` 字典做一次逐值转换, 多一次 `math.isfinite`。

## 6. 验证结果

新增 `backend/tests/test_backtest_stats_json_safe.py`。测试用 `json.dumps(..., allow_nan=False, ...)` —— 与 `starlette.responses.JSONResponse.render` 同参数 —— 把「清洗后能不能被渲染」直接测出来。

> 说明: 本机没装可选依赖 `vectorbt`, 无法端到端跑 `POST /api/backtest/run`。测试因此定位在 `_json_safe` 与真实的序列化行为上, `stats_dict` 用例按 `pf.stats()` 的实际形态构造 (原生 float 的 inf/NaN + `np.float64` + 日期)。原生 float 这一事实由 pandas 实测确认 (见上文根因)。

先在未修改的 `origin/main` 上跑, 复现失败:

```
$ python -m pytest tests/test_backtest_stats_json_safe.py -q
>       return _iterencode(o, 0)
               ^^^^^^^^^^^^^^^^^
E       ValueError: Out of range float values are not JSON compliant: inf

..\..\..\Python312\Lib\json\encoder.py:258: ValueError
=========================== short test summary info ===========================
FAILED tests/test_backtest_stats_json_safe.py::test_non_finite_values_become_null[inf0]
FAILED tests/test_backtest_stats_json_safe.py::test_non_finite_values_become_null[-inf]
FAILED tests/test_backtest_stats_json_safe.py::test_non_finite_values_become_null[nan0]
FAILED tests/test_backtest_stats_json_safe.py::test_non_finite_values_become_null[inf1]
FAILED tests/test_backtest_stats_json_safe.py::test_non_finite_values_become_null[nan1]
FAILED tests/test_backtest_stats_json_safe.py::test_stats_dict_survives_starlette_json_render
6 failed, 2 passed in 1.34s
```

最后一例抛的正是线上会看到的那条 `ValueError` —— 说明清洗后的 `stats` 直接送进 `JSONResponse` 就是 500。

打上修复后:

```
$ python -m pytest tests/test_backtest_stats_json_safe.py -q
8 passed in 0.82s
```

回测相关定向测试:

```
$ python -m pytest tests/backtest tests/test_backtest_etf.py tests/test_backtest_warmup.py \
    tests/test_backtest_stream_date_guard.py tests/test_pipeline_capacity.py -q
331 passed, 6 skipped, 64 warnings in 39.46s
```

全量 (`tests/test_watchdog.py` 在本机会挂起, 已 --ignore):

- `origin/main`: `1 failed, 1926 passed, 6 skipped in 157.46s` (唯一失败 `tests/test_mining_manager.py::test_shutdown_sets_cancel_uses_bounded_join_and_keeps_history`, 是本机既有的偶发用例 —— 在未修改的 `origin/main` 上单独连跑 3 次也有 1 次失败, 且每次挂的用例不同)
- 本分支: `1935 passed, 6 skipped in 195.42s` (= 1926 + 上面那例偶发用例这次通过 + 本 PR 新增 8 例)

Ruff (未引入新告警):

```
$ ruff check app/services/backtest.py
origin/main: Found 9 errors.   本分支: Found 9 errors.     # 均为存量
$ ruff check tests/test_backtest_stats_json_safe.py
All checks passed!
```

`git diff --check` 无输出。

## 7. 界面证据

可见变化是「原本 500 的回测现在能出结果」, 但复现需要装 vectorbt 并跑出一段全胜/零波动的行情, 本机不具备该依赖, 因此以序列化测试替代截图 (见上文说明)。

## 8. 风险与回滚

- 行为差异只发生在 inf/NaN 上: 之前是整个接口 500, 现在是该指标为 `null`。不存在「原本正确的数值被改掉」的路径 —— 回归用例覆盖了有限值/整数/字符串/bool/None/日期。
- `math` 为新增的标准库导入, 无第三方依赖变化。
- 回滚 = revert 本 commit。
