### PR TITLE
fix(ext-data): rows 的 date 入参先校验再拼分区路径

### DIFF
--- a/backend/app/api/ext_data.py
+++ b/backend/app/api/ext_data.py
@@ -204,6 +204,20 @@ def _safe_json_value(value):
     return value
 
 
+def _partition_date(raw: str) -> str:
+    """把 `date` 入参规范成 `YYYY-MM-DD` 分区名。
+
+    这个值直接拼进分区目录名 (`timeseries/date=<value>`), 所以非法值不只是格式问题:
+    `date=x/../../../../kline_daily` 会让读取路径离开 `ext_data/<id>/timeseries/`。
+    同一文件的 `/sync`、`/ingest`、`/backfill` 都先 `date.fromisoformat` 再用, 只有
+    `/rows` 和 `/dimension-members` 走的这条路把原始字符串直接拼进了路径。
+    """
+    try:
+        return date.fromisoformat(raw).isoformat()
+    except ValueError as e:
+        raise HTTPException(400, f"日期格式错误: {raw}") from e
+
+
 def _read_ext_dataframe(
     config: ExtConfig,
     data_dir: Path,
@@ -222,10 +236,11 @@ def _read_ext_dataframe(
         return pl.DataFrame(), None
 
     if snapshot_date:
-        path = base / f"date={snapshot_date}" / "part.parquet"
+        day = _partition_date(snapshot_date)
+        path = base / f"date={day}" / "part.parquet"
         if not path.exists():
-            return pl.DataFrame(), snapshot_date
-        return pl.read_parquet(path), snapshot_date
+            return pl.DataFrame(), day
+        return pl.read_parquet(path), day
 
     partitions = sorted(
         d for d in base.iterdir()

--- a/backend/tests/test_ext_data_rows_date_guard.py
+++ b/backend/tests/test_ext_data_rows_date_guard.py
@@ -1,0 +1,92 @@
+"""`/rows`、`/dimension-members` 的 date 入参校验 — 非法日期返回 400 而不是拼进路径。
+
+`_read_ext_dataframe` 用 `date=<入参>` 拼出时序分区目录名。同一文件的 `/sync`、
+`/ingest`、`/backfill` 都先 `date.fromisoformat` 再用, 只有这条读取路径把原始
+字符串直接拼进 `Path`, 于是 `date=x/../../../../kline_daily` 读到的是配置目录
+之外的 `part.parquet`。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+from fastapi import HTTPException
+
+from app.api.ext_data import _read_ext_dataframe
+from app.services.ext_data import ExtConfig, ExtField
+
+
+def _cfg() -> ExtConfig:
+    return ExtConfig(
+        id="hot",
+        label="人气",
+        mode="timeseries",
+        fields=[ExtField("symbol", "string"), ExtField("heat", "float")],
+    )
+
+
+def _layout(tmp_path: Path) -> Path:
+    """建出真实目录形状: data/ext_data/hot/timeseries/ 和它外面的一份 parquet。"""
+    data_dir = tmp_path / "data"
+    partition = data_dir / "ext_data" / "hot" / "timeseries" / "date=2026-09-11"
+    partition.mkdir(parents=True)
+    pl.DataFrame({"symbol": ["000001.SZ"], "heat": [1.0]}).write_parquet(
+        partition / "part.parquet"
+    )
+
+    outside = data_dir / "kline_daily"
+    outside.mkdir(parents=True)
+    pl.DataFrame({"symbol": ["不该被读到"], "heat": [9.9]}).write_parquet(
+        outside / "part.parquet"
+    )
+    return data_dir
+
+
+def test_rows_date_does_not_leave_the_config_directory(tmp_path: Path) -> None:
+    data_dir = _layout(tmp_path)
+
+    with pytest.raises(HTTPException) as excinfo:
+        _read_ext_dataframe(_cfg(), data_dir, "x/../../../../kline_daily")
+
+    assert excinfo.value.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["not-a-date", "2026-13-01", "2026/09/11", "../../../../kline_daily"],
+)
+def test_rows_rejects_a_date_that_is_not_a_date(tmp_path: Path, bad: str) -> None:
+    data_dir = _layout(tmp_path)
+
+    with pytest.raises(HTTPException) as excinfo:
+        _read_ext_dataframe(_cfg(), data_dir, bad)
+
+    assert excinfo.value.status_code == 400
+
+
+def test_rows_still_reads_the_named_partition(tmp_path: Path) -> None:
+    data_dir = _layout(tmp_path)
+
+    df, active = _read_ext_dataframe(_cfg(), data_dir, "2026-09-11")
+
+    assert active == "2026-09-11"
+    assert df.get_column("symbol").to_list() == ["000001.SZ"]
+
+
+def test_rows_returns_empty_for_a_valid_date_with_no_partition(tmp_path: Path) -> None:
+    data_dir = _layout(tmp_path)
+
+    df, active = _read_ext_dataframe(_cfg(), data_dir, "2026-01-02")
+
+    assert active == "2026-01-02"
+    assert df.is_empty()
+
+
+def test_rows_without_a_date_still_picks_the_latest_partition(tmp_path: Path) -> None:
+    data_dir = _layout(tmp_path)
+
+    df, active = _read_ext_dataframe(_cfg(), data_dir, None)
+
+    assert active == "2026-09-11"
+    assert df.get_column("symbol").to_list() == ["000001.SZ"]


### PR DESCRIPTION
## 现象

`GET /api/ext-data/{id}/rows?date=...` 的 `date` 入参会被原样拼进分区目录名，所以带 `..` 的值能把读取路径带出 `data/ext_data/{id}/timeseries/`，读到配置目录之外的 `part.parquet` 并从接口返回。

在临时目录里按真实形状建两份文件（分区里一份、`data/kline_daily/` 一份），当前 `main`：

```
date='2026-09-11'                -> active='2026-09-11'                rows=[{'symbol': '000001.SZ', 'heat': 1.0}]
date='x/../../../../kline_daily' -> active='x/../../../../kline_daily' rows=[{'symbol': 'OUTSIDE-ext_data', 'heat': 9.9}]
```

第二行读到的是 `data/kline_daily/part.parquet`。

## 原因

`app/api/ext_data.py` 的 `_read_ext_dataframe`：

```python
if snapshot_date:
    path = base / f"date={snapshot_date}" / "part.parquet"
```

`snapshot_date` 来自 `Query(None, alias="date")`，是未经校验的字符串；`Path` 会把里面的 `/` 当成路径分隔符，`..` 由系统在解析时消掉：

```python
base = Path("data/ext_data/hot/timeseries")

base / "date=2026-09-11"              / "part.parquet"  # data/ext_data/hot/timeseries/date=2026-09-11/part.parquet
base / "date=x/../../../../kline_daily" / "part.parquet"  # data/kline_daily/part.parquet
```

这是**同一个文件里的口径不一致**，不是遗漏了一个新规则：`/sync`（797 行）、`/ingest`（829 行）、`/backfill`（997 行）都先 `date.fromisoformat` 再用，只有 `/rows` 和 `/dimension-members` 走的这条读取路径把原始字符串直接拼进了 `Path`。`list_rows` 的 docstring 本身写的也是 `date=YYYY-MM-DD`，只是没人执行这句话。

`backend/tests/test_backtest_stream_date_guard.py` 已经为回测 SSE 端点立过同样的规矩（非法日期返回 400 而不是 500），这里补齐的是同一条。

## 改动

`_read_ext_dataframe` 拼路径前先过 `_partition_date`，把入参规范成 `YYYY-MM-DD`；非法值按本文件既有约定抛 `HTTPException(400, "日期格式错误: ...")`。

放在 `_read_ext_dataframe` 而不是两个端点里，是因为 `/rows` 和 `/dimension-members` 共用这一条读取路径，以后新增的调用方也自动被挡住。返回的 `active_date` 同时变成规范化后的值，保证响应里的日期和实际读的分区名一致。

不变的部分：合法日期读到的分区、分区不存在时返回空表、不传 `date` 时取最新分区 —— 三条都有测试钉住。

## 验证

`backend/tests/test_ext_data_rows_date_guard.py`。只应用本 PR 的测试、`app/api/ext_data.py` 保持 `main`：

```
$ pytest tests/test_ext_data_rows_date_guard.py -q
FAILED test_rows_date_does_not_leave_the_config_directory
FAILED test_rows_rejects_a_date_that_is_not_a_date[not-a-date]
FAILED test_rows_rejects_a_date_that_is_not_a_date[2026-13-01]
FAILED test_rows_rejects_a_date_that_is_not_a_date[2026/09/11]
FAILED test_rows_rejects_a_date_that_is_not_a_date[../../../../kline_daily]
5 failed, 3 passed in 0.83s
```

先通过的 3 条是故意的 —— 它们钉的是「合法输入的行为一个字都不能变」，改动前后都必须绿。

应用改动后：

```
$ pytest tests/test_ext_data_rows_date_guard.py -q
8 passed in 0.91s

$ pytest tests/ -q -k "ext_data or ext_pull or rows"
67 passed, 1877 deselected in 7.90s
```

`ruff check` 在新测试文件上干净；`app/api/ext_data.py` 改动前后同为 62 条既有告警，没有新增。

环境：Windows 11 / Python 3.12。
