### PR TITLE
fix: 统一维度详情股票标签位置

### DIFF
--- a/frontend/src/components/DimensionMembersDialog.test.ts
+++ b/frontend/src/components/DimensionMembersDialog.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+
+const source = readFileSync(
+  new URL('./DimensionMembersDialog.tsx', import.meta.url),
+  'utf8',
+)
+
+test('股票名称在前，板块标签紧随名称且代码保持独立一行', () => {
+  const identity = source.match(
+    /<span className="min-w-0">\s*<span className="flex min-w-0 items-center gap-1\.5">([\s\S]*?)<\/span>\s*<span className="block font-mono text-\[10px\] text-muted">\{row\.symbol\}<\/span>/,
+  )
+
+  assert.ok(identity, '股票名称、板块标签和代码应使用统一的两行身份布局')
+  assert.ok(
+    identity[1].indexOf('{row.name || row.symbol}') < identity[1].indexOf('{board &&'),
+    '板块标签应渲染在股票名称之后',
+  )
+})

--- a/frontend/src/components/DimensionMembersDialog.tsx
+++ b/frontend/src/components/DimensionMembersDialog.tsx
@@ -285,12 +285,12 @@ function DimensionMembersDialogContent({ target, onClose, onStockClick }: Omit<P
                       className="absolute left-0 top-0 grid min-h-[54px] w-full grid-cols-[minmax(132px,1fr)_74px_74px_18px] items-center border-b border-border/60 px-4 text-left text-xs transition-colors hover:bg-elevated/50 disabled:cursor-default md:grid-cols-[minmax(180px,1fr)_90px_84px_88px_100px_18px]"
                       style={{ transform: `translateY(${virtualRow.start}px)` }}
                     >
-                      <span className="flex min-w-0 items-center gap-2">
-                        {board && <span className={`inline-flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded border text-[9px] font-bold ${board.color}`}>{board.label}</span>}
-                        <span className="min-w-0">
-                          <span className="block truncate font-medium text-foreground">{row.name || row.symbol}</span>
-                          <span className="block font-mono text-[10px] text-muted">{row.symbol}</span>
+                      <span className="min-w-0">
+                        <span className="flex min-w-0 items-center gap-1.5">
+                          <span className="min-w-0 truncate font-medium text-foreground">{row.name || row.symbol}</span>
+                          {board && <span className={`inline-flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded border text-[9px] font-bold ${board.color}`}>{board.label}</span>}
                         </span>
+                        <span className="block font-mono text-[10px] text-muted">{row.symbol}</span>
                       </span>
                       <span className="text-right tabular-nums text-secondary">{fmtPrice(finite(row.close))}</span>
                       <span className={`text-right tabular-nums font-medium ${priceColorClass(finite(row.change_pct))}`}>{fmtPct(finite(row.change_pct))}</span>


### PR DESCRIPTION
## 修改内容

- 将概念/行业详情成员列表中的市场标签移到股票名称之后，统一名称左边界
- 保持股票代码独立显示在第二行，不改变虚拟列表、点击行为和数值列布局
- 新增回归测试，约束名称、标签与代码的渲染顺序

## 验证

- `node --experimental-strip-types --test src/components/DimensionMembersDialog.test.ts src/lib/neighborPrefetch.test.ts`（5 项通过）
- `./node_modules/.bin/tsc -b`
- `./node_modules/.bin/vite build`
- `git diff --check`
- 1440x900 与 390x844 浏览器视口视觉验收通过
