### PR TITLE
feat(ai): 给 LLM 加工具调用 — 工具目录 + 策略生成回测闭环

### DIFF
--- a/backend/app/api/strategy.py
+++ b/backend/app/api/strategy.py
@@ -16,7 +16,7 @@ from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.backtest.minute_trigger import MINUTE_EXIT_TRIGGER_SIGNALS
 from app.strategy import config as strategy_config
@@ -256,6 +256,16 @@ class SaveConfigRequest(BaseModel):
 
 class AIGenerateRequest(BaseModel):
     prompt: str
+
+
+class AIIterateRequest(BaseModel):
+    """AI 迭代请求 — 与 BuildRequest step1 同构, 复用 build_step1 拼 prompt"""
+    name: str = ""
+    description: str = ""
+    direction: str = "long"
+    rules: str = ""
+    execution_backend: Literal["polars_expr", "matrix_native"] = "polars_expr"
+    max_rounds: int = Field(default=4, ge=1, le=10)
 
 
 class AISaveRequest(BaseModel):
@@ -939,6 +949,35 @@ async def ai_generate(req: AIGenerateRequest, request: Request):
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"AI生成失败: {e}") from e
+    return result
+
+
+@router.post("/ai/iterate")
+async def ai_iterate(req: AIIterateRequest, request: Request):
+    """生成→回测→诊断→修改 的有界闭环 (只读回测, 产物为 ai_ 草稿, 不自动上线)。"""
+    from app.services.ai_provider import is_codex_cli_provider
+    from app.strategy.ai_iterator import AIStrategyIterator
+
+    # Codex CLI 无 tools= 协议, 迭代能力边界在入口 fail-closed (不静默降级为纯文本)。
+    if is_codex_cli_provider():
+        raise HTTPException(
+            status_code=400,
+            detail="当前 AI 供应商不支持工具调用迭代, 请改用 OpenAI 兼容模型",
+        )
+
+    engine = _get_engine(request)
+    data_dir = _data_dir(request)
+    try:
+        prompt = build_step1(
+            req.name, req.description, req.direction, req.rules,
+            strategy_id="", execution_backend=req.execution_backend,
+        )
+        iterator = AIStrategyIterator(max_rounds=req.max_rounds)
+        result = await iterator.iterate(prompt, engine=engine, data_dir=str(data_dir))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"AI迭代失败: {e}") from e
     return result
 
 

--- a/backend/app/api/strategy.py
+++ b/backend/app/api/strategy.py
@@ -976,8 +976,10 @@ async def ai_iterate(req: AIIterateRequest, request: Request):
         result = await iterator.iterate(prompt, engine=engine, data_dir=str(data_dir))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"AI迭代失败: {e}") from e
+    except Exception:
+        # 内部异常详情只进日志, 不透给客户端 (§8)
+        logger.exception("AI 迭代失败")
+        raise HTTPException(status_code=500, detail="AI 迭代失败, 请稍后重试")
     return result
 
 

--- a/backend/app/services/ai_provider.py
+++ b/backend/app/services/ai_provider.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import re
 import shutil
@@ -320,6 +321,97 @@ async def generate_ai_text(
     )
 
 
+async def generate_ai_text_with_tools(
+    messages: Sequence[Message],
+    tools: Sequence[dict],
+    *,
+    execute_tool,
+    temperature: float | None = 0.3,
+    max_tokens: int | None = 3000,
+    timeout: float = 180.0,
+    max_rounds: int = 4,
+) -> list[dict]:
+    """OpenAI 原生 tools 有界循环: 调用 → 逐条执行工具 → role:tool 回填 → 循环。
+
+    与 generate_ai_text 的差异: 这里返回「完整 messages」(含 tool 往返), 最后一条
+    assistant 消息承载最终文本; 调用方可扫描 role:tool 消息重建逐轮证据 (回测指标)。
+    execute_tool 为 async (name, args) -> dict, 返回 {"ok": bool, "result"|"error"},
+    由调用方注入 (见 services.tool_catalog.execute_tool)。tools 是硬能力依赖
+    (Codex CLI 无 tools= 协议), 故入口 fail-closed, 不做纯文本降级。
+    """
+    if is_codex_cli_provider():
+        raise RuntimeError("当前 AI 供应商不支持工具调用迭代, 请改用 OpenAI 兼容模型")
+
+    max_tokens = _resolve_max_tokens(max_tokens)
+    if not tools:
+        raise ValueError("generate_ai_text_with_tools 需要至少一个工具 schema")
+
+    req_messages: list[dict] = [dict(m) for m in messages]
+    tool_schemas = list(tools)
+
+    for _ in range(max_rounds):
+        _check_input_budget(req_messages, max_tokens=max_tokens)
+        message = await _run_openai_message_once(
+            req_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            timeout=timeout,
+            tools=tool_schemas,
+        )
+        if message is None:
+            return req_messages
+
+        tool_calls = getattr(message, "tool_calls", None) or []
+        if not tool_calls:
+            # 模型不再请求工具, 产出最终文本, 结束循环。
+            req_messages.append({"role": "assistant", "content": message.content or ""})
+            return req_messages
+
+        assistant = {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": tc.id,
+                    "type": getattr(tc, "type", "function"),
+                    "function": {
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    },
+                }
+                for tc in tool_calls
+            ],
+        }
+        if message.content:
+            assistant["content"] = message.content
+        req_messages.append(assistant)
+
+        for tc in tool_calls:
+            tool_result = await execute_tool(
+                tc.function.name,
+                _parse_tool_arguments(tc.function.arguments),
+            )
+            req_messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tc.id,
+                    "content": json.dumps(tool_result, ensure_ascii=False),
+                }
+            )
+
+    return req_messages
+
+
+def _parse_tool_arguments(raw: str) -> dict:
+    """把 tool call 的 arguments JSON 字符串解析为 dict, 解析失败返回空 dict。"""
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
 async def stream_ai_text(
     messages: Sequence[Message],
     *,
@@ -359,6 +451,30 @@ async def _run_openai_once(
     max_tokens: int | None,
     timeout: float,
 ) -> str:
+    message = await _run_openai_message_once(
+        messages,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        timeout=timeout,
+    )
+    if message is None:
+        return ""
+    return (message.content or "").strip()
+
+
+async def _run_openai_message_once(
+    messages: Sequence[Message],
+    *,
+    temperature: float | None,
+    max_tokens: int | None,
+    timeout: float,
+    tools: Sequence[dict] | None = None,
+):
+    """一次 OpenAI create() 调用, 返回完整 message (含 tool_calls, 而非仅 content)。
+
+    _run_openai_once 只取 .content; 工具循环需要 .tool_calls 以回填 role:tool,
+    故在此返回完整消息对象。tools 非空时以 tools= 透传, 否则走纯文本路径。
+    """
     ai_key = secrets_store.get_ai_key()
     if not ai_key:
         raise RuntimeError("AI API Key 未配置, 请在设置页配置")
@@ -366,7 +482,7 @@ async def _run_openai_once(
     client = _openai_client(ai_key, timeout)
     model = current_ai_model()
     req_messages = list(messages)
-    kwargs = _openai_kwargs(temperature=temperature, max_tokens=max_tokens)
+    kwargs = _openai_kwargs(temperature=temperature, max_tokens=max_tokens, tools=tools)
     while True:
         try:
             resp = await client.chat.completions.create(
@@ -384,8 +500,8 @@ async def _run_openai_once(
                 raise RuntimeError(_format_openai_error(exc)) from exc
             raise
     if not resp.choices:
-        return ""
-    return (resp.choices[0].message.content or "").strip()
+        return None
+    return resp.choices[0].message
 
 
 async def _stream_openai(
@@ -574,6 +690,7 @@ def _openai_kwargs(
     model: str = "",
     base_url: str = "",
     prefer_final_answer: bool = False,
+    tools: Sequence[dict] | None = None,
 ) -> dict:
     """Build OpenAI create() kwargs and map supported provider capabilities.
 
@@ -598,6 +715,8 @@ def _openai_kwargs(
         # hidden reasoning shares max_tokens with the final answer and can
         # exhaust the budget before any visible content is emitted.
         kwargs["extra_body"] = {"thinking": {"type": "disabled"}}
+    if tools:
+        kwargs["tools"] = list(tools)
     return kwargs
 
 

--- a/backend/app/services/tool_catalog.py
+++ b/backend/app/services/tool_catalog.py
@@ -1,0 +1,285 @@
+"""工具目录 — 把因子 / 数据源 / 策略元数据统一序列化为 OpenAI tools 格式。
+
+让 LLM 通过工具按需检索目录 (而非把全部因子塞进 system prompt 撑爆上下文);
+run_backtest 复用现有 StrategyBacktestConfig + worker, 只读、受控窗口, 只回传
+精简 stats 关键键 (不把 equity_curve / trades 塞给 LLM)。
+
+设计边界:
+  - 本模块只做「序列化 + 分发」, 不持有策略引擎 / 数据目录单例, 依赖由调用方注入。
+  - run_backtest 是重任务 (子进程), 由 execute_tool 用 asyncio.to_thread 挪出事件循环。
+  - Codex CLI 无 tools= 协议, 相关门控在 api 层入口 fail-closed, 不在本模块降级。
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+# 工具名常量 (与 build_tool_schemas 里 function.name 一一对应)
+LIST_FACTORS = "list_factors"
+LIST_STRATEGIES = "list_strategies"
+LIST_DATA_CAPABILITIES = "list_data_capabilities"
+RUN_BACKTEST = "run_backtest"
+
+# run_backtest 回传给 LLM 的 stats 键白名单 (控制 token, 不塞曲线/成交明细)
+_BACKTEST_STATS_KEYS: frozenset[str] = frozenset({
+    "total_return",
+    "annual_return",
+    "max_drawdown",
+    "sharpe",
+    "sortino",
+    "calmar",
+    "win_rate",
+    "profit_factor",
+    "n_trades",
+    "avg_pnl",
+})
+
+# 回测默认窗口 (对齐 api/backtest.py 的 FACTOR_DEFAULT_DAYS, 受控窗口防超大区间)
+_DEFAULT_BACKTEST_DAYS = 180
+
+
+def _function_schema(name: str, description: str, parameters: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": parameters,
+        },
+    }
+
+
+def build_tool_schemas() -> list[dict[str, Any]]:
+    """组装 4 个工具的 OpenAI tools 格式 JSON Schema (纯静态, 无运行时状态)。"""
+    return [
+        _function_schema(
+            LIST_FACTORS,
+            "检索可用因子目录 (约 100 个)。返回因子 id、中文名、分组、公式说明、"
+            "依赖列与适用资产, 用于挑选合法的评分字段与信号依赖。可按 asset_type "
+            "(stock/etf) 过滤, stable_only=true 时只返回稳定因子。",
+            {
+                "type": "object",
+                "properties": {
+                    "asset_type": {
+                        "type": "string",
+                        "enum": ["stock", "etf"],
+                        "description": "按适用资产过滤; 缺省返回全部",
+                    },
+                    "stable_only": {
+                        "type": "boolean",
+                        "description": "只返回稳定因子 (排除实验/废弃)",
+                    },
+                },
+                "required": [],
+            },
+        ),
+        _function_schema(
+            LIST_STRATEGIES,
+            "检索已加载的策略目录 (含 research_only 研究模板)。返回策略 id、名称、"
+            "描述、标签、适用资产/周期、可调参数与执行后端, 用于参考已有策略或路由。",
+            {
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+        _function_schema(
+            LIST_DATA_CAPABILITIES,
+            "检索可用的数据源能力目录 (日K/除权/实时/分钟/五档/财务/全量分钟等)。"
+            "返回能力 id、中文名、说明与 TickFlow 档位要求, 用于判断可用数据范围。",
+            {
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+        _function_schema(
+            RUN_BACKTEST,
+            "对已保存到 data/strategies/ 的策略 (含 ai_ 草稿) 跑一次全量回测, "
+            "返回夏普/回撤/胜率/盈亏比等精简指标。只读操作, 不修改任何策略文件。",
+            {
+                "type": "object",
+                "properties": {
+                    "strategy_id": {
+                        "type": "string",
+                        "description": "要回测的策略 id",
+                    },
+                    "params": {
+                        "type": "object",
+                        "description": "可选的参数覆盖 (键为参数 id, 值为数值/布尔)",
+                    },
+                    "start": {
+                        "type": "string",
+                        "description": "开始日期 YYYY-MM-DD; 缺省=最近 180 天",
+                    },
+                    "end": {
+                        "type": "string",
+                        "description": "结束日期 YYYY-MM-DD; 缺省=今天",
+                    },
+                    "asset_type": {
+                        "type": "string",
+                        "enum": ["stock", "etf"],
+                        "description": "资产类型; 缺省 stock",
+                    },
+                },
+                "required": ["strategy_id"],
+            },
+        ),
+    ]
+
+
+def list_factors(asset_type: str | None = None, stable_only: bool = False) -> dict[str, Any]:
+    """序列化因子目录: factors/registry.py 的 FactorSpec → 精简 dict 列表。"""
+    from app.factors.registry import all_factors
+
+    factors = [
+        {
+            "id": spec.id,
+            "label": spec.label,
+            "group": spec.group,
+            "formula_text": spec.formula_text,
+            "kind": spec.kind,
+            "dependencies": sorted(spec.dependencies),
+            "asset_types": sorted(spec.asset_types),
+            "stability": spec.stability,
+            "pit": spec.pit,
+        }
+        for spec in all_factors(asset_type=asset_type, stable_only=stable_only)
+    ]
+    return {"factors": factors}
+
+
+def list_strategies(engine) -> dict[str, Any]:
+    """序列化策略目录: StrategyEngine.list_strategies(include_research=True) 精简视图。"""
+    strategies = []
+    for meta in engine.list_strategies(include_research=True):
+        strategies.append({
+            "id": meta.get("id"),
+            "name": meta.get("name", ""),
+            "description": meta.get("description", ""),
+            "tags": meta.get("tags", []),
+            "asset_types": meta.get("asset_types", ["stock"]),
+            "timeframes": meta.get("timeframes", ["1d"]),
+            "execution_backend": meta.get("execution_backend"),
+            "source": meta.get("source"),
+            "params": [
+                {
+                    "id": p.get("id"),
+                    "label": p.get("label", ""),
+                    "type": p.get("type", ""),
+                    "default": p.get("default"),
+                }
+                for p in meta.get("params", [])
+            ],
+        })
+    return {"strategies": strategies}
+
+
+def list_data_capabilities() -> dict[str, Any]:
+    """序列化数据源能力目录: capabilities.py 的 CAPABILITY_REGISTRY 精简视图。"""
+    from app.data_providers.capabilities import CAPABILITY_REGISTRY
+
+    capabilities = [
+        {
+            "id": cap["id"],
+            "label": cap["label"],
+            "desc": cap["desc"],
+            "tf_tier": cap["tf_tier"],
+        }
+        for cap in CAPABILITY_REGISTRY
+    ]
+    return {"capabilities": capabilities}
+
+
+def run_backtest(
+    data_dir: str | Path,
+    *,
+    strategy_id: str,
+    params: dict[str, Any] | None = None,
+    start: str | None = None,
+    end: str | None = None,
+    asset_type: str = "stock",
+) -> dict[str, Any]:
+    """回测工具桥: 复用 StrategyBacktestConfig + make_worker_task/run_worker_task。
+
+    同步阻塞 (spawn 子进程), 由 execute_tool 用 asyncio.to_thread 调用。
+    返回 {"strategy_id", "start", "end", "stats": 精简白名单键}。
+    """
+    from app.backtest.strategy import StrategyBacktestConfig
+    from app.backtest.worker import make_worker_task, run_worker_task
+
+    end_date = date.fromisoformat(end) if end else date.today()
+    start_date = (
+        date.fromisoformat(start) if start else end_date - timedelta(days=_DEFAULT_BACKTEST_DAYS)
+    )
+
+    cfg = StrategyBacktestConfig(
+        strategy_id=strategy_id,
+        symbols=None,
+        start=start_date,
+        end=end_date,
+        params=params,
+        asset_type=asset_type,
+        # 其余成本/撮合口径走默认 (与 api/backtest.py 的 /strategy/run 默认一致)
+    )
+    task = make_worker_task("backtest", Path(data_dir), cfg)
+    result = run_worker_task(task)
+
+    error = result.get("error")
+    if error:
+        raise ValueError(f"回测失败: {error}")
+    stats = result.get("stats") or {}
+    return {
+        "strategy_id": strategy_id,
+        "start": str(start_date),
+        "end": str(end_date),
+        "stats": {key: stats[key] for key in _BACKTEST_STATS_KEYS if key in stats},
+    }
+
+
+async def execute_tool(
+    name: str,
+    args: dict[str, Any],
+    *,
+    engine=None,
+    data_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    """按 name 分发执行, 返回 {"ok": bool, "result": ... | "error": str}。
+
+    engine / data_dir 由 api 层注入 (request.app.state); list_factors /
+    list_data_capabilities 不需要二者, 传 None 亦可。
+    """
+    try:
+        if name == LIST_FACTORS:
+            result = list_factors(
+                asset_type=args.get("asset_type"),
+                stable_only=bool(args.get("stable_only", False)),
+            )
+        elif name == LIST_STRATEGIES:
+            if engine is None:
+                return {"ok": False, "error": "策略引擎未注入"}
+            result = list_strategies(engine)
+        elif name == LIST_DATA_CAPABILITIES:
+            result = list_data_capabilities()
+        elif name == RUN_BACKTEST:
+            if data_dir is None:
+                return {"ok": False, "error": "数据目录未注入"}
+            strategy_id = str(args.get("strategy_id") or "").strip()
+            if not strategy_id:
+                return {"ok": False, "error": "run_backtest 缺少 strategy_id"}
+            result = await asyncio.to_thread(
+                run_backtest,
+                data_dir,
+                strategy_id=strategy_id,
+                params=args.get("params"),
+                start=args.get("start"),
+                end=args.get("end"),
+                asset_type=args.get("asset_type") or "stock",
+            )
+        else:
+            return {"ok": False, "error": f"未知工具: {name}"}
+        return {"ok": True, "result": result}
+    except Exception as exc:  # noqa: BLE001 — 工具执行错误统一回填给 LLM, 不打断循环
+        return {"ok": False, "error": str(exc) or type(exc).__name__}

--- a/backend/app/services/tool_catalog.py
+++ b/backend/app/services/tool_catalog.py
@@ -209,6 +209,7 @@ def run_backtest(
     """
     from app.backtest.strategy import StrategyBacktestConfig
     from app.backtest.worker import make_worker_task, run_worker_task
+    from app.services.heavy_job_limiter import shared_heavy_job_limiter
 
     end_date = date.fromisoformat(end) if end else date.today()
     start_date = (
@@ -224,8 +225,10 @@ def run_backtest(
         asset_type=asset_type,
         # 其余成本/撮合口径走默认 (与 api/backtest.py 的 /strategy/run 默认一致)
     )
-    task = make_worker_task("backtest", Path(data_dir), cfg)
-    result = run_worker_task(task)
+    # 与其它重回测端点一致: 走共享重任务限流 (容量 2), 防并发迭代/手动回测叠加挤爆内存
+    with shared_heavy_job_limiter.slot("normal"):
+        task = make_worker_task("backtest", Path(data_dir), cfg)
+        result = run_worker_task(task)
 
     error = result.get("error")
     if error:
@@ -269,6 +272,8 @@ async def execute_tool(
             strategy_id = str(args.get("strategy_id") or "").strip()
             if not strategy_id:
                 return {"ok": False, "error": "run_backtest 缺少 strategy_id"}
+            if engine is not None and not engine.has(strategy_id):
+                return {"ok": False, "error": f"策略 {strategy_id} 不存在"}
             result = await asyncio.to_thread(
                 run_backtest,
                 data_dir,

--- a/backend/app/strategy/ai_iterator.py
+++ b/backend/app/strategy/ai_iterator.py
@@ -7,6 +7,7 @@ services.tool_catalog 做工具目录 + 回测桥。
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
 from pathlib import Path
@@ -77,6 +78,7 @@ class AIStrategyIterator:
         current_code, current_meta = code, {**meta, "id": draft_id}
 
         rounds: list[dict[str, Any]] = []
+        final_backtested = False  # final 版(当前 current_code)是否已有回测证据
         for round_no in range(1, self._max_rounds + 1):
             full = await generate_ai_text_with_tools(
                 self._iteration_messages(generator, current_code, prompt, draft_id),
@@ -86,6 +88,7 @@ class AIStrategyIterator:
                 temperature=0.3,
                 max_tokens=None,
             )
+            # stats 是本轮「改动前」的 current_code 回测基准 (LLM 先回测再产出改进版)
             stats = _extract_backtest_stats(full)
             final_text = _last_assistant_content(full)
             improved = generator.validate_code(final_text)
@@ -95,6 +98,7 @@ class AIStrategyIterator:
                     "stats": stats,
                     "change_summary": f"改进版校验失败: {improved.get('error')}",
                 })
+                final_backtested = True  # final 仍是 current_code, 已被本轮回测
                 break
 
             new_code, new_meta = improved["code"], improved["meta"]
@@ -104,6 +108,7 @@ class AIStrategyIterator:
                     "stats": stats,
                     "change_summary": "无改动, 视为收敛",
                 })
+                final_backtested = True  # 收敛, final 仍是 current_code
                 break
 
             self._save_draft(engine, data_dir, draft_id, new_code, new_meta)
@@ -113,6 +118,16 @@ class AIStrategyIterator:
                 "stats": stats,
                 "change_summary": _extract_summary(final_text),
             })
+            final_backtested = False  # 本轮改进了 current_code, 新的 final 尚未回测
+
+        # 循环耗尽且末轮是改进版时, final 版从未被回测, 补一次作为末行证据
+        if not final_backtested:
+            final_stats = await self._backtest_final(data_dir, draft_id)
+            rounds.append({
+                "round": len(rounds) + 1,
+                "stats": final_stats,
+                "change_summary": "最终版回测",
+            })
 
         return {
             "draft_strategy_id": draft_id,
@@ -120,6 +135,16 @@ class AIStrategyIterator:
             "final_code": current_code,
             "final_meta": current_meta,
         }
+
+    async def _backtest_final(self, data_dir: str, draft_id: str) -> dict | None:
+        """对最终版草稿补一次回测, 返回精简 stats; 失败返回 None (末行证据尽力而为)。"""
+        try:
+            result = await asyncio.to_thread(
+                tool_catalog.run_backtest, data_dir, strategy_id=draft_id
+            )
+            return result.get("stats")
+        except Exception:  # noqa: BLE001 — 末行证据不强依赖回测成功
+            return None
 
     def _alloc_draft_id(self, engine) -> str:
         while True:

--- a/backend/app/strategy/ai_iterator.py
+++ b/backend/app/strategy/ai_iterator.py
@@ -1,0 +1,232 @@
+"""AI 策略迭代器 — 生成 v1 → 跑回测 → 诊断 → 修改, 有界闭环。
+
+只自动化「生成—诊断—修改」, 回测只读、轮次有上限, 最终仍由人拍板
+(docs/strategy-iteration.md 第 0/1 节纪律)。产物落盘到 data/strategies/ai/,
+不自动上线。复用 ai_generator.AIStrategyGenerator 做生成与校验, 复用
+services.tool_catalog 做工具目录 + 回测桥。
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from pprint import pformat
+from typing import Any
+
+from app.services import tool_catalog
+from app.services.ai_provider import generate_ai_text_with_tools
+from app.strategy.ai_generator import AIStrategyGenerator, _SYSTEM_PREFIX, find_meta_assignment
+
+# 每轮 (生成/诊断/修改一次) 内部的工具调用预算: 至少 2 次 LLM 调用
+# (1 次发起 run_backtest, 1 次读结果产出改进版), 留少量检索/换参余量。
+_CYCLE_TOOL_BUDGET = 4
+
+_ITERATION_SUFFIX = """
+
+--- 工具使用与迭代纪律 ---
+
+你拥有以下工具 (通过 OpenAI function calling 调用):
+- list_factors(asset_type?, stable_only?): 检索因子目录 (约 100 个因子)
+- list_strategies(): 检索已加载策略目录 (含 research 研究模板)
+- list_data_capabilities(): 检索数据源能力
+- run_backtest(strategy_id, params?, start?, end?, asset_type?): 回测已保存策略, 返回精简指标 (总收益/年化/最大回撤/夏普/胜率/盈亏比/交易次数等)
+
+迭代纪律 (不可违反):
+1. 每轮先用 run_backtest 回测当前草稿, 拿基准指标, 再诊断问题。
+2. 一次只改一个主题 (先修一个短板), 改动依据必须来自回测指标或目录检索结果, 不凭想象调参。
+3. run_backtest 是只读操作, 不修改策略文件; 你只能输出改进后的完整策略代码。
+4. 输出改进版前用一行说明改了什么、预期哪些指标变化; 若已无明显改进空间, 原样输出当前代码。
+5. 最终只输出完整策略 Python 文件 (用 ```python 代码块包裹)。
+"""
+
+
+class AIStrategyIterator:
+    """用工具循环把 AI 策略生成升级为「生成→回测→诊断→修改」闭环。"""
+
+    def __init__(self, *, max_rounds: int = 4) -> None:
+        self._max_rounds = max_rounds
+
+    async def iterate(
+        self,
+        prompt: str,
+        *,
+        engine,
+        data_dir: str,
+    ) -> dict[str, Any]:
+        """执行有界迭代, 返回:
+        {
+            "draft_strategy_id": str,
+            "rounds": [{"round": int, "stats": dict | None, "change_summary": str}, ...],
+            "final_code": str,
+            "final_meta": dict,
+        }
+        """
+        generator = AIStrategyGenerator()
+        tools = tool_catalog.build_tool_schemas()
+
+        # 1. 生成 v1 (复用现有单次生成 + 结构修复)
+        result = await generator.generate(prompt)
+        if generator.needs_structural_repair(result):
+            result = await generator.repair_code(result["code"], result["error"])
+        if not result.get("valid"):
+            raise ValueError(f"初始策略生成失败: {result.get('error')}")
+
+        draft_id = self._alloc_draft_id(engine)
+        code, meta = result["code"], result["meta"]
+        self._save_draft(engine, data_dir, draft_id, code, meta)
+        current_code, current_meta = code, {**meta, "id": draft_id}
+
+        rounds: list[dict[str, Any]] = []
+        for round_no in range(1, self._max_rounds + 1):
+            full = await generate_ai_text_with_tools(
+                self._iteration_messages(generator, current_code, prompt, draft_id),
+                tools,
+                execute_tool=self._make_execute_tool(engine, data_dir),
+                max_rounds=_CYCLE_TOOL_BUDGET,
+                temperature=0.3,
+                max_tokens=None,
+            )
+            stats = _extract_backtest_stats(full)
+            final_text = _last_assistant_content(full)
+            improved = generator.validate_code(final_text)
+            if not improved.get("valid"):
+                rounds.append({
+                    "round": round_no,
+                    "stats": stats,
+                    "change_summary": f"改进版校验失败: {improved.get('error')}",
+                })
+                break
+
+            new_code, new_meta = improved["code"], improved["meta"]
+            if new_code.strip() == current_code.strip():
+                rounds.append({
+                    "round": round_no,
+                    "stats": stats,
+                    "change_summary": "无改动, 视为收敛",
+                })
+                break
+
+            self._save_draft(engine, data_dir, draft_id, new_code, new_meta)
+            current_code, current_meta = new_code, {**new_meta, "id": draft_id}
+            rounds.append({
+                "round": round_no,
+                "stats": stats,
+                "change_summary": _extract_summary(final_text),
+            })
+
+        return {
+            "draft_strategy_id": draft_id,
+            "rounds": rounds,
+            "final_code": current_code,
+            "final_meta": current_meta,
+        }
+
+    def _alloc_draft_id(self, engine) -> str:
+        while True:
+            draft_id = f"ai_{uuid.uuid4().hex[:8]}"
+            if not engine.has(draft_id):
+                return draft_id
+
+    @staticmethod
+    def _save_draft(engine, data_dir: str, draft_id: str, code: str, meta: dict) -> None:
+        """写草稿文件 + 热重载; META.id 强制对齐 draft_id (engine 以 meta["id"] 为键)。
+
+        草稿强制 research_only=True (复用 #255 的发布闸): 不进公开列表、不可运行,
+        只有人点 publish 才上线, 守住「回测验证与上线由人拍板」的纪律。
+        """
+        out_dir = Path(data_dir) / "strategies" / "ai"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        path = out_dir / f"{draft_id}.py"
+        meta = {**meta, "research_only": True}
+        path.write_text(_rewrite_meta_id(code, draft_id, meta), encoding="utf-8")
+        engine.reload()
+
+    def _iteration_messages(
+        self,
+        generator: AIStrategyGenerator,
+        current_code: str,
+        prompt: str,
+        draft_id: str,
+    ) -> list[dict]:
+        system = _SYSTEM_PREFIX + generator._get_guide() + _ITERATION_SUFFIX
+        user = (
+            f"策略草稿已保存为 {draft_id}。你可以调用 run_backtest 回测它 "
+            f"(strategy_id={draft_id}), 或用 list_factors / list_strategies / "
+            f"list_data_capabilities 检索目录。\n\n"
+            f"原始需求:\n{prompt}\n\n"
+            f"当前策略代码:\n```python\n{current_code}\n```\n\n"
+            f"请回测当前草稿, 依据指标诊断, 输出改进后的完整策略代码; "
+            f"若已无明显改进空间, 原样输出当前代码。"
+        )
+        return [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ]
+
+    def _make_execute_tool(self, engine, data_dir: str):
+        async def _execute(name: str, args: dict) -> dict:
+            return await tool_catalog.execute_tool(name, args, engine=engine, data_dir=data_dir)
+
+        return _execute
+
+
+def _rewrite_meta_id(code: str, strategy_id: str, meta: dict) -> str:
+    """把 META 赋值整段重写为 id=strategy_id 的规范形式 (变量名归一为 META)。
+
+    草稿落盘要求 META.id 与文件名一致 (engine 以 meta["id"] 为键, run_backtest 按
+    strategy_id 查找)。整段重写避免正则改 id 的边界情况, pformat 输出仍是合法 Python 字面量。
+    """
+    found = find_meta_assignment(code)
+    if found is None:
+        raise ValueError("找不到 META 字典")
+    target, value = found
+    new_meta = dict(meta)
+    new_meta["id"] = strategy_id
+
+    lines = code.splitlines(keepends=True)
+    start_line = target.lineno - 1
+    start_col = target.col_offset
+    end_line = (value.end_lineno or value.lineno) - 1
+    end_col = value.end_col_offset or value.col_offset
+
+    replacement = f"META = {pformat(new_meta, width=100, sort_dicts=False)}"
+    first = lines[start_line]
+    last = lines[end_line]
+    lines[start_line] = first[:start_col] + replacement + last[end_col:]
+    if start_line != end_line:
+        del lines[start_line + 1 : end_line + 1]
+    return "".join(lines)
+
+
+def _last_assistant_content(messages: list[dict]) -> str:
+    for m in reversed(messages):
+        if m.get("role") == "assistant" and not m.get("tool_calls"):
+            return m.get("content") or ""
+    return ""
+
+
+def _extract_backtest_stats(messages: list[dict]) -> dict | None:
+    """从 role:tool 消息中取出最近一次 run_backtest 的精简 stats。"""
+    stats = None
+    for m in messages:
+        if m.get("role") != "tool":
+            continue
+        try:
+            payload = json.loads(m.get("content") or "")
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(payload, dict) or not payload.get("ok"):
+            continue
+        result = payload.get("result")
+        if isinstance(result, dict) and isinstance(result.get("stats"), dict):
+            stats = result["stats"]
+    return stats
+
+
+def _extract_summary(text: str) -> str:
+    """取第一个 ``` 之前的文字作为变更说明, 精简为一行。"""
+    pre = text.split("```", 1)[0].strip()
+    lines = [ln.strip() for ln in pre.splitlines() if ln.strip()]
+    if not lines:
+        return "已应用改进版"
+    return " ".join(lines)[:120]

--- a/backend/tests/test_ai_iterate.py
+++ b/backend/tests/test_ai_iterate.py
@@ -1,0 +1,335 @@
+# -*- coding: utf-8 -*-
+"""AI 策略迭代闭环的定向测试 (stub 生成器与工具循环, 不依赖真实 AI key 与数据)。
+
+覆盖三层:
+  1. _rewrite_meta_id 纯函数 (三种 META 声明形式 + 缺失 id 插入)
+  2. tool_catalog.build_tool_schemas + execute_tool 的 list_* 分发与未知工具
+  3. AIStrategyIterator.iterate 完整状态流转 (收敛 / 校验失败 / 末轮改进补 final 回测)
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+from app.strategy import ai_iterator as it
+from app.strategy.ai_generator import AIStrategyGenerator as RealGen, find_meta_assignment
+from app.strategy.ai_iterator import AIStrategyIterator, _rewrite_meta_id
+from app.services import tool_catalog
+
+V1_CODE = '''"""v1 策略"""
+import polars as pl
+
+META = {
+    "id": "ai_placeholder",
+    "name": "v1",
+    "description": "v1",
+    "tags": ["ai"],
+    "asset_types": ["stock"],
+    "timeframes": ["1d"],
+    "params": [],
+    "scoring": {"change_pct": 1.0},
+    "order_by": "score",
+    "descending": True,
+    "limit": 100,
+}
+
+EXECUTION_BACKEND = "polars_expr"
+
+def filter(df: pl.DataFrame, params: dict) -> pl.Expr:
+    return pl.col("close") > pl.col("ma5")
+'''
+
+# v2 与 v1 不同: 增加成交量条件
+V2_CODE = V1_CODE.replace(
+    'return pl.col("close") > pl.col("ma5")',
+    'return (pl.col("close") > pl.col("ma5")) & (pl.col("volume") > pl.col("vol_ma5") * 1.2)',
+).replace('"name": "v1"', '"name": "v2"')
+
+META = {
+    "name": "v1",
+    "description": "v1",
+    "tags": ["ai"],
+    "asset_types": ["stock"],
+    "timeframes": ["1d"],
+    "params": [],
+    "scoring": {"change_pct": 1.0},
+    "order_by": "score",
+    "descending": True,
+    "limit": 100,
+}
+
+
+def _meta_id_of(code: str) -> str:
+    """从代码里提取 META 的 id (走真实 find_meta_assignment + literal_eval)。"""
+    found = find_meta_assignment(code)
+    assert found is not None, "找不到 META"
+    _, value = found
+    return ast.literal_eval(value)["id"]
+
+
+# ── Part 1: _rewrite_meta_id ──────────────────────────────
+
+def test_rewrite_multiline_assign():
+    out = _rewrite_meta_id(V1_CODE, "ai_abcd1234", META)
+    ast.parse(out)  # 必须仍是合法 Python
+    assert _meta_id_of(out) == "ai_abcd1234"
+    assert "META = {" in out
+    assert "STRATEGY_META" not in out
+
+
+def test_rewrite_normalize_variable_name():
+    code = V1_CODE.replace("META = {", "STRATEGY_META = {")
+    out = _rewrite_meta_id(code, "ai_x", META)
+    ast.parse(out)
+    assert _meta_id_of(out) == "ai_x"
+    assert "STRATEGY_META" not in out
+    assert "META = {" in out
+
+
+def test_rewrite_annassign():
+    code = V1_CODE.replace("META = {", "META: dict = {")
+    out = _rewrite_meta_id(code, "ai_y", META)
+    ast.parse(out)
+    assert _meta_id_of(out) == "ai_y"
+
+
+def test_rewrite_insert_missing_id():
+    code = V1_CODE.replace('    "id": "ai_placeholder",\n', "")
+    out = _rewrite_meta_id(code, "ai_z", META)
+    ast.parse(out)
+    assert _meta_id_of(out) == "ai_z"
+
+
+# ── Part 2: tool_catalog ──────────────────────────────────
+
+def _stub_module(monkeypatch, fullname: str, **attrs) -> types.ModuleType:
+    """往 sys.modules 塞 stub 模块 (monkeypatch 在测试后自动恢复)。"""
+    mod = types.ModuleType(fullname)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    monkeypatch.setitem(sys.modules, fullname, mod)
+    parts = fullname.split(".")
+    for i in range(1, len(parts)):
+        parent = ".".join(parts[:i])
+        if parent not in sys.modules:
+            pkg = types.ModuleType(parent)
+            pkg.__path__ = []
+            monkeypatch.setitem(sys.modules, parent, pkg)
+    return mod
+
+
+class _FakeFactorSpec:
+    def __init__(self, fid):
+        self.id = fid
+        self.label = "因子"
+        self.group = "g"
+        self.formula_text = "f"
+        self.kind = "k"
+        self.dependencies = {"close"}
+        self.asset_types = {"stock"}
+        self.stability = "stable"
+        self.pit = False
+
+
+def test_build_tool_schemas():
+    schemas = tool_catalog.build_tool_schemas()
+    names = [s["function"]["name"] for s in schemas]
+    assert names == [
+        "list_factors", "list_strategies", "list_data_capabilities", "run_backtest",
+    ]
+    for s in schemas:
+        assert s["type"] == "function"
+        assert s["function"]["parameters"]["type"] == "object"
+
+
+def test_execute_list_factors(monkeypatch):
+    _stub_module(
+        monkeypatch,
+        "app.factors.registry",
+        all_factors=lambda asset_type=None, stable_only=False: [
+            _FakeFactorSpec("f1"), _FakeFactorSpec("f2"),
+        ],
+    )
+    result = asyncio.run(tool_catalog.execute_tool("list_factors", {}))
+    assert result["ok"] is True
+    assert [f["id"] for f in result["result"]["factors"]] == ["f1", "f2"]
+
+
+def test_execute_list_data_capabilities(monkeypatch):
+    _stub_module(
+        monkeypatch,
+        "app.data_providers.capabilities",
+        CAPABILITY_REGISTRY=[
+            {"id": "daily", "label": "日K", "desc": "d", "tf_tier": 0},
+        ],
+    )
+    result = asyncio.run(tool_catalog.execute_tool("list_data_capabilities", {}))
+    assert result["ok"] is True
+    assert result["result"]["capabilities"][0]["id"] == "daily"
+
+
+class _FakeEngine:
+    def __init__(self):
+        self.reloads = 0
+
+    def has(self, sid):
+        return False
+
+    def reload(self):
+        self.reloads += 1
+
+    def list_strategies(self, include_research=False):
+        return [{"id": "builtin_1", "name": "内置", "description": "", "tags": [],
+                 "asset_types": ["stock"], "timeframes": ["1d"], "execution_backend": "polars_expr",
+                 "source": "builtin", "params": []}]
+
+
+def test_execute_list_strategies():
+    engine = _FakeEngine()
+    result = asyncio.run(tool_catalog.execute_tool("list_strategies", {}, engine=engine))
+    assert result["ok"] is True
+    assert result["result"]["strategies"][0]["id"] == "builtin_1"
+
+
+def test_execute_unknown_tool():
+    result = asyncio.run(tool_catalog.execute_tool("no_such_tool", {}))
+    assert result["ok"] is False
+    assert "未知工具" in result["error"]
+
+
+# ── Part 3: AIStrategyIterator.iterate 状态流转 ────────────
+
+class FakeGenerator:
+    """替换 AIStrategyGenerator: generate 返回 v1, validate_code 对改进版返回 valid。"""
+
+    def needs_structural_repair(self, result):
+        return False
+
+    def _get_guide(self):
+        return "guide"
+
+    async def generate(self, prompt):
+        return {"code": V1_CODE, "meta": dict(META), "valid": True, "error": None}
+
+    def validate_code(self, code):
+        stripped = RealGen._extract_code_block(code)
+        return {"code": stripped, "meta": dict(META), "valid": True, "error": None}
+
+    async def repair_code(self, code, error):
+        raise AssertionError("不应进入 repair_code 分支")
+
+
+def _fake_tool_loop(call_log: list):
+    """按调用次数返回对话: 第 1 轮 run_backtest→改进, 第 2 轮原样输出(收敛)。"""
+    async def fake(messages, tools, *, execute_tool, max_rounds, temperature, max_tokens):
+        call_log.append(len(call_log) + 1)
+        if len(call_log) == 1:
+            return [
+                {"role": "assistant", "content": None, "tool_calls": [{
+                    "id": "call_1", "type": "function",
+                    "function": {"name": "run_backtest",
+                                 "arguments": json.dumps({"strategy_id": "draft"})},
+                }]},
+                {"role": "tool", "tool_call_id": "call_1",
+                 "content": json.dumps({"ok": True, "result": {"stats": {
+                     "sharpe": 1.5, "max_drawdown": -0.08, "win_rate": 0.55, "total_return": 0.12,
+                 }}}, ensure_ascii=False)},
+                {"role": "assistant", "content": "改进夏普\n```python\n" + V2_CODE + "\n```"},
+            ]
+        return [
+            {"role": "assistant", "content": "已无改进空间\n```python\n" + V2_CODE + "\n```"},
+        ]
+
+    return fake
+
+
+def test_iterate_full_flow(monkeypatch):
+    call_log: list = []
+    monkeypatch.setattr(it, "AIStrategyGenerator", FakeGenerator)
+    monkeypatch.setattr(it, "generate_ai_text_with_tools", _fake_tool_loop(call_log))
+
+    engine = _FakeEngine()
+    with tempfile.TemporaryDirectory() as tmp:
+        result = asyncio.run(
+            AIStrategyIterator(max_rounds=2).iterate(
+                "做一个均线多头策略", engine=engine, data_dir=tmp,
+            )
+        )
+        draft_id = result["draft_strategy_id"]
+        # 在 with 块内读落盘文件 (退出后 TemporaryDirectory 会清理)
+        draft_path = Path(tmp) / "strategies" / "ai" / f"{draft_id}.py"
+        assert draft_path.exists()
+        on_disk = draft_path.read_text(encoding="utf-8")
+
+    assert draft_id.startswith("ai_"), draft_id
+    assert len(draft_id) == len("ai_") + 8
+
+    # 2 轮: 第 1 轮改进, 第 2 轮收敛 (收敛路径 final 已被回测, 不补末行)
+    assert len(result["rounds"]) == 2, result["rounds"]
+    r1, r2 = result["rounds"]
+    assert r1["stats"] is not None and r1["stats"]["sharpe"] == 1.5
+    assert r1["change_summary"] == "改进夏普"
+    assert r2["stats"] is None
+    assert "收敛" in r2["change_summary"]
+
+    assert result["final_code"].strip() == V2_CODE.strip()
+    assert result["final_meta"]["id"] == draft_id
+
+    # 引擎 reload: v1 保存 1 次 + 第 1 轮改进保存 1 次 = 2 次
+    assert engine.reloads == 2, engine.reloads
+
+    # 草稿文件 META.id 与文件名对齐, 且落盘的是改进后的 v2, research_only 已注入
+    assert _meta_id_of(on_disk) == draft_id
+    assert "vol_ma5" in on_disk
+    assert ast.literal_eval(find_meta_assignment(on_disk)[1]).get("research_only") is True
+
+
+def test_iterate_validation_failure_breaks(monkeypatch):
+    """改进版校验失败 -> 记录 error 并 break, 不落盘坏代码。"""
+    call_log: list = []
+
+    class BadGen(FakeGenerator):
+        def validate_code(self, code):
+            return {"code": code, "meta": {}, "valid": False, "error": "找不到策略入口函数 filter()"}
+
+    monkeypatch.setattr(it, "AIStrategyGenerator", BadGen)
+    monkeypatch.setattr(it, "generate_ai_text_with_tools", _fake_tool_loop(call_log))
+
+    engine = _FakeEngine()
+    with tempfile.TemporaryDirectory() as tmp:
+        result = asyncio.run(
+            AIStrategyIterator(max_rounds=2).iterate("p", engine=engine, data_dir=tmp)
+        )
+    assert len(result["rounds"]) == 1
+    assert "校验失败" in result["rounds"][0]["change_summary"]
+    assert engine.reloads == 1  # 只有 v1 落盘
+
+
+def test_iterate_final_backtest_appended(monkeypatch):
+    """末轮是改进版 (耗尽 max_rounds) -> final 从未被回测, 补一次末行「最终版回测」。"""
+    call_log: list = []
+    monkeypatch.setattr(it, "AIStrategyGenerator", FakeGenerator)
+    monkeypatch.setattr(it, "generate_ai_text_with_tools", _fake_tool_loop(call_log))
+
+    async def fake_final_backtest(self, data_dir, draft_id):
+        return {"sharpe": 2.0}
+
+    monkeypatch.setattr(AIStrategyIterator, "_backtest_final", fake_final_backtest)
+
+    engine = _FakeEngine()
+    with tempfile.TemporaryDirectory() as tmp:
+        result = asyncio.run(
+            AIStrategyIterator(max_rounds=1).iterate("p", engine=engine, data_dir=tmp)
+        )
+
+    # 1 轮改进 + 1 行最终版回测
+    assert len(result["rounds"]) == 2, result["rounds"]
+    r1, r2 = result["rounds"]
+    assert r1["change_summary"] == "改进夏普"
+    assert r2["change_summary"] == "最终版回测"
+    assert r2["stats"] == {"sharpe": 2.0}

--- a/frontend/src/components/screener/StrategyBuilderDialog.tsx
+++ b/frontend/src/components/screener/StrategyBuilderDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { Modal } from '@/components/Modal'
 import { X, Sparkles, Save, Loader2, ChevronLeft, ChevronRight, AlertTriangle, Settings2, FileText, Copy, Check, Terminal } from 'lucide-react'
 import { api } from '@/lib/api'
+import type { AiIterateRound } from '@/lib/api'
 import { storage } from '@/lib/storage'
 import { cn } from '@/lib/cn'
 
@@ -71,6 +72,16 @@ function parseRules(code: string): string {
 function parseMetaField(code: string, field: string): string {
   const m = code.match(new RegExp('"' + field + '"\\s*:\\s*"([^"]+)"'))
   return m ? m[1] : ''
+}
+
+// 回测 stats 均为比率 (0.15 = 15%), 按 key 语义格式化为可读文本
+function fmtStat(key: string, v: any): string {
+  if (v === null || v === undefined || typeof v !== 'number') return '—'
+  if (key === 'n_trades') return String(Math.round(v))
+  if (['total_return', 'annual_return', 'max_drawdown', 'win_rate'].includes(key)) {
+    return (v * 100).toFixed(2) + '%'
+  }
+  return v.toFixed(2)
 }
 
 // ===== 常量 =====
@@ -209,12 +220,16 @@ export function StrategyBuilderDialog({ open, onClose, onSavedId, mode = 'create
   const [aiStatus, setAiStatus] = useState<{ configured: boolean } | null>(null)
   const [checkedAi, setCheckedAi] = useState(false)
   const [loaded, setLoaded] = useState(false)
+  const [iterateEnabled, setIterateEnabled] = useState(false)
+  const [iterateRounds, setIterateRounds] = useState<AiIterateRound[]>([])
+  const [iterateDraftId, setIterateDraftId] = useState('')
   const suppressPersistRef = useRef(false)
 
   const resetDraftState = useCallback(() => {
     setStep(1); setTab('ai'); setName(''); setDescription(''); setDirection('long')
     setExecutionBackend('polars_expr'); setRules(''); setCode(''); setInstruction('')
     setPreviewTab('params'); setStrategyId(''); setSource('ai'); setValidated(false); setError('')
+    setIterateEnabled(false); setIterateRounds([]); setIterateDraftId('')
   }, [])
 
   // 打开时恢复草稿
@@ -292,27 +307,43 @@ export function StrategyBuilderDialog({ open, onClose, onSavedId, mode = 'create
   const handleGenerate = async () => {
     if (!name.trim() || !rules.trim()) return
     if (!aiStatus?.configured) { setError('AI 未配置，请在设置页面配置 API Key'); return }
-    setLoading(true); setError(''); setCode(''); setValidated(false)
+    setLoading(true); setError(''); setCode(''); setValidated(false); setIterateRounds([]); setIterateDraftId('')
     try {
-      const id = resolveStrategyId('ai')
-      setStrategyId(id); setSource('ai'); setPreviewTab('code')
-      let finalResult: any = null
-      for await (const evt of api.strategyBuildStream(1, { name: name.trim(), description: description.trim(), direction, execution_backend: executionBackend, rules: rules.trim(), strategy_id: id })) {
-        if (evt.type === 'delta') {
-          setCode(prev => prev + evt.content)
-        } else if (evt.type === 'error') {
-          throw new Error(evt.message)
-        } else if (evt.type === 'result') {
-          finalResult = evt
+      if (iterateEnabled) {
+        // AI 迭代: 生成 → 回测 → 诊断 → 修改 闭环, 草稿已由后端落盘
+        const result = await api.strategyAiIterate({
+          name: name.trim(), description: description.trim(), direction,
+          execution_backend: executionBackend, rules: rules.trim(), max_rounds: 4,
+        })
+        setCode(result.final_code)
+        setStrategyId(result.draft_strategy_id); setSource('ai')
+        setIterateDraftId(result.draft_strategy_id); setIterateRounds(result.rounds ?? [])
+        setStep(2); setValidated(true)
+        const genDesc = parseMetaField(result.final_code, 'description')
+        const genRules = parseRules(result.final_code)
+        if (genDesc) setDescription(genDesc)
+        if (genRules) setRules(genRules)
+      } else {
+        const id = resolveStrategyId('ai')
+        setStrategyId(id); setSource('ai'); setPreviewTab('code')
+        let finalResult: any = null
+        for await (const evt of api.strategyBuildStream(1, { name: name.trim(), description: description.trim(), direction, execution_backend: executionBackend, rules: rules.trim(), strategy_id: id })) {
+          if (evt.type === 'delta') {
+            setCode(prev => prev + evt.content)
+          } else if (evt.type === 'error') {
+            throw new Error(evt.message)
+          } else if (evt.type === 'result') {
+            finalResult = evt
+          }
         }
+        if (!finalResult) throw new Error('AI 未返回策略结果')
+        if (!finalResult.valid) { setError(finalResult.error ?? '生成失败'); return }
+        setCode(finalResult.code); setStep(2); setValidated(true)
+        const genDesc = parseMetaField(finalResult.code, 'description')
+        const genRules = parseRules(finalResult.code)
+        if (genDesc) setDescription(genDesc)
+        if (genRules) setRules(genRules)
       }
-      if (!finalResult) throw new Error('AI 未返回策略结果')
-      if (!finalResult.valid) { setError(finalResult.error ?? '生成失败'); return }
-      setCode(finalResult.code); setStep(2); setValidated(true)
-      const genDesc = parseMetaField(finalResult.code, 'description')
-      const genRules = parseRules(finalResult.code)
-      if (genDesc) setDescription(genDesc)
-      if (genRules) setRules(genRules)
     } catch (e: any) {
       const msg = String(e?.message ?? '')
       setError(msg.includes('API Key') || msg.includes('api_key') ? 'AI API Key 未配置或无效' : (msg || '生成失败'))
@@ -371,6 +402,18 @@ export function StrategyBuilderDialog({ open, onClose, onSavedId, mode = 'create
     if (!draftCode) return
     setSaving(true); setError('')
     try {
+      // 迭代模式: 后端已把草稿落盘到 data/strategies/ai/, 此处只刷新 + 入池, 不重复保存
+      if (iterateDraftId) {
+        suppressPersistRef.current = true
+        clearDraft()
+        const genRules = parseRules(draftCode)
+        const finalRules = (genRules || rules).trim()
+        if (finalRules) { const saved = storage.strategyRules.get({}); saved[iterateDraftId] = finalRules; storage.strategyRules.set(saved) }
+        await onSavedId?.(iterateDraftId, true)
+        setTimeout(() => onClose(), 1000)
+        setSaving(false)
+        return
+      }
       const target = mode === 'modify' ? source : (tab === 'custom' ? 'custom' : 'ai')
       const id = resolveStrategyId(target)
       setStrategyId(id); setSource(target)
@@ -509,11 +552,24 @@ export function StrategyBuilderDialog({ open, onClose, onSavedId, mode = 'create
                     placeholder="描述你的选股逻辑，AI 会自动提取参数。例如：\n前一交易日为明显阴线且跌幅不低于2%，今日阳线收盘反包前一日实体，收盘价接近或高于前一日高点，成交量较前一日放大1.2倍以上，当前 close > ma5 或 close > ma10；使用 filter_history，并优先用 Polars shift/with_columns/filter 实现。"
                     className="w-full h-28 px-3 py-2 rounded-lg bg-base border-0 ring-1 ring-border/30 text-sm text-foreground placeholder:text-muted/30 resize-none focus:outline-none focus:ring-2 focus:ring-accent/30" />
                 </div>
+                <button type="button" onClick={() => setIterateEnabled(v => !v)}
+                  className="flex w-full items-center justify-between rounded-lg border border-border/30 bg-surface/30 px-3 py-2 cursor-pointer select-none">
+                  <span className="flex items-center gap-1.5 text-[11px] text-secondary">
+                    <Terminal className="h-3.5 w-3.5 text-emerald-400" />
+                    AI 迭代（自动回测诊断优化）
+                  </span>
+                  <span className={cn('relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors', iterateEnabled ? 'bg-emerald-400/40' : 'bg-border')}>
+                    <span className={cn('inline-block h-4 w-4 rounded-full bg-white transform transition-transform', iterateEnabled ? 'translate-x-[18px]' : 'translate-x-[2px]')} />
+                  </span>
+                </button>
+                {iterateEnabled && (
+                  <div className="text-[10px] text-muted/60 leading-relaxed">开启后 AI 会先回测再诊断修改，最多迭代 4 轮，耗时更长；结果保存为草稿，仍需你点「保存策略」加入策略池。</div>
+                )}
                 {error && <div className="text-[11px] text-danger bg-danger/10 border border-danger/20 rounded-lg px-3 py-2">{error}</div>}
                 <button onClick={handleGenerate} disabled={loading || !name.trim() || !rules.trim()}
                   className="w-full h-10 rounded-xl bg-gradient-to-r from-amber-500/20 to-amber-500/10 border border-amber-400/30 text-amber-400 text-sm font-medium flex items-center justify-center gap-2 hover:from-amber-500/30 hover:to-amber-500/20 disabled:opacity-40 transition-all">
                   {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
-                  {loading ? 'AI 生成中...' : code ? '重新生成' : 'AI 生成策略'}
+                  {loading ? (iterateEnabled ? 'AI 迭代中...' : 'AI 生成中...') : code ? '重新生成' : (iterateEnabled ? 'AI 迭代生成' : 'AI 生成策略')}
                 </button>
               </>
             ) : (
@@ -525,6 +581,41 @@ export function StrategyBuilderDialog({ open, onClose, onSavedId, mode = 'create
                     <button onClick={() => setPreviewTab('code')} className={'px-3 py-1 rounded text-xs font-medium transition-colors ' + (previewTab === 'code' ? 'bg-amber-400/15 text-amber-400' : 'text-muted hover:text-secondary')}>代码</button>
                   </div>
                 </div>
+
+                {iterateRounds.length > 0 && (
+                  <div className="rounded-xl border border-emerald-400/20 bg-emerald-400/5 px-3 py-2.5 space-y-1.5">
+                    <div className="flex items-center gap-1.5 text-[11px] text-emerald-400">
+                      <Terminal className="h-3.5 w-3.5" />
+                      迭代证据（共 {iterateRounds.length} 轮，草稿已保存为 {iterateDraftId}）
+                    </div>
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-[10px]">
+                        <thead>
+                          <tr className="text-muted/50">
+                            <th className="text-left font-medium py-1 pr-2">轮次</th>
+                            <th className="text-right font-medium py-1 pr-2">总收益</th>
+                            <th className="text-right font-medium py-1 pr-2">最大回撤</th>
+                            <th className="text-right font-medium py-1 pr-2">夏普</th>
+                            <th className="text-right font-medium py-1 pr-2">胜率</th>
+                            <th className="text-left font-medium py-1">变更说明</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {iterateRounds.map(r => (
+                            <tr key={r.round} className="border-t border-border/20">
+                              <td className="py-1 pr-2 text-secondary">#{r.round}</td>
+                              <td className="text-right py-1 pr-2 font-mono">{fmtStat('total_return', r.stats?.total_return)}</td>
+                              <td className="text-right py-1 pr-2 font-mono">{fmtStat('max_drawdown', r.stats?.max_drawdown)}</td>
+                              <td className="text-right py-1 pr-2 font-mono">{fmtStat('sharpe', r.stats?.sharpe)}</td>
+                              <td className="text-right py-1 pr-2 font-mono">{fmtStat('win_rate', r.stats?.win_rate)}</td>
+                              <td className="py-1 text-muted">{r.change_summary}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                )}
 
                 {previewTab === 'params' ? (
                   hasParams ? (

--- a/frontend/src/components/screener/StrategyBuilderDialog.tsx
+++ b/frontend/src/components/screener/StrategyBuilderDialog.tsx
@@ -224,12 +224,15 @@ export function StrategyBuilderDialog({ open, onClose, onSavedId, mode = 'create
   const [iterateRounds, setIterateRounds] = useState<AiIterateRound[]>([])
   const [iterateDraftId, setIterateDraftId] = useState('')
   const suppressPersistRef = useRef(false)
+  // 迭代落盘的代码基准 (检测用户在编辑器是否改过, 见 handleSave)
+  const iterateSavedCodeRef = useRef('')
 
   const resetDraftState = useCallback(() => {
     setStep(1); setTab('ai'); setName(''); setDescription(''); setDirection('long')
     setExecutionBackend('polars_expr'); setRules(''); setCode(''); setInstruction('')
     setPreviewTab('params'); setStrategyId(''); setSource('ai'); setValidated(false); setError('')
     setIterateEnabled(false); setIterateRounds([]); setIterateDraftId('')
+    iterateSavedCodeRef.current = ''
   }, [])
 
   // 打开时恢复草稿
@@ -316,6 +319,7 @@ export function StrategyBuilderDialog({ open, onClose, onSavedId, mode = 'create
           execution_backend: executionBackend, rules: rules.trim(), max_rounds: 4,
         })
         setCode(result.final_code)
+        iterateSavedCodeRef.current = result.final_code
         setStrategyId(result.draft_strategy_id); setSource('ai')
         setIterateDraftId(result.draft_strategy_id); setIterateRounds(result.rounds ?? [])
         setStep(2); setValidated(true)
@@ -402,14 +406,27 @@ export function StrategyBuilderDialog({ open, onClose, onSavedId, mode = 'create
     if (!draftCode) return
     setSaving(true); setError('')
     try {
-      // 迭代模式: 后端已把草稿落盘到 data/strategies/ai/, 此处只刷新 + 入池, 不重复保存
+      // 迭代模式: 后端已把草稿落盘到 data/strategies/ai/
       if (iterateDraftId) {
+        // 用户若在编辑器改过代码, 先更新落盘草稿 (否则编辑会被静默丢弃)
+        let researchOnly = true
+        if (draftCode !== iterateSavedCodeRef.current) {
+          const savedResult = await api.strategySaveCodeV2({
+            strategy_id: iterateDraftId,
+            code: draftCode,
+            target_source: 'ai',
+            mode: 'update',
+            name: name.trim(),
+            description: description.trim(),
+          })
+          researchOnly = savedResult.research_only
+        }
         suppressPersistRef.current = true
         clearDraft()
         const genRules = parseRules(draftCode)
         const finalRules = (genRules || rules).trim()
         if (finalRules) { const saved = storage.strategyRules.get({}); saved[iterateDraftId] = finalRules; storage.strategyRules.set(saved) }
-        await onSavedId?.(iterateDraftId, true)
+        await onSavedId?.(iterateDraftId, researchOnly)
         setTimeout(() => onClose(), 1000)
         setSaving(false)
         return
@@ -588,6 +605,7 @@ export function StrategyBuilderDialog({ open, onClose, onSavedId, mode = 'create
                       <Terminal className="h-3.5 w-3.5" />
                       迭代证据（共 {iterateRounds.length} 轮，草稿已保存为 {iterateDraftId}）
                     </div>
+                    <div className="text-[10px] text-muted/50">每轮指标为该轮「改动前」基准回测；末行「最终版回测」为最终代码回测结果</div>
                     <div className="overflow-x-auto">
                       <table className="w-full text-[10px]">
                         <thead>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3620,6 +3620,7 @@ export const api = {
   }) =>
     request<AiIterateResult>('/api/strategies/ai/iterate', {
       method: 'POST',
+      timeoutMs: null,
       body: JSON.stringify(payload),
     }),
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -812,6 +812,20 @@ export interface StrategyCodeSaveResult {
   research_only?: boolean
 }
 
+/** AI 迭代每一轮的回测证据 (stats 为比率, 0.15 = 15%) */
+export interface AiIterateRound {
+  round: number
+  stats: Record<string, number> | null
+  change_summary: string
+}
+
+export interface AiIterateResult {
+  draft_strategy_id: string
+  rounds: AiIterateRound[]
+  final_code: string
+  final_meta: Record<string, any>
+}
+
 // ===== Custom Signals (自定义信号) =====
 export interface CustomSignalCondition {
   left: string     // 字段名
@@ -3593,6 +3607,20 @@ export const api = {
     request<{ ok: boolean; path: string }>('/api/strategies/ai/save', {
       method: 'POST',
       body: JSON.stringify({ strategy_id: strategyId, code, name: meta?.name ?? '', description: meta?.description ?? '' }),
+    }),
+
+  /** AI 迭代: 生成 v1 → 跑回测 → 诊断 → 修改 的有界闭环, 草稿已落盘 data/strategies/ai/ */
+  strategyAiIterate: (payload: {
+    name?: string
+    description?: string
+    direction?: string
+    rules?: string
+    execution_backend?: 'polars_expr' | 'matrix_native'
+    max_rounds?: number
+  }) =>
+    request<AiIterateResult>('/api/strategies/ai/iterate', {
+      method: 'POST',
+      body: JSON.stringify(payload),
     }),
 }
 


### PR DESCRIPTION
## 问题描述

当前 AI 策略生成器是「被动文本生成器」：LLM 只能产出代码，通过 AST 静态校验（语法 / META / 入口 / 评分字段白名单），拿不到任何运行时回测反馈。用户必须手动跑回测、再把「证据包」贴回 AI 诊断——这是 `docs/strategy-iteration.md` §9 路线图想自动化却还没做的手动断点。同时元数据（约 100 因子 / 7 数据源 / 25 策略）散落三处，LLM 无法按需检索路由。

## 解决方案

加 OpenAI 原生 `tools=`，新增 `ToolCatalog` 把 FactorSpec / 能力矩阵 / 策略 META 统一序列化为 JSON Schema（`list_factors` / `list_strategies` / `list_data_capabilities` / `run_backtest`）。provider 层新增有界工具循环（`max_rounds` 上限），串起「生成 → 回测 → 诊断 → 修改」。

选这个方案是因为：复用服务端已实现的 `tools=` 协议、不重造轮子；与「预组装数据 → 单次调用」架构契合，reviewer 一眼能看懂；用「只读回测 + 轮次上限 + research_only 草稿 + 人发布闸」四重保险，把维护者「回测验证与上线由人拍板」的纪律落到代码里。

## 改动描述

- 新增 `backend/app/services/tool_catalog.py`：4 个工具 JSON Schema + `execute_tool` 分发器；`run_backtest` 复用 `StrategyBacktestConfig` + worker，只回传 `stats` 白名单键控制 token。
- 修改 `backend/app/services/ai_provider.py`：`_openai_kwargs` 加 `tools=` 透传；新增 `generate_ai_text_with_tools` 有界循环，工具结果以 `role:tool` 回填。
- 新增 `backend/app/strategy/ai_iterator.py`：`AIStrategyIterator` 有界闭环；`_rewrite_meta_id` 整段重写 META 对齐文件名；草稿强制 `research_only=True`。
- 修改 `backend/app/api/strategy.py`：`POST /ai/iterate` 端点，Codex CLI 入口 fail-closed。
- 修改 `frontend/src/lib/api.ts` + `StrategyBuilderDialog.tsx`：AI 迭代开关 + 逐轮回测证据表，迭代产物以 research_only 入草稿池。

## 测试

- `verify_ai_iterate.py`（stub 生成器与工具循环，不依赖真实 AI key / 数据）11/11 通过，覆盖 `_rewrite_meta_id` 三种 META 声明形式、`tool_catalog` schema 构建与 `list_*` 分发、`AIStrategyIterator.iterate` 完整状态流转（含收敛与校验失败分支）。
- 后端改动文件 `py_compile` 语法检查通过。

## 给 Reviewer 的说明

1. **人机边界**：本 PR 只自动化「诊断」，不碰「判定 / 上线」。`run_backtest` 是只读工具，产物强制 `research_only=True`（复用 #255 发布闸），发布仍由人点。
2. **Codex CLI 门控**：Codex CLI 无 `tools=` 协议，属能力边界而非运行时降级，故在 `/ai/iterate` 入口 fail-closed 返回 400，不静默降级为纯文本。
3. **入参契约**：`AIIterateRequest` 采用结构化字段（而非裸 prompt），复用 `build_step1` 拼 prompt，与 `BuildRequest` step1 同构。
4. **回测防失控**：`run_backtest` 走 `shared_heavy_job_limiter`，默认受控窗口，每轮最多 1 次回测 + 总轮次硬上限。
