### PR TITLE
fix(market-time): 非交易日的已交易分钟数按全天算, 量比不再被折算放大

### DIFF
--- a/backend/app/market_time.py
+++ b/backend/app/market_time.py
@@ -44,6 +44,8 @@ def trading_minutes_elapsed_from_dt(dt: datetime) -> float:
     - 开盘前 = 0; 午休(11:30-13:00) = 120(保持上午累计); 收盘后 = 240。
     - 非交易日(周末) = 240 (视作全天, 避免量比被折算成 0)。
     """
+    if dt.weekday() >= 5:
+        return float(_TRADING_TOTAL_MINUTES)
     t = dt.time()
     if t < _MORNING_START:
         return 0.0

--- a/backend/tests/test_trading_minutes_elapsed.py
+++ b/backend/tests/test_trading_minutes_elapsed.py
@@ -1,0 +1,61 @@
+"""当日已交易分钟数 — 量比时间折算的分母来源。
+
+compute_enriched_today 用 `time_factor = 240 / elapsed_minutes` 把盘中的部分
+成交量折算到全天量级。周末/非交易日没有"当日已交易分钟", 必须按全天 240 算,
+否则手动刷新一次行情就会把全市场量比放大 240/已过分钟数 倍, 「放量」
+(vol_ratio_5d >= 2) 整片误触发。
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.market_time import (
+    trading_minutes_elapsed_from_dt,
+    trading_minutes_elapsed_from_ts,
+)
+
+CN = timezone(timedelta(hours=8))
+
+
+def _ms(dt: datetime) -> int:
+    return int(dt.timestamp() * 1000)
+
+
+@pytest.mark.parametrize(
+    ("moment", "label"),
+    [
+        (datetime(2026, 9, 12, 9, 31, tzinfo=CN), "周六 开盘后 1 分钟"),
+        (datetime(2026, 9, 12, 10, 0, tzinfo=CN), "周六 上午"),
+        (datetime(2026, 9, 13, 14, 0, tzinfo=CN), "周日 下午"),
+    ],
+)
+def test_weekend_counts_as_a_full_session(moment, label):
+    assert trading_minutes_elapsed_from_dt(moment) == 240.0, label
+
+
+def test_weekend_timestamp_also_counts_as_full_session():
+    """行情戳落在周末 (源侧异常戳) 时同样按全天算。"""
+    assert trading_minutes_elapsed_from_ts(_ms(datetime(2026, 9, 12, 10, 0, tzinfo=CN))) == 240.0
+
+
+@pytest.mark.parametrize(
+    ("moment", "expected", "label"),
+    [
+        (datetime(2026, 9, 11, 9, 0, tzinfo=CN), 0.0, "周五 开盘前"),
+        (datetime(2026, 9, 11, 9, 31, tzinfo=CN), 1.0, "周五 9:31"),
+        (datetime(2026, 9, 11, 11, 30, tzinfo=CN), 120.0, "周五 午休起点"),
+        (datetime(2026, 9, 11, 12, 30, tzinfo=CN), 120.0, "周五 午休中"),
+        (datetime(2026, 9, 11, 14, 0, tzinfo=CN), 180.0, "周五 14:00"),
+        (datetime(2026, 9, 11, 15, 30, tzinfo=CN), 240.0, "周五 收盘后"),
+    ],
+)
+def test_weekday_session_progress_unchanged(moment, expected, label):
+    """交易日的分段折算不受影响 (回归保护)。"""
+    assert trading_minutes_elapsed_from_dt(moment) == expected, label
+
+
+def test_missing_timestamp_still_counts_as_full_session():
+    assert trading_minutes_elapsed_from_ts(None) == 240.0
+    assert trading_minutes_elapsed_from_ts(0) == 240.0


### PR DESCRIPTION
## 1. 问题与复现

周末在行情页点「手动刷新」后, 全市场量比 (`vol_ratio_5d`) 集体虚高, 「放量」信号 (`signal_volume_surge`, 量比 ≥ 2) 整片误触发 —— 放大倍数取决于点刷新时的**时刻**:

| 北京时间 (周六/周日) | 实现返回的已交易分钟数 | 量比放大倍数 |
| --- | --- | --- |
| 9:31 | 1 | ×240 |
| 10:00 | 30 | ×8 |
| 14:00 | 60 | ×4 |
| 15:30 | 240 | ×1 (正常) |

复现 (纯函数):

```python
from app.market_time import trading_minutes_elapsed_from_dt
trading_minutes_elapsed_from_dt(datetime(2026, 9, 12, 10, 0, tzinfo=CN_TZ))  # 周六
# 期望 240.0 (文档口径), 实际 30.0
```

## 2. 根因

`backend/app/market_time.py:trading_minutes_elapsed_from_dt` 的 docstring 明确写了非交易日的口径:

```
- 开盘前 = 0; 午休(11:30-13:00) = 120(保持上午累计); 收盘后 = 240。
- 非交易日(周末) = 240 (视作全天, 避免量比被折算成 0)。
```

但函数体里只有时刻分段, 没有周几判断 —— 最后一条从来没有实现。相邻的 `trading_minutes_elapsed_from_ts` 对「戳缺失」的同类兜底 (`return 240`) 倒是实现了。

这个值是量比的时间折算分母。`app/indicators/pipeline.py:compute_enriched_today`:

```python
if elapsed_minutes and elapsed_minutes > 0:
    time_factor = 240.0 / elapsed_minutes   # 盘中折算: 部分量 → 全天量级
else:
    time_factor = 1.0
...
((pl.col("volume") * time_factor) / vol_ma5_prev).alias("vol_ratio_5d"),
```

`app/services/quote_service.py:_flush_live_enriched` 里, 优先用行情 `quote_ts` (交易日收盘戳 → 正确得到 240), **缺失时才兜底服务端时间**:

```python
if elapsed_minutes is None:
    elapsed_minutes = trading_minutes_elapsed()      # ← 走到有缺陷的分支
```

周末为什么会跑到这里: 自动轮询确实被 `_market_phase()` 挡住 (周末返回 `"closed"`), 但 `QuoteService.refresh()` (手动刷新一次行情, `POST /api/intraday/refresh`) **不过** `_should_fetch_for_phase` 门控, 直接调 `_fetch_quotes`。此时若行情源不下发 `quote_ts` (自定义源可以不带该字段), 就落到服务端时间兜底上。

## 3. 解决方案

把 docstring 已经声明的周末判定补上, 放在时刻分段之前:

```python
if dt.weekday() >= 5:
    return float(_TRADING_TOTAL_MINUTES)
```

两行, 不动任何时刻分段逻辑。

范围说明: 本仓库没有交易日历常量, 探针 `app/services/trading_day.py` 也是运行期问数据源, 是纯函数的 `market_time` 拿不到的。因此本 PR 只补齐文档已声明的**周末**这一条, 不扩到节假日 (工作日休市仍会走到时刻分段, 与修复前一致)。

## 4. 兼容性

- 交易日 (周一~周五) 的返回值逐位不变, 已加 6 个时刻的回归用例覆盖开盘前/9:31/午休起点/午休中/下午/收盘后。
- `trading_minutes_elapsed_from_ts` 通过 `_from_dt` 间接获得同一规则: 行情戳落在周末 (源侧异常戳) 时也按全天算, 与「戳缺失 → 240」的既有兜底同向。
- 不涉及 API 契约、持久化、缓存键、数据源能力。

## 5. 性能

一次 `weekday()` 调用, 每次 enriched 增量计算一次 (不是逐行)。

## 6. 验证结果

新增 `backend/tests/test_trading_minutes_elapsed.py` (该函数此前无测试)。

先在未修改的 `origin/main` 上跑, 复现失败:

```
$ python -m pytest tests/test_trading_minutes_elapsed.py -q
    def test_weekend_counts_as_a_full_session(moment, label):
>       assert trading_minutes_elapsed_from_dt(moment) == 240.0, label
E       AssertionError: 周日 下午
E       assert 180.0 == 240.0
E        +  where 180.0 = trading_minutes_elapsed_from_dt(datetime.datetime(2026, 9, 13, 14, 0, tzinfo=...timedelta(seconds=28800)))

    def test_weekend_timestamp_also_counts_as_full_session():
>       assert trading_minutes_elapsed_from_ts(_ms(datetime(2026, 9, 12, 10, 0, tzinfo=CN))) == 240.0
E       assert 30.0 == 240.0
E        +  where 30.0 = trading_minutes_elapsed_from_ts(1789178400000)

tests\test_trading_minutes_elapsed.py:40: AssertionError
=========================== short test summary info ===========================
FAILED tests/test_trading_minutes_elapsed.py::test_weekend_counts_as_a_full_session[moment0-周六 开盘后 1 分钟]
FAILED tests/test_trading_minutes_elapsed.py::test_weekend_counts_as_a_full_session[moment1-周六 上午]
FAILED tests/test_trading_minutes_elapsed.py::test_weekend_counts_as_a_full_session[moment2-周日 下午]
FAILED tests/test_trading_minutes_elapsed.py::test_weekend_timestamp_also_counts_as_full_session
4 failed, 7 passed in 0.15s
```

(同文件里 7 个交易日/戳缺失用例在 main 上就通过, 说明失败只来自周末这一条。)

打上修复后:

```
$ python -m pytest tests/test_trading_minutes_elapsed.py -q
11 passed in 0.06s
```

消费方与时区相关的定向测试:

```
$ python -m pytest tests/test_realtime_turnover_rate.py tests/test_realtime_mode.py \
    tests/test_kline_sync_timezone.py tests/test_minute_timezone_contract.py \
    tests/test_trading_day.py tests/test_quote_index_merge.py \
    tests/test_live_enriched_metadata.py tests/test_realtime_enriched_resume.py \
    tests/test_pipeline_and_monitor_fixes.py -q
53 passed, 3 warnings in 3.32s
```

全量 (`tests/test_watchdog.py` 在本机会挂起, 已 --ignore):

- `origin/main`: `1 failed, 1926 passed, 6 skipped in 157.46s`
- 本分支: `2 failed, 1936 passed, 6 skipped in 122.81s` (= 1926 + 本 PR 新增 11 例)

两边的失败全部来自 `tests/test_mining_manager.py` —— 它在本机是既有的偶发用例, 在**未修改的** `origin/main` 上单独连跑 3 次也有 1 次失败, 且每次挂的用例都不同 (main 全量挂 `test_shutdown_sets_cancel_...`, 本分支全量挂 `test_cancel_while_waiting_for_capacity_...` 与 `test_cancel_running_job_wins_over_worker_success`, main 单跑挂 `test_start_records_states_...`)。都是取消/超时的时序用例, 与本 PR 无关: 本 PR 只动 `app/market_time.py` 的一个周几判断。

Ruff (未引入新告警):

```
$ ruff check app/market_time.py
origin/main: Found 1 error.   本分支: Found 1 error.     # 存量
$ ruff check tests/test_trading_minutes_elapsed.py
All checks passed!
```

`git diff --check` 无输出。

## 7. 界面证据

可见变化是周末手动刷新后行情列表的「量比」列与「放量」标记, 复现需要一个不下发 `quote_ts` 的行情源 + 周末现场, 本机没有可用于截图的实盘环境, 因此以单元测试替代截图 —— 测试断言的正是 `compute_enriched_today` 拿到的那个 `elapsed_minutes`。

## 8. 风险与回滚

- 行为差异只出现在 `dt.weekday() >= 5` 时, 交易日路径逐位不变。
- 周末走到该函数时本就没有「当日已交易分钟」可言, 返回 240 等于「不折算」, 与 `elapsed_minutes` 为 0/None 时的 `time_factor = 1.0` 同向, 不会把量比压成 0 也不会放大。
- 节假日 (工作日休市) 不在本次范围内, 仍与修复前一致 —— 这是已知遗留, 需要交易日历才能收口。
- 回滚 = revert 本 commit。
