### PR TITLE
fix(monitor): 告警以实际命中信号为主，自定义信号显示用户命名

### DIFF
--- a/backend/app/strategy/custom_signals.py
+++ b/backend/app/strategy/custom_signals.py
@@ -535,3 +535,27 @@ def load_intraday_all(data_dir: Path) -> list[dict]:
 
 def invalidate_intraday_cache() -> None:
     _intraday_cache.clear()
+
+
+# ── 信号命名映射 (告警文案把 csg_/csgi_ 列名翻译成用户命名) ──────────
+_names_cache: dict[Path, tuple[object, dict[str, str]]] = {}
+
+
+def signal_names(data_dir: Path) -> dict[str, str]:
+    """自定义信号列名 (csg_/csgi_) → 用户命名的映射, 带目录指纹缓存。
+
+    指纹含文件名 + mtime, 保存/删除信号后自动失效重载, 调用方无需配合失效。
+    """
+    d = _dir(data_dir)
+    fp = _dir_fingerprint(d)
+    cached = _names_cache.get(data_dir)
+    if cached is not None and cached[0] == fp:
+        return cached[1]
+    names: dict[str, str] = {}
+    for s in load_all(data_dir):
+        sid, name = s.get("id"), s.get("name")
+        if sid and name:
+            names[column_name(sid)] = name
+            names[intraday_column_name(sid)] = name
+    _names_cache[data_dir] = (fp, names)
+    return names

--- a/backend/app/strategy/monitor.py
+++ b/backend/app/strategy/monitor.py
@@ -24,6 +24,7 @@ import polars as pl
 from app.market_time import cn_today
 from app.strategy import config as _strategy_config
 from app.strategy.custom_signals import _OP_BUILDERS  # type: ignore  # 复用运算符构造器
+from app.strategy.custom_signals import signal_names as _custom_signal_names
 from app.strategy.intraday_signals import INTRADAY_SIGNAL_LABELS, uses_intraday_signals
 from app.strategy.monitor_rules import date_rule_in_window
 
@@ -380,6 +381,18 @@ class MonitorRuleEngine:
     def set_data_dir(self, data_dir) -> None:
         """注入数据目录, 用于加载策略的用户覆盖配置。"""
         self._data_dir = data_dir
+
+    def _signal_label(self, field: str) -> str:
+        """信号/字段 → 中文名: 内置查 _SIGNAL_CN; 自定义 csg_/csgi_ 查用户命名。
+
+        自定义信号命名从 data_dir 的 custom_signals 定义加载 (指纹缓存);
+        未注入 data_dir 或查不到时回退原始列名。
+        """
+        if field.startswith(("csg_", "csgi_")) and self._data_dir is not None:
+            name = _custom_signal_names(self._data_dir).get(field)
+            if name:
+                return name
+        return _signal_cn_name(field)
 
     def set_sector_monitor_service(self, service) -> None:
         self._sector_monitor_service = service
@@ -1119,6 +1132,7 @@ class MonitorRuleEngine:
                     rule, ev_type=ev_type, sym=sym, name=resolved_name,
                     pct=pct, price=price,
                     conditions=list(rule.get("conditions", [])) if rule.get("type") != "strategy" else None,
+                    signals=hit_sigs,
                 )
 
             ev = {
@@ -1681,11 +1695,12 @@ class MonitorRuleEngine:
 
     def _default_message(self, rule: dict, ev_type: str = "", sym: str = "",
                           name: str = "", pct: Any = None, price: Any = None,
-                          conditions: list[dict] | None = None) -> str:
+                          conditions: list[dict] | None = None,
+                          signals: list[str] | None = None) -> str:
         """生成默认 message。
 
         - strategy: 按变更方向生成 (进入/移出 + 涨跌幅)
-        - signal/price/market: 条件摘要 + 现价 + 涨跌幅 (避免笼统的「信号触发」)
+        - signal/price/market: 命中信号 (signals 非空时) 或条件摘要 + 现价 + 涨跌幅
         """
         rtype = rule.get("type", "signal")
         if rtype == "strategy":
@@ -1718,32 +1733,43 @@ class MonitorRuleEngine:
                 return f"策略「{sname}」{action} {name}{pct_text}"
             return f"策略「{sname}」事件"
 
-        # signal / price / market: 条件摘要 + 现价 + 涨跌幅
-        # 条件摘要: 把 conditions (truth/比较) 拼成可读串, 如 "MA20金叉 且 量比>2"
-        cond_text = self._format_conditions_text(rule, conditions)
+        # signal / price / market: 命中信号 + 现价 + 涨跌幅
+        # 有实际命中信号 (op=truth 且为真的子集) 时以命中信号开头 — 全量规则
+        # 条件仍保留在 event.conditions 供前端展示, message 不再复读 (OR 规则
+        # 条件多时全文复读会淹没真正触发的条件)。
         tail = format_alert_quote(price, pct)
+        if signals:
+            hit_text = "命中 " + "、".join(self._signal_label(s) for s in signals)
+            return f"{hit_text} · {tail}" if tail else hit_text
+        # 无 truth 命中 (纯比较条件规则): 回退条件摘要
+        # 条件摘要: 把 conditions (truth/比较) 拼成可读串, 如 "MA20金叉 且 量比>2"
+        cond_text = self._format_conditions_text(rule, conditions, resolver=self._signal_label)
         if cond_text and tail:
             return f"{cond_text} · {tail}"
         return cond_text or tail or "监控触发"
 
     @staticmethod
-    def _format_conditions_text(rule: dict, conditions: list[dict] | None) -> str:
+    def _format_conditions_text(rule: dict, conditions: list[dict] | None,
+                                 resolver: Callable[[str], str] | None = None) -> str:
         """把 rule.conditions 拼成可读文本 (用于 message / 推送)。
 
         op=truth: 直接用信号中文名 (如 "MA20金叉")
         op=比较: 字段中文名 + 操作符 + 值 (如 "涨跌幅≥5")
         logic: and → "且", or → "或"
+        resolver: 自定义信号名解析器 (默认 _signal_cn_name); 引擎内传
+            self._signal_label 以解析 csg_/csgi_ 用户命名, 外部 (lots.py) 不传。
         """
         conds = conditions if conditions is not None else list(rule.get("conditions", []))
         if not conds:
             return ""
         logic_word = "且" if rule.get("logic", "and") == "and" else "或"
+        label_of = resolver or _signal_cn_name
         parts: list[str] = []
         for c in conds:
             field = c.get("field", "")
             op = c.get("op", "truth")
             value = c.get("value")
-            label = _signal_cn_name(field) or field
+            label = label_of(field) or field
             if op == "truth":
                 parts.append(label)
             else:

--- a/backend/app/strategy/monitor.py
+++ b/backend/app/strategy/monitor.py
@@ -1740,6 +1740,15 @@ class MonitorRuleEngine:
         tail = format_alert_quote(price, pct)
         if signals:
             hit_text = "命中 " + "、".join(self._signal_label(s) for s in signals)
+            # AND 规则: 比较条件同样全部满足, 补进 message 保持信息完整。
+            # OR 规则无法判定哪些比较条件为真 (hit_sigs 只收集 truth 信号), 不补。
+            if rule.get("logic", "and") == "and":
+                comp = [c for c in (conditions if conditions is not None else rule.get("conditions", []))
+                        if c.get("op") != "truth"]
+                if comp:
+                    comp_text = self._format_conditions_text(rule, comp, resolver=self._signal_label)
+                    if comp_text:
+                        hit_text = f"{hit_text} 且 {comp_text}"
             return f"{hit_text} · {tail}" if tail else hit_text
         # 无 truth 命中 (纯比较条件规则): 回退条件摘要
         # 条件摘要: 把 conditions (truth/比较) 拼成可读串, 如 "MA20金叉 且 量比>2"

--- a/backend/tests/test_monitor_hit_message.py
+++ b/backend/tests/test_monitor_hit_message.py
@@ -79,6 +79,30 @@ def test_message_resolves_custom_signal_cn_name(tmp_path):
     assert "csg_ma_dead_5_10" not in msg
 
 
+def test_message_and_logic_includes_comparison_conditions():
+    """AND 规则 truth+比较混合: 比较条件全部满足, 一并补进 message (信息完整)。"""
+    eng = MonitorRuleEngine()
+    rule = _rule(logic="and", conditions=[
+        {"field": "signal_macd_dead", "op": "truth"},
+        {"field": "close", "op": ">=", "value": 2500},
+    ])
+    msg = _fire(eng, rule, _df(signal_macd_dead=[True]))
+    assert msg.startswith("命中 MACD死叉 且 收盘价>=2500")
+    assert "现价 3000.0" in msg
+
+
+def test_message_or_logic_omits_comparison_conditions():
+    """OR 规则 truth+比较混合: 无法判定比较条件是否为真, 不补进 message。"""
+    eng = MonitorRuleEngine()
+    rule = _rule(logic="or", conditions=[
+        {"field": "signal_macd_dead", "op": "truth"},
+        {"field": "close", "op": ">=", "value": 2500},
+    ])
+    msg = _fire(eng, rule, _df(signal_macd_dead=[True]))
+    assert msg.startswith("命中 MACD死叉 · ")
+    assert "收盘价" not in msg
+
+
 def test_message_custom_signal_fallback_without_data_dir():
     """未注入 data_dir 时 csg_ 名称解析优雅回退为原始列名 (不报错)。"""
     eng = MonitorRuleEngine()

--- a/backend/tests/test_monitor_hit_message.py
+++ b/backend/tests/test_monitor_hit_message.py
@@ -1,0 +1,87 @@
+"""告警 message 以实际命中信号为主 + 自定义信号中文名解析。
+
+修复前: signal/price/market 类告警的 message 拼的是规则全量条件 (8 个 "或" 连接),
+看不出实际触发的是哪条; 自定义信号 (csg_/csgi_) 显示原始列名而非用户命名。
+修复后: 有命中信号时 message 以「命中 信号A、信号B」开头; 无 truth 命中
+(纯比较条件) 时回退原条件摘要; 自定义信号解析为用户命名。
+"""
+import json
+
+import polars as pl
+
+from app.strategy.monitor import MonitorRuleEngine
+
+
+def _rule(rid="r1", conditions=None, **over):
+    rule = {
+        "id": rid, "name": rid, "type": "signal", "asset_type": "stock",
+        "scope": "symbols", "symbols": ["000001.SH"], "logic": "or",
+        "conditions": conditions or [], "cooldown_seconds": 0, "enabled": True,
+    }
+    rule.update(over)
+    return rule
+
+
+def _df(**cols):
+    base = {"symbol": ["000001.SH"], "close": [3000.0], "change_pct": [0.01]}
+    base.update(cols)
+    return pl.DataFrame(base)
+
+
+def _fire(eng, rule, df):
+    eng.set_rules([rule])
+    events = eng.evaluate(df, asset_type="stock", reset_strategy_results=False)
+    assert len(events) == 1
+    return events[0]["message"]
+
+
+def test_message_leads_with_hit_signals():
+    """OR 规则部分命中: message 只含实际命中的信号, 不再列全量条件。"""
+    eng = MonitorRuleEngine()
+    rule = _rule(conditions=[
+        {"field": "signal_ma_dead_5_20", "op": "truth"},
+        {"field": "signal_macd_dead", "op": "truth"},
+        {"field": "signal_boll_breakout_upper", "op": "truth"},
+    ])
+    df = _df(signal_ma_dead_5_20=[True], signal_macd_dead=[True],
+             signal_boll_breakout_upper=[False])
+    msg = _fire(eng, rule, df)
+    assert msg.startswith("命中 MA5下穿MA20、MACD死叉")
+    assert "突破布林上轨" not in msg
+    assert " 或 " not in msg
+    assert "现价 3000.0" in msg
+
+
+def test_message_falls_back_to_conditions_when_no_truth_hit():
+    """纯比较条件规则 (hit_sigs 为空): 保持原条件摘要格式, 行为不变。"""
+    eng = MonitorRuleEngine()
+    rule = _rule(type="price",
+                 conditions=[{"field": "close", "op": ">=", "value": 2500}])
+    msg = _fire(eng, rule, _df())
+    assert "收盘价>=2500" in msg
+    assert "现价 3000.0" in msg
+
+
+def test_message_resolves_custom_signal_cn_name(tmp_path):
+    """csg_ 自定义信号在 message 中显示用户命名, 而非原始列名。"""
+    d = tmp_path / "user_data" / "custom_signals"
+    d.mkdir(parents=True)
+    (d / "ma_dead_5_10.json").write_text(json.dumps({
+        "id": "ma_dead_5_10", "name": "5日线下穿10日线", "kind": "exit",
+        "conditions": [{"left": "ma5", "op": "<=", "right": "field:ma10"}],
+    }, ensure_ascii=False), encoding="utf-8")
+
+    eng = MonitorRuleEngine()
+    eng.set_data_dir(tmp_path)
+    rule = _rule(conditions=[{"field": "csg_ma_dead_5_10", "op": "truth"}])
+    msg = _fire(eng, rule, _df(csg_ma_dead_5_10=[True]))
+    assert "5日线下穿10日线" in msg
+    assert "csg_ma_dead_5_10" not in msg
+
+
+def test_message_custom_signal_fallback_without_data_dir():
+    """未注入 data_dir 时 csg_ 名称解析优雅回退为原始列名 (不报错)。"""
+    eng = MonitorRuleEngine()
+    rule = _rule(conditions=[{"field": "csg_unknown_sig", "op": "truth"}])
+    msg = _fire(eng, rule, _df(csg_unknown_sig=[True]))
+    assert "csg_unknown_sig" in msg

--- a/frontend/src/components/AlertToast.tsx
+++ b/frontend/src/components/AlertToast.tsx
@@ -5,6 +5,7 @@ import { Bell, TrendingUp, TrendingDown, X } from 'lucide-react'
 import type { AlertEvent } from '@/lib/api'
 import { fmtPct, fmtPrice } from '@/lib/format'
 import { cnSignal } from '@/lib/signals'
+import { useCustomSignalNames } from '@/lib/useCustomSignalNames'
 import { cn } from '@/lib/cn'
 import { playNotificationSound } from '@/lib/notificationSound'
 import { speakAlerts } from '@/lib/voiceBroadcast'
@@ -103,6 +104,7 @@ export function AlertToastContainer() {
   const [items, setItems] = useState<Item[]>([])
   const navigate = useNavigate()
   const { data: prefs } = usePreferences()
+  const customNames = useCustomSignalNames()
   const extFields = prefs?.monitor_ext_fields ?? {
     concept: { field: 'ext_gn_ths.所属概念' },
     industry: { field: 'ext_hy_ths.所属同花顺行业' },
@@ -204,7 +206,7 @@ export function AlertToastContainer() {
                   {ev.signals && ev.signals.length > 0 && (
                     <div className="mt-1 flex flex-wrap gap-1 pl-0.5">
                       {ev.signals.map(signal => (
-                        <span key={signal} className="rounded bg-accent/8 px-1 py-px text-[9px] text-accent/80">{cnSignal(signal)}</span>
+                        <span key={signal} className="rounded bg-accent/8 px-1 py-px text-[9px] text-accent/80">{cnSignal(signal, customNames)}</span>
                       ))}
                     </div>
                   )}

--- a/frontend/src/components/StockPreviewDialog.tsx
+++ b/frontend/src/components/StockPreviewDialog.tsx
@@ -6,6 +6,7 @@ import { api } from '@/lib/api'
 import { QK } from '@/lib/queryKeys'
 import { cn } from '@/lib/cn'
 import { cnSignal } from '@/lib/signals'
+import { useCustomSignalNames } from '@/lib/useCustomSignalNames'
 import { fmtPct } from '@/lib/format'
 import { StockPanel, getDefaultRange } from '@/components/StockPanel'
 import { WatchlistAddMenu } from '@/components/WatchlistAddMenu'
@@ -114,6 +115,7 @@ export function StockPreviewDialog({ symbol, name, onClose, triggerInfo, navList
   const [intradayDays, setIntradayDays] = useState<number | null>(loadIntradayDays)
   const [dateRange, setDateRange] = useState(getDefaultRange)
   const [showMonitorEditor, setShowMonitorEditor] = useState(false)
+  const customNames = useCustomSignalNames()
   const [priceAlertDraft, setPriceAlertDraft] = useState<PriceAlertDraft | null>(null)
   const [maximized, setMaximized] = useState(false)
   const qc = useQueryClient()
@@ -550,7 +552,7 @@ export function StockPreviewDialog({ symbol, name, onClose, triggerInfo, navList
                   {triggerInfo.signals && triggerInfo.signals.length > 0 && (
                     <div className="flex items-center gap-1 flex-wrap">
                       {triggerInfo.signals.map((s, j) => (
-                        <span key={j} className="rounded bg-accent/10 px-1.5 py-0.5 text-[9px] text-accent/80">{cnSignal(s)}</span>
+                        <span key={j} className="rounded bg-accent/10 px-1.5 py-0.5 text-[9px] text-accent/80">{cnSignal(s, customNames)}</span>
                       ))}
                     </div>
                   )}

--- a/frontend/src/lib/useCustomSignalNames.ts
+++ b/frontend/src/lib/useCustomSignalNames.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { api } from '@/lib/api'
+import { QK } from '@/lib/queryKeys'
+
+/**
+ * 自定义信号列名 (csg_/csgi_) → 用户命名 的映射。
+ *
+ * 复用 QK.customSignals 查询 (与 SignalPicker/信号库共享缓存, 不额外发请求)。
+ * 告警/监控等展示侧应把返回值传给 cnSignal 第二参数 — 不传时 csg_/csgi_
+ * 会显示原始列名 (如 csg_ma_dead_5_10) 而非用户命名。
+ */
+export function useCustomSignalNames(): Record<string, string> {
+  const query = useQuery({ queryKey: QK.customSignals, queryFn: api.customSignalsList })
+  return useMemo(() => {
+    const names: Record<string, string> = {}
+    for (const s of query.data?.signals ?? []) {
+      if (s.id && s.name) {
+        names[`csg_${s.id}`] = s.name
+        names[`csgi_${s.id}`] = s.name
+      }
+    }
+    return names
+  }, [query.data])
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -16,6 +16,7 @@ import { useAdjFactorSyncGate } from '@/components/AdjFactorSyncGate'
 import { STAGE_LABELS } from '@/components/data/ActiveJobCard'
 import { cn } from '@/lib/cn'
 import { cnSignal } from '@/lib/signals'
+import { useCustomSignalNames } from '@/lib/useCustomSignalNames'
 import { strategyEventMeta, strategyName } from '@/lib/strategyMonitorEvents'
 import { boardTag } from '@/components/stock-table/primitives'
 
@@ -103,6 +104,7 @@ function MonitorWidget({ onStockClick, activeSymbol }: {
   activeSymbol?: string
 }) {
   const navigate = useNavigate()
+  const customNames = useCustomSignalNames()
   const alerts = useQuery({
     queryKey: ['alerts', ''],
     queryFn: () => api.alertsList({ days: 7, limit: 10 }),
@@ -193,7 +195,7 @@ function MonitorWidget({ onStockClick, activeSymbol }: {
                   {ev.signals && ev.signals.length > 0 && (
                     <div className="mt-1 flex flex-wrap gap-1">
                       {ev.signals.map(signal => (
-                        <span key={signal} className="rounded bg-accent/8 px-1 py-px text-[8px] text-accent/80">{cnSignal(signal)}</span>
+                        <span key={signal} className="rounded bg-accent/8 px-1 py-px text-[8px] text-accent/80">{cnSignal(signal, customNames)}</span>
                       ))}
                     </div>
                   )}
@@ -214,7 +216,7 @@ function MonitorWidget({ onStockClick, activeSymbol }: {
                   {ev.signals && ev.signals.length > 0 && (
                     <div className="mt-1 flex flex-wrap gap-1">
                       {ev.signals.map((s, j) => (
-                        <span key={j} className="rounded bg-accent/8 px-1 py-px text-[8px] text-accent/80">{cnSignal(s)}</span>
+                        <span key={j} className="rounded bg-accent/8 px-1 py-px text-[8px] text-accent/80">{cnSignal(s, customNames)}</span>
                       ))}
                     </div>
                   )}

--- a/frontend/src/pages/Monitor.tsx
+++ b/frontend/src/pages/Monitor.tsx
@@ -12,6 +12,7 @@ import { fmtPrice, fmtPct } from '@/lib/format'
 import { useDialogBackdrop } from '@/lib/useDialogBackdrop'
 import { cn } from '@/lib/cn'
 import { cnSignal } from '@/lib/signals'
+import { useCustomSignalNames } from '@/lib/useCustomSignalNames'
 import { LEGACY_STRATEGY_NOTIFY_EVENTS, STRATEGY_NOTIFY_EVENT_OPTIONS, strategyEventMeta, strategyName } from '@/lib/strategyMonitorEvents'
 import { boardTag } from '@/components/stock-table/primitives'
 import { resolveWatchlistGroupColor } from '@/lib/watchlist-group-colors'
@@ -342,6 +343,7 @@ function AlertsList({ alertsQuery, confirmClear, setConfirmClear, total, enterTs
   const [memberPreview, setMemberPreview] = useState<{ symbol: string; name?: string } | null>(null)
   const [previewNavList, setPreviewNavList] = useState<NavItem[]>([])
   const [dimensionTarget, setDimensionTarget] = useState<DimensionMembersTarget | null>(null)
+  const customNames = useCustomSignalNames()
 
   const clearMut = useMutation({
     mutationFn: api.alertsClear,
@@ -481,7 +483,7 @@ function AlertsList({ alertsQuery, confirmClear, setConfirmClear, total, enterTs
                         {ev.signals && ev.signals.length > 0 && (
                           <div className="mt-1.5 flex flex-wrap gap-1">
                             {ev.signals.map((signal: string) => (
-                              <span key={signal} className="rounded bg-accent/8 px-1.5 py-0.5 text-[9px] text-accent/70">{cnSignal(signal)}</span>
+                              <span key={signal} className="rounded bg-accent/8 px-1.5 py-0.5 text-[9px] text-accent/70">{cnSignal(signal, customNames)}</span>
                             ))}
                           </div>
                         )}
@@ -550,17 +552,31 @@ function AlertsList({ alertsQuery, confirmClear, setConfirmClear, total, enterTs
                           })()}
                         </span>
                       </div>
-                      {/* 详情行: 命中条件 (signal/price/market) + 当前价 / 或默认消息 */}
-                      {(ev.conditions && ev.conditions.length > 0) ? (
+                      {/* 详情行: 实际命中信号为主 (有 signals 时); 无 truth 命中则回退条件摘要 */}
+                      {ev.signals && ev.signals.length > 0 ? (
+                        <div className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px]">
+                          <span className="text-muted">命中</span>
+                          {ev.signals.map((s: string, j: number) => (
+                            <span key={j} className="rounded bg-accent/10 px-1.5 py-0.5 text-[10px] font-medium text-accent">{cnSignal(s, customNames)}</span>
+                          ))}
+                          {ev.price != null && (
+                            <>
+                              <span className="text-muted">·</span>
+                              <span className="text-muted">现价</span>
+                              <span className="font-mono text-foreground/90">{fmtPrice(ev.price)}</span>
+                            </>
+                          )}
+                        </div>
+                      ) : (ev.conditions && ev.conditions.length > 0) ? (
                         <div className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[11px]">
                           <span className="text-muted">命中</span>
                           {ev.conditions.map((c: MonitorCondition, ci: number) => (
                             <span key={ci} className="inline-flex items-center gap-0.5">
                               {ci > 0 && <span className="text-secondary">{ev.logic === 'or' ? '或' : '且'}</span>}
                               {c.op === 'truth' ? (
-                                <span className="text-accent/80">{cnSignal(c.field)}</span>
+                                <span className="text-accent/80">{cnSignal(c.field, customNames)}</span>
                               ) : (
-                                <span className="text-foreground/80 font-mono">{cnSignal(c.field)}{c.op}{c.value}</span>
+                                <span className="text-foreground/80 font-mono">{cnSignal(c.field, customNames)}{c.op}{c.value}</span>
                               )}
                             </span>
                           ))}
@@ -577,10 +593,19 @@ function AlertsList({ alertsQuery, confirmClear, setConfirmClear, total, enterTs
                           <span className="text-[11px]">{renderMessage(ev.source, ev.message)}</span>
                         </div>
                       )}
-                      {ev.signals && ev.signals.length > 0 && (
-                        <div className="mt-1.5 flex flex-wrap gap-1">
-                          {ev.signals.map((s: string, j: number) => (
-                            <span key={j} className="rounded bg-accent/8 px-1.5 py-0.5 text-[9px] text-accent/70">{cnSignal(s)}</span>
+                      {/* 规则全量条件 (次要灰字): 已有命中信号主行时展示, 供回溯规则定义 */}
+                      {ev.signals && ev.signals.length > 0 && ev.conditions && ev.conditions.length > 0 && (
+                        <div className="mt-1 flex flex-wrap items-center gap-x-1 gap-y-0.5 text-[10px] text-muted/70">
+                          <span>规则</span>
+                          {ev.conditions.map((c: MonitorCondition, ci: number) => (
+                            <span key={ci} className="inline-flex items-center gap-0.5">
+                              {ci > 0 && <span>{ev.logic === 'or' ? '或' : '且'}</span>}
+                              {c.op === 'truth' ? (
+                                <span>{cnSignal(c.field, customNames)}</span>
+                              ) : (
+                                <span className="font-mono">{cnSignal(c.field, customNames)}{c.op}{c.value}</span>
+                              )}
+                            </span>
                           ))}
                         </div>
                       )}
@@ -672,6 +697,7 @@ function RulesList({ rulesQuery, onEdit }: {
   const [confirmId, setConfirmId] = useState<string | null>(null)
   const [previewSymbol, setPreviewSymbol] = useState<string | null>(null)
   const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const customNames = useCustomSignalNames()
 
   const rules: MonitorRule[] = (rulesQuery.data as any)?.rules ?? []
 
@@ -961,9 +987,9 @@ function RulesList({ rulesQuery, onEdit }: {
                       <span key={i} className="inline-flex items-center gap-0.5">
                         {i > 0 && <span className="text-secondary">{r.logic === 'and' ? '且' : '或'}</span>}
                         {c.op === 'truth' ? (
-                          <span className="text-accent/80">{cnSignal(c.field)}</span>
+                          <span className="text-accent/80">{cnSignal(c.field, customNames)}</span>
                         ) : (
-                          <span className="text-foreground/80 font-mono">{cnSignal(c.field)}{c.op}{c.value}</span>
+                          <span className="text-foreground/80 font-mono">{cnSignal(c.field, customNames)}{c.op}{c.value}</span>
                         )}
                       </span>
                     ))}

--- a/frontend/src/pages/backtest/StrategyBacktest.tsx
+++ b/frontend/src/pages/backtest/StrategyBacktest.tsx
@@ -20,6 +20,7 @@ import { boardTag } from '@/lib/board'
 import { boardTag as boardBadge } from '@/components/stock-table/primitives'
 import { BUILTIN_COLUMNS } from '@/lib/watchlist-columns'
 import { cnSignal } from '@/lib/signals'
+import { useCustomSignalNames } from '@/lib/useCustomSignalNames'
 import { SignalPicker } from '@/components/screener/SignalPicker'
 import { startBacktest, stopBacktest, tryReconnect, useBacktestTask } from '@/lib/backtestTask'
 import { useDataStatus, useCapabilities } from '@/lib/useSharedQueries'
@@ -380,14 +381,7 @@ const statValueColor = (v: number | null | undefined) => {
 }
 
 /** 信号 ID → 可读名称映射 (内置 + 自定义), 供交易记录显示具体触发信号。 */
-function useSignalNames(): Record<string, string> {
-  const customQ = useQuery({ queryKey: QK.customSignals, queryFn: api.customSignalsList })
-  return useMemo(() => {
-    const names: Record<string, string> = {}
-    for (const cs of customQ.data?.signals ?? []) names[`csg_${cs.id}`] = cs.name
-    return names
-  }, [customQ.data])
-}
+const useSignalNames = useCustomSignalNames
 
 function ExitReasonBadge({ reason, signalId, signalNames }: { reason: string; signalId?: string | null; signalNames?: Record<string, string> }) {
   const config: Record<string, { label: string; cls: string }> = {


### PR DESCRIPTION
### 问题
监控告警的 message 存在两个可读性问题：

看不出实际触发的是哪条：signal/price/market 类告警的 message 拼的是规则全量条件——OR 规则 8 个条件全文复读，实际命中的信号淹没在条件摘要里。
自定义信号显示原始列名：自定义信号（csg_ / csgi_ 前缀）在告警 message 和前端各展示处均显示内部列名，而非用户在自定义信号里起的名字。
### 方案
#### 后端（monitor.py、custom_signals.py）
_default_message 新增 signals 参数：存在实际命中信号（评估时本就计算好的 op=truth 为真的子集 hit_sigs）时，message 以「命中 信号A、信号B · 现价 x · ±y%」开头；无 truth 命中（纯比较条件规则）时回退原条件摘要，行为不变。webhook/系统通知共用 message，全渠道受益。
AND 规则补比较条件摘要：AND 规则触发时比较条件（如 收盘价>=2500）同样全部满足，message 在命中信号名后以「以及」补上比较条件摘要，避免 webhook 等仅看 message 的渠道丢失阈值信息；OR 规则无法判定哪些比较条件为真，不补。
自定义信号名解析：custom_signals.signal_names() 提供 csg_/csgi_ 列名→用户命名映射（目录指标缓存，保存/删除自动失效）；MonitorRuleEngine._signal_label 接入；_format_conditions_text 增加可选 resolver（lots.py 类方法调用兼容）。
#### 前端（新 hook useCustomSignalNames，复用 QK.customSignals 缓存，不发额外请求）
Monitor 触发记录重排：实际命中信号标签提升为主行（含现价），规则全量条件降级为灰字辅行；无命中信号时保持原条件摘要展示。
信号名映射全站统一：Monitor / AlertToast / Dashboard / StockPreviewDialog 的 cnSignal 调用全部传入自定义信号名称映射（此前仅回测页传入，其余显示原始列名）。
StrategyBacktest 本地 useSignalNames 替换为共享 useCustomSignalNames，消除重复实现。
### 用户可见行为变化
告警 message 文案从「规则全量条件摘要」变为「实际命中信号为主」；纯比较条件规则（无 truth 命中）文案不变。
回测页交易记录中的 csgi_ 盘中信号从原始列名变为用户命名（共享 hook 新增 csgi_ 映射的顺带效果）。
各页面自定义信号统一显示用户命名，不再出现 csg_xxx / csgi_xxx 原始列名。
<img width="912" height="95" alt="PixPin_2026-09-14_21-23-32" src="https://github.com/user-attachments/assets/596bfcb6-2865-4d68-8a71-de5086367753" />

### 测试
新增 tests/test_monitor_hit_message.py 6 个用例：命中信号为主 / 纯比较条件回退 / AND 补条件 / OR 不补条件 / csg_ 中文名解析 / 无 data_dir 回退。
监控相关测试 90 passed；前端 tsc + vite build 通过。
### 兼容性
无 schema / API 契约变化；message 仅文案变化，SSE、webhook 渠道结构不变（quote_service._body_with_quote 尾部去重逻辑不受影响）。
用户自定义 message 的规则不受影响（_default_message 不生效）。
lots.py 等既有 _format_conditions_text 调用方通过可选 resolver 参数保持兼容。